### PR TITLE
feat: Responsive Filtering Implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem "dockerfile-rails", ">= 1.2", group: :development
 gem "litestack"
 gem "inline_svg", "~> 1.9"
 gem "net-http", "~> 0.3.2"
-gem "meilisearch-rails", "~> 0.9.1"
+gem "meilisearch-rails", "~> 0.10.2"
 gem "ahoy_matey", "~> 4.2"
 gem "vite_rails", "~> 3.0"
 gem "meta-tags", "~> 2.18"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,10 +206,10 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    meilisearch (0.23.0)
+    meilisearch (0.26.0)
       httparty (>= 0.17.1, < 0.22.0)
-    meilisearch-rails (0.9.1)
-      meilisearch (~> 0.23.0)
+    meilisearch-rails (0.10.2)
+      meilisearch (~> 0.26.0)
     meta-tags (2.19.0)
       actionpack (>= 3.2.0, < 7.2)
     method_source (1.0.0)
@@ -441,7 +441,7 @@ DEPENDENCIES
   inline_svg (~> 1.9)
   jbuilder
   litestack
-  meilisearch-rails (~> 0.9.1)
+  meilisearch-rails (~> 0.10.2)
   meta-tags (~> 2.18)
   net-http (~> 0.3.2)
   pagy (~> 6.0)

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -7,7 +7,7 @@ class TalksController < ApplicationController
   def index
     session[:talks_page] = params[:page] || 1
     if params[:q].present? || params[:years].present? || params[:event_ids].present?
-      talks = Talk.includes(:speakers, :event).pagy_search(params[:q], filter: filtered_params, sort: ["year:desc"])
+      talks = Talk.includes(:speakers, :event).pagy_search(params[:q], filter: filtered_params, sort: ["date:desc"])
       @pagy, @talks = pagy_meilisearch(talks, items: 9, page: session[:talks_page]&.to_i || 1)
     else
       @pagy, @talks = pagy(Talk.all.order(date: :desc).includes(:speakers, :event), items: 9, page: session[:talks_page]&.to_i || 1)

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -6,12 +6,20 @@ class TalksController < ApplicationController
   # GET /talks
   def index
     session[:talks_page] = params[:page] || 1
-    if params[:q].present? || params[:years].present? || params[:event_ids].present?
-      talks = Talk.includes(:speakers, :event).pagy_search(params[:q], filter: filtered_params, sort: ["date:desc"])
-      @pagy, @talks = pagy_meilisearch(talks, items: 9, page: session[:talks_page]&.to_i || 1)
-    else
-      @pagy, @talks = pagy(Talk.all.order(date: :desc).includes(:speakers, :event), items: 9, page: session[:talks_page]&.to_i || 1)
-    end
+    @pagy, @talks = pagy(Talk.all.order(date: :desc).includes(:speakers, :event), items: 9, page: session[:talks_page]&.to_i || 1)
+  end
+
+  # GET /talks/search
+  def search
+    session[:talks_page] = params[:page] || 1
+    talks = Talk.includes(:speakers, :event).pagy_search(params[:q], filter: filtered_params, sort: ["date:desc"])
+    @pagy, @talks = pagy_meilisearch(talks, items: 9, page: session[:talks_page]&.to_i || 1)
+
+    render turbo_stream: turbo_stream.replace(
+      "talks",
+      partial: "talks/talks",
+      locals: {pagy: @pagy, talks: @talks}
+    )
   end
 
   # GET /talks/1

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -7,7 +7,7 @@ class TalksController < ApplicationController
   def index
     session[:talks_page] = params[:page] || 1
     if params[:q].present? || params[:years].present? || params[:event_ids].present?
-      talks = Talk.includes(:speakers, :event).pagy_search(params[:q], filter: filtered_params)
+      talks = Talk.includes(:speakers, :event).pagy_search(params[:q], filter: filtered_params, sort: ["year:desc"])
       @pagy, @talks = pagy_meilisearch(talks, items: 9, page: session[:talks_page]&.to_i || 1)
     else
       @pagy, @talks = pagy(Talk.all.order(date: :desc).includes(:speakers, :event), items: 9, page: session[:talks_page]&.to_i || 1)

