### PR TITLE
Start cleaning up the test suite

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,6 @@
 class EventsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
-  before_action :set_event, only: %i[show edit update destroy]
+  before_action :set_event, only: %i[show edit update]
 
   # GET /events
   def index
@@ -11,24 +11,8 @@ class EventsController < ApplicationController
   def show
   end
 
-  # GET /events/new
-  def new
-    @event = Event.new
-  end
-
   # GET /events/1/edit
   def edit
-  end
-
-  # POST /events
-  def create
-    @event = Event.new(event_params)
-
-    if @event.save
-      redirect_to @event, notice: "Event was successfully created."
-    else
-      render :new, status: :unprocessable_entity
-    end
   end
 
   # PATCH/PUT /events/1
@@ -38,12 +22,6 @@ class EventsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
-  end
-
-  # DELETE /events/1
-  def destroy
-    @event.destroy!
-    redirect_to events_url, notice: "Event was successfully destroyed.", status: :see_other
   end
 
   private

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -1,6 +1,6 @@
 class SpeakersController < ApplicationController
   skip_before_action :authenticate_user!
-  before_action :set_speaker, only: %i[show edit update destroy]
+  before_action :set_speaker, only: %i[show edit update]
 
   # GET /speakers
   def index
@@ -16,24 +16,8 @@ class SpeakersController < ApplicationController
     # fresh_when(@speaker)
   end
 
-  # GET /speakers/new
-  def new
-    @speaker = Speaker.new
-  end
-
   # GET /speakers/1/edit
   def edit
-  end
-
-  # POST /speakers
-  def create
-    @speaker = Speaker.new(speaker_params)
-
-    if @speaker.save
-      redirect_to @speaker, notice: "Speaker was successfully created."
-    else
-      render :new, status: :unprocessable_entity
-    end
   end
 
   # PATCH/PUT /speakers/1
@@ -44,12 +28,6 @@ class SpeakersController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
-  end
-
-  # DELETE /speakers/1
-  def destroy
-    @speaker.destroy!
-    redirect_to speakers_url, notice: "Speaker was successfully destroyed.", status: :see_other
   end
 
   private

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,7 +1,7 @@
 class TalksController < ApplicationController
   include Pagy::Backend
   skip_before_action :authenticate_user!
-  before_action :set_talk, only: %i[show edit update destroy]
+  before_action :set_talk, only: %i[show edit update]
 
   # GET /talks
   def index
@@ -28,17 +28,6 @@ class TalksController < ApplicationController
   def edit
   end
 
-  # POST /talks
-  def create
-    @talk = Talk.new(talk_params)
-
-    if @talk.save
-      redirect_to @talk, notice: "Talk was successfully created."
-    else
-      render :new, status: :unprocessable_entity
-    end
-  end
-
   # PATCH/PUT /talks/1
   def update
     suggestion = @talk.create_suggestion_from(params: talk_params, user: Current.user)
@@ -47,12 +36,6 @@ class TalksController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
-  end
-
-  # DELETE /talks/1
-  def destroy
-    @talk.destroy!
-    redirect_to talks_url, notice: "Talk was successfully destroyed.", status: :see_other
   end
 
   private

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -11,7 +11,7 @@
       <%= link_to edit_talk_path(@talk), class: "button secondary" do %>
           <div class="flex items-center gap-2">
             <%= heroicon :pencil_square %>
-            <span>edit</span>
+            <span>Edit</span>
           </div>
         <% end %>
     </div>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -22,9 +22,11 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should update event" do
-    sign_in_as @user
-    patch event_url(@event), params: {event: {description: @event.description, frequency: @event.frequency, kind: @event.kind, name: @event.name, website: @event.website}}
-    assert_redirected_to event_url(@event)
-  end
+  # Currently fails because 'description', 'frequency', 'kind' and 'website' are attributes of the event's organisation, not the event itself.
+  # The #update method and the corresponding form would need to be amended
+  # test "should update event" do
+  #   sign_in_as @user
+  #   patch event_url(@event), params: {event: {description: @event.description, frequency: @event.frequency, kind: @event.kind, name: @event.name, website: @event.website}}
+  #   assert_redirected_to event_url(@event)
+  # end
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class EventsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @event = events(:one)
+    @user = users(:lazaro_nixon)
   end
 
   test "should get index" do
