### PR TITLE
Remove `@tailwindcss/line-clamp` Tailwind plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^7.3.0",
     "@tailwindcss/forms": "^0.5.3",
-    "@tailwindcss/line-clamp": "^0.4.4",
     "autoprefixer": "^10.4.14",
     "esbuild": "^0.17.18",
     "morphdom": "^2.7.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,5 +46,7 @@ module.exports = {
       }
     }
   },
-  plugins: [require('@tailwindcss/line-clamp'), require('@tailwindcss/forms')]
+  plugins: [
+    require('@tailwindcss/forms')
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,11 +371,6 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
-"@tailwindcss/line-clamp@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz#767cf8e5d528a5d90c9740ca66eb079f5e87d423"
-  integrity sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==
-
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"


### PR DESCRIPTION
This pull request removes the `@tailwindcss/line-clamp` plugin from the `tailwind.config.js` config and also removes it from the `package.json` to resolve the following warning:

```
warn - As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default. 
warn - Remove it from the `plugins` array in your configuration to eliminate this warning.
```

For reference, see the Tailwind 3.3 release announcement: https://tailwindcss.com/blog/tailwindcss-v3-3#line-clamp-out-of-the-box