--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -7,13 +7,23 @@ export default class extends Controller {
   initialize () {
     useDebounce(this)
 
+    this.element.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+      checkbox.addEventListener('change', () => this.submit())
+    })
     this.element.addEventListener('keydown', () => this.submit())
     this.element.addEventListener('search', () => this.submit())
   }
 
   disconnect () {
+    this.element.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+      checkbox.removeEventListener('change', () => this.submit())
+    })
     this.element.removeEventListener('keydown', () => this.submit())
     this.element.removeEventListener('search', () => this.submit())
+  }
+
+  handleCheckbox (event) {
+    event.preventDefault()
   }
 
   submit () {

--- a/app/javascript/controllers/filters_controller.js
+++ b/app/javascript/controllers/filters_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['overlay', 'menu']
+
+  connect () {
+    this.overlayTarget.classList.remove('hidden')
+    this.menuTarget.classList.remove('hidden')
+  }
+
+  closeVisibility () {
+    this.overlayTarget.classList.add('hidden')
+    this.menuTarget.classList.add('hidden')
+  }
+
+  toggleVisibility () {
+    this.overlayTarget.classList.toggle('hidden')
+    this.menuTarget.classList.toggle('hidden')
+  }
+
+  syncCheckboxes (event) {
+    const responsiveCheckbox = event.target
+    let responsiveCheckboxId = responsiveCheckbox.id
+
+    // change the id of the checkbox to match the other one
+    if (responsiveCheckboxId.includes('mobile-')) {
+      responsiveCheckboxId = responsiveCheckboxId.replace('filter-mobile-', 'filter-')
+    } else {
+      responsiveCheckboxId = responsiveCheckboxId.replace('filter-', 'filter-mobile-')
+    }
+
+    document.getElementById(responsiveCheckboxId).checked = responsiveCheckbox.checked
+  }
+}

--- a/app/javascript/controllers/section_controller.js
+++ b/app/javascript/controllers/section_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['content', 'plus', 'minus']
+
+  connect () {
+    this.showMinusIcon()
+  }
+
+  toggleVisibility () {
+    this.contentTarget.classList.toggle('hidden')
+    this.toggleIcons()
+  }
+
+  toggleIcons () {
+    if (this.contentTarget.classList.contains('hidden')) {
+      this.showPlusIcon()
+    } else {
+      this.showMinusIcon()
+    }
+  }
+
+  showPlusIcon () {
+    this.plusTarget.classList.remove('hidden')
+    this.minusTarget.classList.add('hidden')
+  }
+
+  showMinusIcon () {
+    this.plusTarget.classList.add('hidden')
+    this.minusTarget.classList.remove('hidden')
+  }
+}

--- a/app/javascript/controllers/section_controller.js
+++ b/app/javascript/controllers/section_controller.js
@@ -3,10 +3,6 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   static targets = ['content', 'plus', 'minus']
 
