### PR TITLE
Configure CSS nesting for Tailwind

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: {
-    'postcss-nested': {},
     'postcss-import': {},
+    'tailwindcss/nesting': {},
     tailwindcss: {},
     autoprefixer: {}
   }


### PR DESCRIPTION
This resolves the following warning:

```
[vite:css] Nested CSS was detected, but CSS nesting has not been configured correctly.
Please enable a CSS nesting plugin *before* Tailwind in your configuration.
See how here: https://tailwindcss.com/docs/using-with-preprocessors#nesting
8  |  @import "components/pagination.css";
9  |  @import "components/transition.css";
10 |  @import "components/typography.css";
   |       ^
11 |  @import "components/video.css";
```

See the Tailwind docs for reference: https://tailwindcss.com/docs/using-with-preprocessors#nesting