### PR TITLE
Adds Helsinki Ruby Brigade

### DIFF
--- a/data/rubybrigade/playlists.yml
+++ b/data/rubybrigade/playlists.yml
@@ -1,0 +1,10 @@
+---
+- id: PLF1jkqcXA5ckRPFZdq572uRHD_wHG0jO9
+  title: Helsinki Ruby Brigade
+  description: Recordings from Ruby Brigade meet-ups
+  published_at: '2023-06-20'
+  channel_id: UCcoS038f4xA_Lz5AoD0ShzA
+  year: 2023
+  videos_count: 6
+  metadata_parser: Youtube::VideoMetadata
+  slug: rubybrigade

--- a/data/rubybrigade/rubybrigade/videos.yml
+++ b/data/rubybrigade/rubybrigade/videos.yml
@@ -1,0 +1,64 @@
+---
+- title: Oivan’s journey with Ruby on Rails
+  raw_title: Oivan’s journey with Ruby on Rails
+  speakers:
+  - Aki Teliö
+  event_name: Ruby Brigade
+  published_at: '2023-06-20'
+  description: |-
+    Oivan has built and scaling one of the largest applications in the ME region. Among this journey, there have been several learnings including restructuring the team, cultural differences and working with microservices application. Now we are scaling up and building larger teams.
+
+    Aki Teliö at the Helsinki Ruby Brigade meet-up on 2023-05-10.
+  video_id: 8s-8E0NhM88
+- title: Ruby ❤️ Rust
+  raw_title: Ruby ❤️ Rust
+  speakers:
+  - Matias Korhonen
+  event_name: Ruby Brigade
+  published_at: '2023-06-20'
+  description: |-
+    A very quick intro to Rust-based gem extensions and an even quicker introduction to Rust itself.
+
+    Matias Korhonen at the Helsinki Ruby Brigade meet-up on 2023-05-10.
+  video_id: O5HCGJIcK68
+- title: Interact with AI effortlessly
+  raw_title: Interact with AI effortlessly
+  speakers:
+  - Lauri Jutila
+  event_name: Ruby Brigade
+  published_at: '2023-06-20'
+  description: |-
+    AI, and especially LLMs, are all the rage right now. Lauri will show you how interacting with AI models can be easy and effortless.
+
+    Lauri Jutila at the Helsinki Ruby Brigade meet-up on 2023-05-10.
+  video_id: oftEvWV0us0
+- title: ''
+  raw_title: Developers’ role in elevating the quality of design
+  speakers:
+  - Simo Virtanen
+  event_name: Ruby Brigade
+  published_at: '2023-09-09'
+  description: Does designing end when designs are handed over to developers? A talk
+    about how developers can help designers be better. By Simo Virtanen at Helsinki
+    Ruby Brigade on 2023-09-06.
+  video_id: GUKSN6ePoj8
+- title: Dependencies – an asset and a curse
+  raw_title: Dependencies – an asset and a curse (Joakim Antman)
+  speakers:
+  - Joakim Antman
+  event_name: Ruby Brigade
+  published_at: '2024-02-26'
+  description: Helsinki Ruby Brigade, 2024-02-21.
+  video_id: gYYBhmSFiCE
+- title: How I’m trying to fix localization, and what you can do to help
+  raw_title: How I’m trying to fix localization, and what you can do to help (Eemeli
+    Aro)
+  speakers:
+  - Eemeli Aro
+  event_name: Ruby Brigade
+  published_at: '2024-02-26'
+  description: |-
+    Like many other problems in coding, localization (the art of making your stuff usable and nice to people from various countries and cultures) can seem really easy, until it’s not. Really simple solutions often get you most of the way to what you need, but then the final few complexities turn out to be Hard. I’ve spent a decade working on making localization easier; let me share with you a couple of the projects I’m currently engaged in, and how you can help make the world a little bit more international.
+
+    Helsinki Ruby Brigade on 2024-02-21.
+  video_id: _nRgzlBSUs8


### PR DESCRIPTION
Adds videos from the [Helsinki Ruby Brigade](https://rubybrigade.fi) meet-ups.

* All the videos are listed in one yaml file as we typically only have one or two talks per event so it doesn't seem to make sense to split them up into separate playlists
* Needs the slug fix from the Helvetic Ruby PR
    * #86 

Let me know if you'd like any changes…