### PR TITLE
Enable action cable with litestack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@
 /config/credentials/production.key
 
 test-run-report*
+
+# Ignore SQLite databases create by Litestack for action cable to be removed once we are able to move them to storage
+db/*.db
+db/*.db-*

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "turbo-rails"
 # gem "cssbundling-rails"
 
 # Use Redis adapter to run Action Cable in production
-gem "redis", ">= 4.0.1"
+# gem "redis", ">= 4.0.1"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ end
 
 gem "pagy", "~> 6.0"
 gem "dockerfile-rails", ">= 1.2", group: :development
-gem "litestack", "~> 0.2.3"
+gem "litestack"
 gem "inline_svg", "~> 1.9"
 gem "net-http", "~> 0.3.2"
 gem "meilisearch-rails", "~> 0.9.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     lint_roller (1.0.0)
-    litestack (0.2.6)
+    litestack (0.3.0)
       erubi
       hanami-router
       oj
@@ -229,7 +229,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
-    oj (3.15.0)
+    oj (3.15.1)
     pagy (6.0.4)
     parallel (1.23.0)
     parser (3.2.2.3)
@@ -380,7 +380,7 @@ DEPENDENCIES
   error_highlight (>= 0.4.0)
   groupdate (~> 6.2)
   inline_svg (~> 1.9)
-  litestack (~> 0.2.3)
+  litestack
   meilisearch-rails (~> 0.9.1)
   meta-tags (~> 2.18)
   net-http (~> 0.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,14 @@ GEM
       activesupport (>= 5.0)
     groupdate (6.2.1)
       activesupport (>= 5.2)
+    hanami-router (0.6.2)
+      hanami-utils (~> 0.7)
+      http_router (~> 0.11)
+    hanami-utils (0.9.2)
     hashdiff (1.0.1)
+    http_router (0.11.2)
+      rack (>= 1.0.0)
+      url_mount (~> 0.2.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -177,9 +184,13 @@ GEM
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     lint_roller (1.0.0)
-    litestack (0.2.3)
+    litestack (0.2.6)
+      erubi
+      hanami-router
       oj
+      rack
       sqlite3
+      tilt
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -255,10 +266,6 @@ GEM
       nokogiri (~> 1.14)
     rainbow (3.1.1)
     rake (13.0.6)
-    redis (5.0.6)
-      redis-client (>= 0.9.0)
-    redis-client (0.14.1)
-      connection_pool
     regexp_parser (2.8.1)
     reline (0.3.5)
       io-console (~> 0.5)
@@ -310,6 +317,7 @@ GEM
     syntax_tree (6.1.1)
       prettier_print (>= 1.2.0)
     thor (1.2.2)
+    tilt (2.2.0)
     timeout (0.4.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -319,6 +327,8 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     uri (0.12.1)
+    url_mount (0.2.1)
+      rack
     vcr (6.2.0)
     vite_rails (3.0.15)
       railties (>= 5.1, < 8)
@@ -379,7 +389,6 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-mini-profiler
   rails!
-  redis (>= 4.0.1)
   ruby-lsp (~> 0.5.1)
   selenium-webdriver
   sqlite3 (~> 1.4)

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -1,6 +1,6 @@
 // Example: Load Rails libraries in Vite.
 //
-import * as Turbo from '@hotwired/turbo'
+import '@hotwired/turbo-rails'
 
 import Turn from '@domchristie/turn'
 
@@ -14,7 +14,6 @@ import Turn from '@domchristie/turn'
 import '../../assets/stylesheets/application.tailwind.css'
 
 import '~/controllers'
-window.Turbo = Turbo
 
 // Page transitions
 Turn.start()

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,11 +1,8 @@
 development:
-  adapter: redis
-  url: redis://localhost:6379/1
+  adapter: litecable
 
 test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: rubyvideo_production
+  adapter: litecable

--- a/config/litecable.yml
+++ b/config/litecable.yml
@@ -1,0 +1,1 @@
+path: "./storage/cable.db"

--- a/config/litlecable.yml
+++ b/config/litlecable.yml
@@ -1,1 +1,0 @@
-path: ./storage/cable.db


### PR DESCRIPTION
Litestack provides an adapter for ActionCable so that we can omit Redis. 

## Blocking point 

~~I am running into an issue where I cannot configure the path for the action cable database. It always stores it in `/db/cable.db` where as we need to store it in `/storage/cable.db` as this is our persisted volume~~

~~I have tried to put the litecable.yml file both at the root or in `config/` with no luck~~

~~Will open an issue on the main repo~~ 

resolved by litestack 0.3