### PR TITLE
add a test to cover the Turbo stream broadcast with Litestack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ gem "rails", "~> 7.1.0"
 gem "propshaft"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+# gem "sqlite3", "~> 1.4"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", ">= 5.0"
+gem "puma"
 
 # use jbuilder for the api
 gem "jbuilder"

--- a/Gemfile
+++ b/Gemfile
@@ -85,8 +85,8 @@ end
 
 gem "pagy", "~> 6.0"
 gem "dockerfile-rails", ">= 1.2", group: :development
-gem "litestack"
-# gem "litestack", git: "git@github.com:oldmoe/litestack.git", branch: "master"
+# gem "litestack"
+gem "litestack", git: "git@github.com:oldmoe/litestack.git", branch: "master"
 gem "inline_svg", "~> 1.9"
 gem "net-http", "~> 0.3.2"
 gem "meilisearch-rails", "~> 0.9.1"

--- a/Gemfile
+++ b/Gemfile
@@ -85,8 +85,7 @@ end
 
 gem "pagy", "~> 6.0"
 gem "dockerfile-rails", ">= 1.2", group: :development
-# gem "litestack"
-gem "litestack", git: "git@github.com:oldmoe/litestack.git", branch: "master"
+gem "litestack"
 gem "inline_svg", "~> 1.9"
 gem "net-http", "~> 0.3.2"
 gem "meilisearch-rails", "~> 0.9.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: git@github.com:oldmoe/litestack.git
+  revision: 003041b7fde9fdeda3c0fb8ab8dc045c21c9656a
+  branch: master
+  specs:
+    litestack (0.4.1)
+      erubi
+      hanami-router
+      oj
+      rack
+      sqlite3
+      tilt
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -349,6 +362,8 @@ GEM
     standardrb (1.0.1)
       standard
     stringio (3.0.8)
+    syntax_tree (6.1.1)
+      prettier_print (>= 1.2.0)
     thor (1.3.0)
     tilt (2.3.0)
     timeout (0.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,7 +418,7 @@ DEPENDENCIES
   net-http (~> 0.3.2)
   pagy (~> 6.0)
   propshaft
-  puma (>= 5.0)
+  puma
   rack-mini-profiler
   rails (~> 7.1.0)
   rails-controller-testing
@@ -427,7 +427,6 @@ DEPENDENCIES
   ruby-lsp-rails
   selenium-webdriver
   sitemap_generator (~> 6.3)
-  sqlite3 (~> 1.4)
   standardrb (~> 1.0)
   turbo-rails
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: git@github.com:oldmoe/litestack.git
-  revision: 003041b7fde9fdeda3c0fb8ab8dc045c21c9656a
-  branch: master
-  specs:
-    litestack (0.4.1)
-      erubi
-      hanami-router
-      oj
-      rack
-      sqlite3
-      tilt
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -183,7 +170,7 @@ GEM
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
-    litestack (0.4.1)
+    litestack (0.4.2)
       erubi
       hanami-router
       oj
@@ -343,10 +330,10 @@ GEM
       builder (~> 3.0)
     smart_properties (1.17.0)
     sorbet-runtime (0.5.11089)
-    sqlite3 (1.6.7-aarch64-linux)
-    sqlite3 (1.6.7-arm64-darwin)
-    sqlite3 (1.6.7-x86_64-darwin)
-    sqlite3 (1.6.7-x86_64-linux)
+    sqlite3 (1.6.8-aarch64-linux)
+    sqlite3 (1.6.8-arm64-darwin)
+    sqlite3 (1.6.8-x86_64-darwin)
+    sqlite3 (1.6.8-x86_64-linux)
     standard (1.31.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -362,8 +349,6 @@ GEM
     standardrb (1.0.1)
       standard
     stringio (3.0.8)
-    syntax_tree (6.1.1)
-      prettier_print (>= 1.2.0)
     thor (1.3.0)
     tilt (2.3.0)
     timeout (0.4.0)

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -2,7 +2,7 @@ development:
   adapter: litecable
 
 test:
-  adapter: test
+  adapter: litecable
 
 production:
   adapter: litecable

--- a/config/litecable.yml
+++ b/config/litecable.yml
@@ -1,1 +1,4 @@
 path: "./storage/cable.db"
+
+test:
+  path: "./storage/cable.test.db"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -31,6 +31,15 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       has_no_css?(".turbo-progress-bar", wait: timeout)
     end
   end
+
+  def wait_for_turbo_stream_connected(streamable: nil)
+    if streamable
+      signed_stream_name = Turbo::StreamsChannel.signed_stream_name(streamable)
+      assert_selector("turbo-cable-stream-source[connected][channel=\"Turbo::StreamsChannel\"][signed-stream-name=\"#{signed_stream_name}\"]", visible: :all)
+    else
+      assert_selector("turbo-cable-stream-source[connected][channel=\"Turbo::StreamsChannel\"]", visible: :all)
+    end
+  end
 end
 
 Capybara.default_max_wait_time = 5 # Set the wait time in seconds

--- a/test/system/speakers_test.rb
+++ b/test/system/speakers_test.rb
@@ -21,4 +21,15 @@ class SpeakersTest < ApplicationSystemTestCase
 
     assert_text "Your suggestion was successfully created and will be reviewed soon."
   end
+
+  test "broadcast a speaker about partial" do
+    # ensure Turbo Stream broadcast is working with Litestack
+    visit speaker_url(@speaker)
+    wait_for_turbo_stream_connected(streamable: @speaker)
+
+    @speaker.update(bio: "New bio")
+    @speaker.broadcast_about
+
+    assert_text "New bio"
+  end
 end

--- a/test/system/speakers_test.rb
+++ b/test/system/speakers_test.rb
@@ -7,6 +7,7 @@ class SpeakersTest < ApplicationSystemTestCase
 
   test "should update Speaker" do
     visit speaker_url(@speaker)
+    assert_selector "h1", text: @speaker.name
     click_on "Edit", match: :first
 
     assert_text "Editing speaker"


### PR DESCRIPTION
Adds a simple test that broadcast the `_about` partial of a speaker to ensure TurboStream broadcast is working with Litestack

## Issue

The current test works when I use the normal cable `test` adapter but fails when I use the `litestack` adapter. The cable.test.db is created but the channel never connects. It would be a great benefit of Litestack to be about to have the exact same configuration for test and production for Action cable infrastructure.

