### PR TITLE
Only display a few speakers per card

### DIFF
--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -10,7 +10,7 @@ module IconHelper
   }
 
   def heroicon(icon_name, size: :md, **options)
-    classes = SIZE_CLASSES[size]
+    classes = class_names(SIZE_CLASSES[size], options[:class])
     inline_svg_tag "icons/heroicons/outline/#{icon_name.to_s.tr("_", "-")}.svg", class: classes
   end
 

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -27,9 +27,16 @@
               <%#= link_to talk.event.name, talk.event %>
               <%= content_tag :div, talk.event.name %>
             <% end %>
-            <% talk.speakers.each do |speaker| %>
+
+            <strong class="mt-5">Speakers:</strong>
+            <% talk.speakers.first(10).each do |speaker| %>
               <%= link_to speaker.name, speaker_path(speaker) %>
             <% end %>
+            <div class="my-2">
+              <% if talk.speakers.count > 10 %>
+                <span class="text-red">and <%= talk.speakers.count - 10 %> more speakers</span>
+              <% end %>
+            </div>
         </div>
       </div>
     </div>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -29,12 +29,12 @@
             <% end %>
 
             <strong class="mt-5">Speakers:</strong>
-            <% talk.speakers.first(10).each do |speaker| %>
+            <% talk.speakers.first(5).each do |speaker| %>
               <%= link_to speaker.name, speaker_path(speaker) %>
             <% end %>
             <div class="my-2">
-              <% if talk.speakers.count > 10 %>
-                <span class="text-red">and <%= talk.speakers.count - 10 %> more speakers</span>
+              <% if talk.speakers.count > 5 %>
+                <span class="text-red">and <%= talk.speakers.count - 5 %> more speakers</span>
               <% end %>
             </div>
         </div>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -14,28 +14,34 @@
     <div class="flex items-start gap-2">
       <% if talk.speakers.last&.github&.present? && local_assigns.fetch(:picture_profile, true) %>
         <%= image_tag talk.speakers.last.github_avatar_url(size: 64),
-              class: "rounded-full w-8 h-8 mr-2",
+              class: "rounded-full w-8 h-8 mr-2 mt-1",
               alt: "Github picture profile of #{talk.speakers.last.github}",
               loading: :lazy %>
       <% end %>
       <div>
         <%= link_to talk do %>
-          <%= content_tag :h2, talk.title, class: "py-2 text-base" %>
+          <%= content_tag :h2, talk.title, class: "text-base" %>
         <% end %>
         <div class="flex flex-col text-gray">
             <% if talk.event %>
+              <div class="flex items-center gap-2">
+                <%= heroicon :map_pin, size: :sm, class: "shrink-0 grow-0" %>
+                <%= content_tag :div, talk.event.name %>
+              </div>
               <%#= link_to talk.event.name, talk.event %>
-              <%= content_tag :div, talk.event.name %>
             <% end %>
 
-            <strong class="mt-5">Speakers:</strong>
-            <% talk.speakers.first(5).each do |speaker| %>
-              <%= link_to speaker.name, speaker_path(speaker) %>
-            <% end %>
-            <div class="my-2">
-              <% if talk.speakers.count > 5 %>
-                <span class="text-red">and <%= talk.speakers.count - 5 %> more speakers</span>
+            <div class="flex items-start gap-2">
+              <% if talk.speakers.length > 1 %>
+                <%= heroicon :users, size: :sm, class: "shrink-0 grow-0 my-1" %>
+              <% elsif talk.speakers.length == 1 %>
+                <%= heroicon :user, size: :sm, class: "shrink-0 grow-0 my-1" %>
               <% end %>
+
+              <div class="line-clamp-1">
+                <% speaker_names = talk.speakers.shuffle.map { |speaker| link_to speaker.name, speaker_path(speaker) } %>
+                <%= sanitize speaker_names.join(", ") %>
+              </div>
             </div>
         </div>
       </div>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -6,9 +6,11 @@
   <% end %>
 
   <%= turbo_frame_tag "talks", target: "_top" do %>
-    <div id="talks" class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3 gallery">
-      <%= render partial: "talks/card", collection: @talks, as: :talk, locals: {from_talk_id: @from_talk_id} %>
+    <div id="talks" class="grid min-w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 gallery">
+      <%= render partial: "talks/card", collection: @talks, as: :talk, locals: {from_talk_id: @from_talk_id}, cache: true %>
     </div>
-    <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+    <div class="flex mt-4 w-full">
+      <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+    </div>
   <% end %>
 </div>


### PR DESCRIPTION
This is a follow-up of #28 somehow I couldn't edit the main PR 

<img width="1284" alt="CleanShot 2023-07-21 at 06 48 23@2x" src="https://github.com/adrienpoly/rubyvideo/assets/7847244/da565702-e280-4d84-a44b-234446419373">

Speakers are listed on a single line using the line-clamp of Tailwind and icons have been added

Co-authored-by: @enderahmetyurt