### PR TITLE
Add `countries` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# All sorts of useful information about every country packaged as convenient little country objects
+gem "countries"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     chartkick (5.0.7)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
+    countries (6.0.1)
+      unaccent (~> 0.3)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -418,6 +420,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     useragent (0.16.10)
@@ -456,6 +459,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-19
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -470,6 +474,7 @@ DEPENDENCIES
   byebug (~> 11.1)
   capybara
   chartkick (~> 5.0)
+  countries
   debug
   dockerfile-rails (>= 1.2)
   dotenv-rails


### PR DESCRIPTION
We need the countries gem, otherwise `rails db:seed` is going to fail with:

```
❯ rails db:seed
bin/rails aborted!
NameError: uninitialized constant Event::ISO3166 (NameError)

  VALID_COUNTRY_CODES = ISO3166::Country.codes
                        ^^^^^^^
/Users/marcoroth/Development/rubyvideo/app/models/event.rb:29:in `<class:Event>'
/Users/marcoroth/Development/rubyvideo/app/models/event.rb:17:in `<main>'
/Users/marcoroth/Development/rubyvideo/db/seeds.rb:30:in `block (3 levels) in <main>'
/Users/marcoroth/Development/rubyvideo/db/seeds.rb:29:in `each'
/Users/marcoroth/Development/rubyvideo/db/seeds.rb:29:in `block (2 levels) in <main>'
/Users/marcoroth/Development/rubyvideo/db/seeds.rb:16:in `each'
/Users/marcoroth/Development/rubyvideo/db/seeds.rb:16:in `block in <main>'
/Users/marcoroth/Development/rubyvideo/db/seeds.rb:15:in `<main>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```