### PR TITLE
use turn to polyfill navbar animation on non chrominium browsers

### DIFF
--- a/app/assets/stylesheets/components/transition.css
+++ b/app/assets/stylesheets/components/transition.css
@@ -59,3 +59,17 @@
     isolation: none;
   }
 }
+
+/* turn annimations */
+
+html.turn-advance.turn-exit.turn-no-view-transitions [data-turn-exit] {
+  animation-name: fade-out;
+  animation-duration: 0.3s;
+  animation-fill-mode: forwards;
+}
+
+html.turn-advance.turn-enter.turn-no-view-transitions [data-turn-enter] {
+  animation-name: fade-in;
+  animation-duration: 0.3s;
+  animation-fill-mode: forwards;
+}

--- a/app/views/shared/navbar/_link.html.erb
+++ b/app/views/shared/navbar/_link.html.erb
@@ -1,4 +1,5 @@
-<%= content_tag :li, class: class_names(active: current_page?(path)) do %>
+<% active = current_page?(path) %>
+<%= content_tag :li, class: class_names(active: active) do %>
   <%= link_to link_title, path %>
-  <div></div>
+  <%= content_tag :div, "", data: {turn_exit: !active.to_s, turn_enter: active.to_s} %>
 <% end %>


### PR DESCRIPTION

https://github.com/adrienpoly/rubyvideo/assets/7847244/f91ad4fd-0872-4a98-86ab-633993268a9d

following #29 this is adding a small polyfill to the navbar animation for other browsers

@domchristie thoughts welcome 

