### PR TITLE
Litesearch POC

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -7,8 +7,7 @@ class TalksController < ApplicationController
   def index
     session[:talks_page] = params[:page] || 1
     if params[:q].present?
-      talks = Talk.includes(:speakers, :event).pagy_search(params[:q])
-      @pagy, @talks = pagy_meilisearch(talks, items: 9, page: session[:talks_page]&.to_i || 1)
+      @pagy, @talks = pagy(Talk.search(params[:q]).all.order(date: :desc).includes(:speakers, :event), items: 9, page: session[:talks_page]&.to_i || 1)
     else
       @pagy, @talks = pagy(Talk.all.order(date: :desc).includes(:speakers, :event), items: 9, page: session[:talks_page]&.to_i || 1)
     end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -27,9 +27,7 @@ class Talk < ApplicationRecord
   include Sluggable
   include Suggestable
   slug_from :title
-  include MeiliSearch::Rails
-  ActiveRecord_Relation.include Pagy::Meilisearch
-  extend Pagy::Meilisearch
+  include Litesearch::Model
 
   # associations
   belongs_to :event, optional: true
@@ -43,31 +41,12 @@ class Talk < ApplicationRecord
   delegate :name, to: :event, prefix: true, allow_nil: true
 
   # search
-  meilisearch do
-    attribute :title
-    attribute :description
-    attribute :slug
-    attribute :video_id
-    attribute :video_provider
-    attribute :thumbnail_sm
-    attribute :thumbnail_md
-    attribute :thumbnail_lg
-    attribute :speaker_names do
-      speakers.pluck(:name)
-    end
-    attribute :event_name do
-      event_name
-    end
-    searchable_attributes [:title, :description, :speaker_names, :event_name]
-    sortable_attributes [:title]
 
-    attributes_to_highlight ["*"]
+  litesearch do |schema|
+    schema.field :title, weight: 3
+    schema.field :description
+    schema.tokenizer :trigram
   end
-
-  meilisearch enqueue: true
-
-  # ensure that during the reindex process the associated records are eager loaded
-  scope :meilisearch_import, -> { includes(:speakers, :event) }
 
   def to_meta_tags
     {


### PR DESCRIPTION
This is mostly a POC at this time to test the Litesearch capabilities.

It is very straight forward to integrate with Active record. The ability to set a weight. Being able to replace Meilisearch here would be nice to have something easier to install/deploy. Maybe we can keep the vector based recommendations from #19 

Current limitation is that I cannot search on speakers name as the `through` associations are not yet supported https://github.com/oldmoe/litestack/issues/45