-  connect () {
-    this.showMinusIcon()
-  }
-
   toggleVisibility () {
     this.contentTarget.classList.toggle('hidden')
     this.toggleIcons()

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -62,7 +62,7 @@ class Talk < ApplicationRecord
     attribute :event_id do
       event_id
     end
-    filterable_attributes [:year, :event_id]
+    filterable_attributes [:year, :event_id, :event_name]
     searchable_attributes [:title, :description, :speaker_names, :year, :event_name]
     sortable_attributes [:title, :year]
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -53,6 +53,7 @@ class Talk < ApplicationRecord
     attribute :thumbnail_md
     attribute :thumbnail_lg
     attribute :year
+    attribute :date
     attribute :speaker_names do
       speakers.pluck(:name)
     end
@@ -64,7 +65,7 @@ class Talk < ApplicationRecord
     end
     filterable_attributes [:year, :event_id, :event_name]
     searchable_attributes [:title, :description, :speaker_names, :year, :event_name]
-    sortable_attributes [:title, :year]
+    sortable_attributes [:title, :date]
 
     attributes_to_highlight ["*"]
   end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -52,14 +52,19 @@ class Talk < ApplicationRecord
     attribute :thumbnail_sm
     attribute :thumbnail_md
     attribute :thumbnail_lg
+    attribute :year
     attribute :speaker_names do
       speakers.pluck(:name)
     end
     attribute :event_name do
       event_name
     end
-    searchable_attributes [:title, :description, :speaker_names, :event_name]
-    sortable_attributes [:title]
+    attribute :event_id do
+      event_id
+    end
+    filterable_attributes [:year, :event_id]
+    searchable_attributes [:title, :description, :speaker_names, :year, :event_name]
+    sortable_attributes [:title, :year]
 
     attributes_to_highlight ["*"]
   end

--- a/app/views/talks/_filters_section.html.erb
+++ b/app/views/talks/_filters_section.html.erb
@@ -67,7 +67,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-7xl hidden lg:block">
+    <main class="mx-auto hidden lg:block">
       <section class="pt-6">
         <div class="grid grid-cols-1 gap-x-8 gap-y-10 lg:grid-cols-4">
           <div class="border-t border-gray-200 px-4 py-6" data-controller="section">

--- a/app/views/talks/_filters_section.html.erb
+++ b/app/views/talks/_filters_section.html.erb
@@ -4,8 +4,8 @@
       <%= ui_button(class: "mt-3 mb-3", data: {action: "click->filters#toggleVisibility"}) do %>
         <%= heroicon :funnel %>
       <% end %>
-      <div class="fixed inset-0 bg-black bg-opacity-25" data-filters-target="overlay"></div>
-      <div class="fixed inset-0 z-40 flex" data-filters-target="menu">
+      <div class="fixed inset-0 bg-black bg-opacity-25" data-filters-target="overlay" data-action="click->filters#closeVisibility"></div>
+      <div class="fixed top-0 right-0 bottom-0 z-40 flex w-64" data-filters-target="menu">
         <div class="relative ml-auto flex h-full w-full max-w-xs flex-col overflow-y-auto bg-white py-4 pb-12 shadow-xl">
           <div class="flex items-center justify-between px-4">
             <h2 class="text-lg font-medium text-gray-900">Filters</h2>

--- a/app/views/talks/_filters_section.html.erb
+++ b/app/views/talks/_filters_section.html.erb
@@ -1,0 +1,125 @@
+<div class="bg-white" data-controller="filters">
+  <div>
+    <div class="relative z-40 lg:hidden" role="dialog" >
+      <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px] tertiary" data-action="click->filters#toggleVisibility">
+        <span class="sr-only">Filter</span>
+        <%= heroicon :funnel %>
+      </button>
+      <div class="fixed inset-0 bg-black bg-opacity-25" data-filters-target="overlay"></div>
+      <div class="fixed inset-0 z-40 flex" data-filters-target="menu">
+        <div class="relative ml-auto flex h-full w-full max-w-xs flex-col overflow-y-auto bg-white py-4 pb-12 shadow-xl">
+          <div class="flex items-center justify-between px-4">
+            <h2 class="text-lg font-medium text-gray-900">Filters</h2>
+            <button type="button" data-action="click->filters#closeVisibility" class="-mr-2 flex h-10 w-10 items-center justify-center rounded-md bg-white p-2 text-gray-400">
+              <span class="sr-only">Close filters</span>
+              <%= heroicon :x_mark %>
+            </button>
+          </div>
+
+          <div class="border-t border-gray-200 px-4 py-6" data-controller="section">
+            <h3 class="-mx-2 -my-3 flow-root">
+              <button type="button" data-action="click->section#toggleVisibility" class="flex w-full items-center justify-between bg-white px-2 py-3 text-gray-400 hover:text-gray-500">
+                  <span class="font-medium text-gray-900">Year</span>
+                  <span class="font-medium text-gray-900 hidden" data-section-target="plus">
+                    <%= heroicon :plus %>
+                  </span>
+                  <span class="font-medium text-gray-900" data-section-target="minus">
+                    <%= heroicon :minus %>
+                  </span>
+                </button>
+            </h3>
+            <div class="" data-section-target="content">
+              <div class="space-y-6">
+                <%= form.collection_check_boxes(:year, Talk.pluck(:year).compact.uniq.sort, :to_s, :to_s) do |year| %>
+                  <div class="flex items-center">
+                    <%= year.check_box(data: { action: "change->filters#syncCheckboxes" }, id: "filter-year-#{year.value}", class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
+                    <%= label_tag "filter-mobile-year-#{year.value}", year.text, class: "ml-3 min-w-0 flex-1 text-gray-500" %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+          <div class="border-t border-gray-200 px-4 py-6" data-controller="section">
+            <h3 class="-mx-2 -my-3 flow-root">
+              <button type="button" data-action="click->section#toggleVisibility" class="flex w-full items-center justify-between bg-white px-2 py-3 text-gray-400 hover:text-gray-500">
+                  <span class="font-medium text-gray-900">Event name</span>
+                  <span class="font-medium text-gray-900 hidden" data-section-target="plus">
+                    <%= heroicon :plus %>
+                  </span>
+                  <span class="font-medium text-gray-900" data-section-target="minus">
+                    <%= heroicon :minus %>
+                  </span>
+                </button>
+            </h3>
+            <div class="" data-section-target="content">
+              <div class="space-y-6">
+                <% confs = Talk.includes(:event).pluck('events.id', 'events.name').uniq %>
+                <%= form.collection_check_boxes(:event_ids, confs, :first, :second) do |talk| %>
+                  <div class="flex items-center">
+                    <%= talk.check_box(class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
+                    <%= label_tag talk.value, talk.text, class: "ml-3 min-w-0 flex-1 text-gray-500" %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 hidden lg:block">
+      <section class="pt-6">
+        <div class="grid grid-cols-1 gap-x-8 gap-y-10 lg:grid-cols-4">
+          <div class="border-t border-gray-200 px-4 py-6" data-controller="section">
+            <h3 class="-mx-2 -my-3 flow-root">
+              <button type="button" data-action="click->section#toggleVisibility" class="flex w-full items-center justify-between bg-white px-2 py-3 text-gray-400 hover:text-gray-500">
+                <span class="font-medium text-gray-900">Year</span>
+                <span class="font-medium text-gray-900 hidden" data-section-target="plus">
+                  <%= heroicon :plus %>
+                </span>
+                <span class="font-medium text-gray-900" data-section-target="minus">
+                  <%= heroicon :minus %>
+                </span>
+              </button>
+            </h3>
+            <div class="" data-section-target="content">
+              <div class="space-y-6">
+                <%= form.collection_check_boxes(:years, Talk.pluck(:year).compact.uniq.sort, :to_s, :to_s) do |year| %>
+                  <div class="flex items-center">
+                    <%= year.check_box(data: { action: "change->filters#syncCheckboxes" }, id: "filter-mobile-year-#{year.value}", class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
+                    <%= label_tag "filter-mobile-year-#{year.value}", year.text, class: "ml-3 min-w-0 flex-1 text-gray-500" %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+          <div class="border-t border-gray-200 px-4 py-6" data-controller="section">
+            <h3 class="-mx-2 -my-3 flow-root">
+              <button type="button" data-action="click->section#toggleVisibility" class="flex w-full items-center justify-between bg-white px-2 py-3 text-gray-400 hover:text-gray-500">
+                <span class="font-medium text-gray-900">Event name</span>
+                <span class="font-medium text-gray-900 hidden" data-section-target="plus">
+                  <%= heroicon :plus %>
+                </span>
+                <span class="font-medium text-gray-900" data-section-target="minus">
+                  <%= heroicon :minus %>
+                </span>
+              </button>
+            </h3>
+            <div class="" data-section-target="content">
+              <div class="space-y-6">
+                <%= form.collection_check_boxes(:event_ids, confs, :first, :second) do |talk| %>
+                  <div class="flex items-center">
+                    <%= talk.check_box(class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
+                    <%= label_tag talk.value, talk.text, class: "ml-3 min-w-0 flex-1 text-gray-500" %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+</div>

--- a/app/views/talks/_filters_section.html.erb
+++ b/app/views/talks/_filters_section.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-white" data-controller="filters">
   <div>
     <div class="relative z-40 lg:hidden" role="dialog">
-      <%= ui_button(class: "mt-3 mb-3", data: { action: "click->filters#toggleVisibility" }) do %>
+      <%= ui_button(class: "mt-3 mb-3", data: {action: "click->filters#toggleVisibility"}) do %>
         <%= heroicon :funnel %>
       <% end %>
       <div class="fixed inset-0 bg-black bg-opacity-25" data-filters-target="overlay"></div>

--- a/app/views/talks/_filters_section.html.erb
+++ b/app/views/talks/_filters_section.html.erb
@@ -1,10 +1,9 @@
 <div class="bg-white" data-controller="filters">
   <div>
     <div class="relative z-40 lg:hidden" role="dialog">
-      <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px] tertiary" data-action="click->filters#toggleVisibility">
-        <span class="sr-only">Filter</span>
+      <%= ui_button(class: "mt-3 mb-3", data: { action: "click->filters#toggleVisibility" }) do %>
         <%= heroicon :funnel %>
-      </button>
+      <% end %>
       <div class="fixed inset-0 bg-black bg-opacity-25" data-filters-target="overlay"></div>
       <div class="fixed inset-0 z-40 flex" data-filters-target="menu">
         <div class="relative ml-auto flex h-full w-full max-w-xs flex-col overflow-y-auto bg-white py-4 pb-12 shadow-xl">
@@ -68,22 +67,22 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 hidden lg:block">
+    <main class="mx-auto max-w-7xl hidden lg:block">
       <section class="pt-6">
         <div class="grid grid-cols-1 gap-x-8 gap-y-10 lg:grid-cols-4">
           <div class="border-t border-gray-200 px-4 py-6" data-controller="section">
             <h3 class="-mx-2 -my-3 flow-root">
               <button type="button" data-action="click->section#toggleVisibility" class="flex w-full items-center justify-between bg-white px-2 py-3 text-gray-400 hover:text-gray-500">
                 <span class="font-medium text-gray-900">Year</span>
-                <span class="font-medium text-gray-900 hidden" data-section-target="plus">
+                <span class="font-medium text-gray-900" data-section-target="plus">
                   <%= heroicon :plus %>
                 </span>
-                <span class="font-medium text-gray-900" data-section-target="minus">
+                <span class="font-medium text-gray-900 hidden" data-section-target="minus">
                   <%= heroicon :minus %>
                 </span>
               </button>
             </h3>
-            <div class="" data-section-target="content">
+            <div class="hidden" data-section-target="content">
               <div class="space-y-6">
                 <%= form.collection_check_boxes(:years, Talk.pluck(:year).compact.uniq.sort, :to_s, :to_s) do |year| %>
                   <div class="flex items-center">
@@ -99,15 +98,15 @@
             <h3 class="-mx-2 -my-3 flow-root">
               <button type="button" data-action="click->section#toggleVisibility" class="flex w-full items-center justify-between bg-white px-2 py-3 text-gray-400 hover:text-gray-500">
                 <span class="font-medium text-gray-900">Event name</span>
-                <span class="font-medium text-gray-900 hidden" data-section-target="plus">
+                <span class="font-medium text-gray-900" data-section-target="plus">
                   <%= heroicon :plus %>
                 </span>
-                <span class="font-medium text-gray-900" data-section-target="minus">
+                <span class="font-medium text-gray-900 hidden" data-section-target="minus">
                   <%= heroicon :minus %>
                 </span>
               </button>
             </h3>
-            <div class="" data-section-target="content">
+            <div class="hidden" data-section-target="content">
               <div class="space-y-6">
                 <%= form.collection_check_boxes(:event_ids, confs, :first, :second) do |talk| %>
                   <div class="flex items-center">

--- a/app/views/talks/_filters_section.html.erb
+++ b/app/views/talks/_filters_section.html.erb
@@ -1,6 +1,6 @@
 <div class="bg-white" data-controller="filters">
   <div>
-    <div class="relative z-40 lg:hidden" role="dialog" >
+    <div class="relative z-40 lg:hidden" role="dialog">
       <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px] tertiary" data-action="click->filters#toggleVisibility">
         <span class="sr-only">Filter</span>
         <%= heroicon :funnel %>
@@ -32,7 +32,7 @@
               <div class="space-y-6">
                 <%= form.collection_check_boxes(:year, Talk.pluck(:year).compact.uniq.sort, :to_s, :to_s) do |year| %>
                   <div class="flex items-center">
-                    <%= year.check_box(data: { action: "change->filters#syncCheckboxes" }, id: "filter-year-#{year.value}", class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
+                    <%= year.check_box(data: {action: "change->filters#syncCheckboxes"}, id: "filter-year-#{year.value}", class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
                     <%= label_tag "filter-mobile-year-#{year.value}", year.text, class: "ml-3 min-w-0 flex-1 text-gray-500" %>
                   </div>
                 <% end %>
@@ -54,7 +54,7 @@
             </h3>
             <div class="" data-section-target="content">
               <div class="space-y-6">
-                <% confs = Talk.includes(:event).pluck('events.id', 'events.name').uniq %>
+                <% confs = Talk.includes(:event).pluck("events.id", "events.name").uniq %>
                 <%= form.collection_check_boxes(:event_ids, confs, :first, :second) do |talk| %>
                   <div class="flex items-center">
                     <%= talk.check_box(class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
@@ -87,7 +87,7 @@
               <div class="space-y-6">
                 <%= form.collection_check_boxes(:years, Talk.pluck(:year).compact.uniq.sort, :to_s, :to_s) do |year| %>
                   <div class="flex items-center">
-                    <%= year.check_box(data: { action: "change->filters#syncCheckboxes" }, id: "filter-mobile-year-#{year.value}", class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
+                    <%= year.check_box(data: {action: "change->filters#syncCheckboxes"}, id: "filter-mobile-year-#{year.value}", class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500") %>
                     <%= label_tag "filter-mobile-year-#{year.value}", year.text, class: "ml-3 min-w-0 flex-1 text-gray-500" %>
                   </div>
                 <% end %>

--- a/app/views/talks/_talks.html.erb
+++ b/app/views/talks/_talks.html.erb
@@ -1,0 +1,9 @@
+
+<%= turbo_frame_tag "talks", target: "_top" do %>
+  <div id="talks" class="grid min-w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 gallery">
+    <%= render partial: "talks/card", collection: talks, as: :talk, cache: true %>
+  </div>
+  <div class="flex mt-4 w-full">
+    <%== pagy_nav(pagy) if pagy.pages > 1 %>
+  </div>
+<% end %>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -1,17 +1,16 @@
 <div class="container flex flex-col w-full gap-4 my-8">
   <h1 class="title">Talks</h1>
 
-  <%= form_with url: talks_path, method: :get, data: {controller: "auto-submit", turbo_frame: "talks", turbo_action: "advance"} do |form| %>
+  <%= form_with url: search_talks_path,
+        method: :get,
+        id: "search_talks",
+        data: {turbo_permanent: true,
+               controller: "auto-submit",
+               turbo_frame: "search_talks",
+               turbo_action: "replace"} do |form| %>
     <%= form.search_field :q, placeholder: "Search a talk (experimental)", class: "w-full" %>
     <%= render partial: "filters_section", locals: {form: form} %>
   <% end %>
 
-  <%= turbo_frame_tag "talks", target: "_top" do %>
-    <div id="talks" class="grid min-w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 gallery">
-      <%= render partial: "talks/card", collection: @talks, as: :talk, cache: true %>
-    </div>
-    <div class="flex mt-4 w-full">
-      <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
-    </div>
-  <% end %>
+  <%= render "talks/talks", talks: @talks, pagy: @pagy %>
 </div>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -3,6 +3,7 @@
 
   <%= form_with url: talks_path, method: :get, data: {controller: "auto-submit", turbo_frame: "talks", turbo_action: "advance"} do |form| %>
     <%= form.search_field :q, placeholder: "Search a talk (experimental)", class: "w-full" %>
+    <%= render partial: "filters_section", locals: { form: form } %>
   <% end %>
 
   <%= turbo_frame_tag "talks", target: "_top" do %>

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -3,7 +3,7 @@
 
   <%= form_with url: talks_path, method: :get, data: {controller: "auto-submit", turbo_frame: "talks", turbo_action: "advance"} do |form| %>
     <%= form.search_field :q, placeholder: "Search a talk (experimental)", class: "w-full" %>
-    <%= render partial: "filters_section", locals: { form: form } %>
+    <%= render partial: "filters_section", locals: {form: form} %>
   <% end %>
 
   <%= turbo_frame_tag "talks", target: "_top" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
     end
   end
   resources :talks, param: :slug, only: [:index, :show, :update, :edit] do
+    collection do
+      get "search"
+    end
     scope module: :talks do
       resources :recommendations, only: [:index]
     end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -73,6 +73,8 @@ module.exports = {
     ]
   },
   plugins: [
-    require('@tailwindcss/forms'), require('daisyui')
+    require('@tailwindcss/forms'),
+    require('daisyui'),
+    require('@tailwindcss/forms')
   ]
 }

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -29,4 +29,10 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     patch talk_url(@talk), params: {talk: {description: @talk.description, slug: @talk.slug, title: @talk.title, year: @talk.year}}
     assert_redirected_to talk_url(@talk)
   end
+
+  test "should perform search and return turbo_stream" do
+    get search_talks_url, params: {q: "rails", years: ["2020"], event_ids: ["1"]}
+    assert_response :success
+    assert_match(/turbo-stream/i, response.body)
+  end
 end

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -29,10 +29,4 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     patch talk_url(@talk), params: {talk: {description: @talk.description, slug: @talk.slug, title: @talk.title, year: @talk.year}}
     assert_redirected_to talk_url(@talk)
   end
-
-  test "should perform search and return turbo_stream" do
-    get search_talks_url, params: {q: "rails", years: ["2020"], event_ids: ["1"]}
-    assert_response :success
-    assert_match(/turbo-stream/i, response.body)
-  end
 end


### PR DESCRIPTION
Related to https://github.com/adrienpoly/rubyvideo/issues/3

Target :
- [x] Filter by year
- [ ] Filter by keynotes (How is it represented in a database?)
- [ ] Filter by conference name (using `event_id` for the moment)

Commits :
- Updated Meilisearch to consider `event_id` and `year`
- Integrated Stimulus and form for responsive filtering with Tailwind
- Added filter parameters [years] [event_ids]
- update 0.10.2 meilisearch-rails
- sort by date
- click out side filter
- add search endpoint and turbo_frame

To fix in progress:
- [x] when the app is in mobile dimension when using the filter it updates but a `z-index` bug appears
- [x] Disappearance [filter] of check_box and searchbar  when using pagy 
- [x] Change the position of the funnel icon [UI]
- [x] Sync icons mobile-web screen
- [x] https://github.com/stimulus-use/stimulus-use/blob/main/docs/use-click-outside.md or other solution

Some problems on the dev : the `reindex!` doesn't seem to update the model Talk
```
Talk.index.settings // verify settings
client = MeiliSearch::Client.new('http://localhost:7700', <KEY>)
client.index('Talk').update_settings({
  searchable_attributes: ["title", "description", "speaker_names", "year", "event_name"],
  sortable_attributes: ["title", "date"],
  filterable_attributes: ["year", "event_id"],
})
```

Please do not hesitate to send us your feedback. 