@@ -16,11 +17,13 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get edit" do
+    sign_in_as @user
     get edit_event_url(@event)
     assert_response :success
   end
 
   test "should update event" do
+    sign_in_as @user
     patch event_url(@event), params: {event: {description: @event.description, frequency: @event.frequency, kind: @event.kind, name: @event.name, website: @event.website}}
     assert_redirected_to event_url(@event)
   end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -10,19 +10,6 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should get new" do
-    get new_event_url
-    assert_response :success
-  end
-
-  test "should create event" do
-    assert_difference("Event.count") do
-      post events_url, params: {event: {description: @event.description, frequency: @event.frequency, kind: @event.kind, name: @event.name, website: @event.website}}
-    end
-
-    assert_redirected_to event_url(Event.last)
-  end
-
   test "should show event" do
     get event_url(@event)
     assert_response :success
@@ -36,13 +23,5 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
   test "should update event" do
     patch event_url(@event), params: {event: {description: @event.description, frequency: @event.frequency, kind: @event.kind, name: @event.name, website: @event.website}}
     assert_redirected_to event_url(@event)
-  end
-
-  test "should destroy event" do
-    assert_difference("Event.count", -1) do
-      delete event_url(@event)
-    end
-
-    assert_redirected_to events_url
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -30,7 +30,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to sign_in_url(email_hint: @user.email)
     assert_equal "That email or password is incorrect", flash[:alert]
 
-    get root_url
+    get edit_event_url(events(:one))
     assert_redirected_to sign_in_url
   end
 

--- a/test/controllers/speakers/enhance_controller_test.rb
+++ b/test/controllers/speakers/enhance_controller_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 class Speakers::EnhanceControllerTest < ActionDispatch::IntegrationTest
-  test "should get update" do
-    get speakers_enhance_update_url
+  setup do
+    @user = sign_in_as(users(:admin))
+  end
+
+  test "#patch" do
+    patch speakers_enhance_url(speakers(:one), {format: :turbo_stream})
     assert_response :success
   end
 end

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -10,19 +10,6 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should get new" do
-    get new_speaker_url
-    assert_response :success
-  end
-
-  test "should create speaker" do
-    assert_difference("Speaker.count") do
-      post speakers_url, params: {speaker: {bio: @speaker.bio, github: @speaker.github, name: @speaker.name, slug: @speaker.slug, twitter: @speaker.twitter, website: @speaker.website}}
-    end
-
-    assert_redirected_to speaker_url(Speaker.last)
-  end
-
   test "should show speaker" do
     get speaker_url(@speaker)
     assert_response :success
@@ -36,13 +23,5 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
   test "should update speaker" do
     patch speaker_url(@speaker), params: {speaker: {bio: @speaker.bio, github: @speaker.github, name: @speaker.name, slug: @speaker.slug, twitter: @speaker.twitter, website: @speaker.website}}
     assert_redirected_to speaker_url(@speaker)
-  end
-
-  test "should destroy speaker" do
-    assert_difference("Speaker.count", -1) do
-      delete speaker_url(@speaker)
-    end
-
-    assert_redirected_to speakers_url
   end
 end

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -10,19 +10,6 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should get new" do
-    get new_talk_url
-    assert_response :success
-  end
-
-  test "should create talk" do
-    assert_difference("Talk.count") do
-      post talks_url, params: {talk: {description: @talk.description, slug: @talk.slug, title: @talk.title, year: @talk.year}}
-    end
-
-    assert_redirected_to talk_url(Talk.last)
-  end
-
   test "should show talk" do
     get talk_url(@talk)
     assert_response :success
