### PR TITLE
Hide black bands on video thumbnails

### DIFF
--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -1,6 +1,6 @@
 
 <div class="max-w-sm bg-white" id="<%= dom_id talk %>">
-  <%= link_to talk_path(talk, speaker_slug: local_assigns.fetch(:speaker_slug, nil)), class: "flex aspect-video" do %>
+  <%= link_to talk_path(talk, speaker_slug: local_assigns.fetch(:speaker_slug, nil)), class: "flex aspect-video overflow-hidden" do %>
     <%= image_tag talk.thumbnail_sm,
           srcset: ["#{talk.thumbnail_lg} 2x"],
           id: dom_id(talk),


### PR DESCRIPTION
I just looked into this issue:
https://github.com/adrienpoly/rubyvideo/issues/20

It is quite an odd case as on my Mac, I could see the thumbnails display with black bands on my laptop screen but they displayed correctly on my second screen. Adding overflow-hidden on the link seems to fix the issue and does not seem to trigger other issues as far as I can tell on my machine checking it on Safari, Google Chrome and Mozilla Firefox.

I found the idea to use "overflow-hidden" reading some of the answers here: https://stackoverflow.com/questions/13220715/removing-black-borders-43-on-youtube-thumbnails

Before:

https://github.com/adrienpoly/rubyvideo/assets/99920845/d0c94451-04b7-482c-85e4-0444d723edd9


After:

https://github.com/adrienpoly/rubyvideo/assets/99920845/3998d8fc-b7ac-41b1-8355-118ccb2db0d8



