### PR TITLE
Simple api for speakers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem "sqlite3", "~> 1.4"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 
+# use jbuilder for the api
+gem "jbuilder"
+
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
 # gem "jsbundling-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,9 @@ GEM
     irb (1.8.3)
       rdoc
       reline (>= 0.3.8)
+    jbuilder (2.11.5)
+      actionview (>= 5.0.0)
+      activesupport (>= 5.0.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
@@ -408,6 +411,7 @@ DEPENDENCIES
   error_highlight (>= 0.4.0)
   groupdate (~> 6.2)
   inline_svg (~> 1.9)
+  jbuilder
   litestack
   meilisearch-rails (~> 0.9.1)
   meta-tags (~> 2.18)

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -1,11 +1,19 @@
 class SpeakersController < ApplicationController
   skip_before_action :authenticate_user!
   before_action :set_speaker, only: %i[show edit update]
+  include Pagy::Backend
 
   # GET /speakers
   def index
-    @speakers = Speaker.all.order(:name).select(:id, :name, :slug, :talks_count, :github)
-    @speakers = @speakers.where("lower(name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
+    respond_to do |format|
+      format.html do
+        @speakers = Speaker.all.order(:name).select(:id, :name, :slug, :talks_count, :github)
+        @speakers = @speakers.where("lower(name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
+      end
+      format.json do
+        @pagy, @speakers = pagy(Speaker.all.order(:name), {items: params[:per_page]})
+      end
+    end
   end
 
   # GET /speakers/1

--- a/app/views/speakers/_speaker.json.jbuilder
+++ b/app/views/speakers/_speaker.json.jbuilder
@@ -1,0 +1,3 @@
+json.cache! speaker do
+  json.extract! speaker, :name, :twitter, :github, :bio, :website, :slug, :talks_count, :updated_at, :created_at
+end

--- a/app/views/speakers/index.json.jbuilder
+++ b/app/views/speakers/index.json.jbuilder
@@ -1,0 +1,16 @@
+json.cache! ["v1", params[:per_page], @pagy.page, @speakers.maximum(:updated_at)] do
+  json.speakers do
+    json.array! @speakers do |speaker|
+      json.partial! "speakers/speaker", speaker: speaker
+    end
+  end
+
+  json.pagination do
+    json.current_page @pagy.page
+    json.pages @pagy.pages
+    json.next_page @pagy.next
+    json.prev_page @pagy.prev
+    json.total_items @pagy.count
+    json.items_per_page @pagy.items
+  end
+end

--- a/scripts/dump_speakers.rb
+++ b/scripts/dump_speakers.rb
@@ -1,0 +1,41 @@
+# This script will query the API and dump the speakers data to a YAML file
+# speaker data can we updated in production, this is a way to sync our seed data to reflect as closely as possible the prod environment
+
+require "net/http"
+require "json"
+require "yaml"
+
+API_ENDPOINT = "https://www.rubyvideo.dev/speakers.json"
+OUTPUT_FILE = "data/speakers.yml"
+
+def fetch_speakers
+  speakers = []
+  current_page = 1
+
+  loop do
+    uri = URI("#{API_ENDPOINT}?page=#{current_page}")
+    response = Net::HTTP.get(uri)
+    parsed_response = JSON.parse(response)
+
+    speakers.concat(parsed_response["speakers"])
+    current_page += 1
+    break if parsed_response.dig("pagination", "next_page").nil?
+  end
+
+  speakers
+end
+
+def save_to_yaml(data)
+  File.write(OUTPUT_FILE, data.to_yaml)
+end
+
+speakers_data = fetch_speakers
+save_to_yaml(speakers_data)
+
+puts "Speakers data saved to #{OUTPUT_FILE}"
+
+puts "formating with Prettier..."
+
+system("yarn prettier --write #{OUTPUT_FILE}")
+
+puts "Done!"

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -24,4 +24,12 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     patch speaker_url(@speaker), params: {speaker: {bio: @speaker.bio, github: @speaker.github, name: @speaker.name, slug: @speaker.slug, twitter: @speaker.twitter, website: @speaker.website}}
     assert_redirected_to speaker_url(@speaker)
   end
+
+  test "should get index as JSON" do
+    get speakers_url, as: :json
+    assert_response :success
+
+    json_response = JSON.parse(response.body)
+    assert_includes json_response["speakers"].map { |speaker_data| speaker_data["name"] }, @speaker.name
+  end
 end


### PR DESCRIPTION
add a simple api endpoint for speakers

1. I thing think data should be open so that others can build upon it in the future
2. on a regular basis I can run a script to update the seed data 