@@ -36,13 +23,5 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
   test "should update talk" do
     patch talk_url(@talk), params: {talk: {description: @talk.description, slug: @talk.slug, title: @talk.title, year: @talk.year}}
     assert_redirected_to talk_url(@talk)
-  end
-
-  test "should destroy talk" do
-    assert_difference("Talk.count", -1) do
-      delete talk_url(@talk)
-    end
-
-    assert_redirected_to talks_url
   end
 end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -18,7 +18,13 @@
 one:
   date: 2017-05-01
   organisation: one
+  city: Phoenix
+  name: RailsConf 2017
+  slug: rails-conf-2017
 
 two:
   date: 2023-05-01
   organisation: two
+  city: Bangkok
+  name: RubyConf TH 2022
+  slug: ruby-conf-th-2022

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -19,3 +19,9 @@ lazaro_nixon:
   email: lazaronixon@hotmail.com
   password_digest: <%= BCrypt::Password.create("Secret1*3*5*") %>
   verified: true
+
+admin:
+  email: admin@rubyvideo.dev
+  password_digest: <%= BCrypt::Password.create("Secret1*3*5*") %>
+  verified: true
+  admin: true

--- a/test/jobs/speaker/enhance_profile_job_test.rb
+++ b/test/jobs/speaker/enhance_profile_job_test.rb
@@ -30,7 +30,7 @@ class Speaker::EnhanceProfileJobTest < ActiveJob::TestCase
     VCR.use_cassette("speaker/enhance_profile_job_test_search_design") do
       @speaker = Speaker.create!(name: "Design")
       Speaker::EnhanceProfileJob.new.perform(@speaker)
-      assert_equal "design", @speaker.reload.github
+      assert_equal "Design-and-Code", @speaker.reload.github
     end
   end
 end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -10,40 +10,22 @@ class EventsTest < ApplicationSystemTestCase
     assert_selector "h1", text: "Events"
   end
 
-  test "should create event" do
-    visit events_url
-    click_on "New event"
+  # Currently this test fails for 2 reasons:
+  # 1. The "Edit this event" button is on events_url
+  # 2. 'Description', 'Frequency', 'Kind' and 'Website' are attributes of the event's organisation, not the even itself
+  # The update method and the form would need to be amended for the method to work
+  # test "should update Event" do
+  #   visit event_url(@event)
+  #   click_on "Edit this event", match: :first
 
-    fill_in "Description", with: @event.description
-    fill_in "Frequency", with: @event.frequency
-    fill_in "Kind", with: @event.kind
-    fill_in "Name", with: @event.name
-    fill_in "Website", with: @event.website
-    click_on "Create Event"
+  #   fill_in "Description", with: @event.description
+  #   fill_in "Frequency", with: @event.frequency
+  #   fill_in "Kind", with: @event.kind
+  #   fill_in "Name", with: @event.name
+  #   fill_in "Website", with: @event.website
+  #   click_on "Update Event"
 
-    assert_text "Event was successfully created"
-    click_on "Back"
-  end
-
-  test "should update Event" do
-    visit event_url(@event)
-    click_on "Edit this event", match: :first
-
-    fill_in "Description", with: @event.description
-    fill_in "Frequency", with: @event.frequency
-    fill_in "Kind", with: @event.kind
-    fill_in "Name", with: @event.name
-    fill_in "Website", with: @event.website
-    click_on "Update Event"
-
-    assert_text "Event was successfully updated"
-    click_on "Back"
-  end
-
-  test "should destroy Event" do
-    visit event_url(@event)
-    click_on "Destroy this event", match: :first
-
-    assert_text "Event was successfully destroyed"
-  end
+  #   assert_text "Event was successfully updated"
+  #   click_on "Back"
+  # end
 end

--- a/test/system/speakers_test.rb
+++ b/test/system/speakers_test.rb
@@ -5,30 +5,15 @@ class SpeakersTest < ApplicationSystemTestCase
     @speaker = speakers(:one)
   end
 
-  test "visiting the index" do
-    visit speakers_url
-    assert_selector "h1", text: "Speakers"
-  end
-
-  test "should create speaker" do
-    visit speakers_url
-    click_on "New speaker"
-
-    fill_in "Bio", with: @speaker.bio
-    fill_in "Github", with: @speaker.github
-    fill_in "Name", with: @speaker.name
-    fill_in "Slug", with: @speaker.slug
-    fill_in "Twitter", with: @speaker.twitter
-    fill_in "Website", with: @speaker.website
-    click_on "Create Speaker"
-
-    assert_text "Speaker was successfully created"
-    click_on "Back"
-  end
+  # Contrary to "Talks", there is currently no "Speakers" heading
+  # test "visiting the index" do
+  #   visit speakers_url
+  #   assert_selector "h1", text: "Speakers"
+  # end
 
   test "should update Speaker" do
     visit speaker_url(@speaker)
-    click_on "Edit this speaker", match: :first
+    click_on "Edit", match: :first
 
     fill_in "Bio", with: @speaker.bio
     fill_in "Github", with: @speaker.github
@@ -36,16 +21,8 @@ class SpeakersTest < ApplicationSystemTestCase
     fill_in "Slug", with: @speaker.slug
     fill_in "Twitter", with: @speaker.twitter
     fill_in "Website", with: @speaker.website
-    click_on "Update Speaker"
+    click_on "Suggest modifications"
 
-    assert_text "Speaker was successfully updated"
-    click_on "Back"
-  end
-
-  test "should destroy Speaker" do
-    visit speaker_url(@speaker)
-    click_on "Destroy this speaker", match: :first
-
-    assert_text "Speaker was successfully destroyed"
+    assert_text "Your suggestion was successfully created and will be reviewed soon."
   end
 end

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -10,38 +10,15 @@ class TalksTest < ApplicationSystemTestCase
     assert_selector "h1", text: "Talks"
   end
 
-  test "should create talk" do
-    visit talks_url
-    click_on "New talk"
-
-    fill_in "Description", with: @talk.description
-    fill_in "Slug", with: @talk.slug
-    fill_in "Title", with: @talk.title
-    fill_in "Year", with: @talk.year
-    click_on "Create Talk"
-
-    assert_text "Talk was successfully created"
-    click_on "Back"
-  end
-
   test "should update Talk" do
     visit talk_url(@talk)
-    click_on "Edit this talk", match: :first
+    click_on "Edit", match: :first
 
     fill_in "Description", with: @talk.description
-    fill_in "Slug", with: @talk.slug
     fill_in "Title", with: @talk.title
     fill_in "Year", with: @talk.year
-    click_on "Update Talk"
+    click_on "Suggest modifications"
 
-    assert_text "Talk was successfully updated"
-    click_on "Back"
-  end
-
-  test "should destroy Talk" do
-    visit talk_url(@talk)
-    click_on "Destroy this talk", match: :first
-
-    assert_text "Talk was successfully destroyed"
+    assert_text "Your suggestion was successfully created and will be reviewed soon."
   end
 end


### PR DESCRIPTION
### What does this PR do?
This PR aims at fixing some issues in the test suite. It:

- removes tests and methods generated by the scaffold that are actually not needed
- fixes incorrect expectations in the tests
- comments out some failing tests that may be useful in the future but would first require a method to be changed or a heading to be added

### What is left to do?
The only tests still erroring on my end when running "bundle exec bin/rails test" are 6 tests using VCR under the test/clients/youtube folder, because of this error:

`
RuntimeError: Neutered Exception VCR::Errors::UnhandledHTTPRequestError:
` 

For your reference, I also noticed that some tests in test/system raise errors when I run them separately, because they are meant to check text on home#index, but there is only a page#home in the routes. These tests are:

- test/system/identity/emails_test.rb
- test/system/passwords_test.rb
- test/system/sessions_test.rb

They also have this warning displayed:

`
Rack::Handler is deprecated and replaced by Rackup::Handler
`
### Context
This PR was made to solve some issues raised in Issue https://github.com/adrienpoly/rubyvideo/issues/5: "Clean the test suite"
