### PR TITLE
Add videos from Ruby Warsaw Community Conference events

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -32,7 +32,7 @@ class Organisation < ApplicationRecord
 
   # enums
   enum :kind, {conference: 0, meetup: 1}
-  enum :frequency, {unknown: 0, yearly: 1, monthly: 2}
+  enum :frequency, {unknown: 0, yearly: 1, monthly: 2, biyearly: 3}
 
   def edition
     "#{name} 2022"

--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -61,3 +61,14 @@
   slug: helsinki-ruby-brigade
   language: english
   youtube_channel_id: UCcoS038f4xA_Lz5AoD0ShzA
+- name: Ruby Warsaw Community Conference
+  website: https://www.rubycommunityconference.com
+  twitter: visualitypl
+  kind: conference
+  frequency: biyearly
+  playlist_matcher: Ruby Warsaw Community Conference
+  default_country_code: PL
+  youtube_channel_name: Visualitypl
+  slug: ruby-warsaw-community-conference
+  language: english
+  youtube_channel_id: UCVlG6qQ1mGnJv185ayWjEzg

--- a/data/ruby-warsaw-community-conference/playlists.yml
+++ b/data/ruby-warsaw-community-conference/playlists.yml
@@ -1,0 +1,30 @@
+---
+- id: PLvMNoWK93wtmlQyKf59wu0IZk9N7ZpWpJ
+  title: Ruby Warsaw Community Conference Summer Edition 2023
+  description: 'The first edition of the Ruby Warsaw Community Conference'
+  published_at: '2023-08-30'
+  channel_id: UCVlG6qQ1mGnJv185ayWjEzg
+  year: 2023
+  videos_count: 4
+  metadata_parser: Youtube::VideoMetadata
+  slug: ruby-warsaw-community-conference-summer-edition-2023
+
+- id: PLvMNoWK93wtnvS4NiaIkvAf_44u5L7T9n
+  title: 'Ruby Warsaw Community Conference Winter Edition 2024'
+  description: The second edition of the Ruby Warsaw Community Conference, which took place on February 2nd, 2024 at the PKiN in Warsaw.
+  published_at: '2024-02-22'
+  channel_id: UCVlG6qQ1mGnJv185ayWjEzg
+  year: 2024
+  videos_count: 4
+  metadata_parser: Youtube::VideoMetadata
+  slug: ruby-warsaw-community-conference-winter-edition-2024
+
+- id: PLvMNoWK93wtnWTpEaJBlEIf5JxrE7rPFY
+  title: 'Ruby Warsaw Community Conference Summer Edition 2024'
+  description: 'The third edition of the Ruby Warsaw Community Conference, which took place on July 19th, 2024 at the PKiN in Warsaw.'
+  published_at: '2024-07-29'
+  channel_id: UCVlG6qQ1mGnJv185ayWjEzg
+  year: '2024'
+  videos_count: 4
+  metadata_parser: Youtube::VideoMetadata
+  slug: ruby-warsaw-community-conference-summer-edition-2024

--- a/data/ruby-warsaw-community-conference/ruby-warsaw-community-conference-summer-edition-2023/videos.yml
+++ b/data/ruby-warsaw-community-conference/ruby-warsaw-community-conference-summer-edition-2023/videos.yml
@@ -1,0 +1,89 @@
+---
+- title: The Transformation of Trailblazer
+  raw_title: "[EN] The Transformation of Trailblazer - Nick Sutterer"
+  speakers:
+    - Nick Sutterer
+  event_name: Ruby Warsaw Community Conference Summer Edition 2023
+  published_at: '2023-08-30'
+  description: "The Transformation of Trailblazer - A ride through the history of
+    the Trailblazer project, through important milestones and releases that formed
+    the functional concepts of the business logic framework over two decades.\n\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram: https://www.instagram.com/visuality.pl/\nFacebook:
+    https://www.facebook.com/visualitypl\nLinkedin: https://www.linkedin.com/company/visualitypl/\nX:
+    https://twitter.com/visualitypl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: B9ibwFBwrjE
+
+- title: Fantastic Databases And Where To Find Them
+  raw_title: "[EN] Fantastic Databases And Where To Find Them - Krzysztof Hasiński"
+  speakers:
+    - Krzysztof Hasiński
+  event_name: Ruby Warsaw Community Conference Summer Edition 2023
+  published_at: '2023-08-30'
+  description: "Fantastic Databases And Where To Find Them\n\nRuby on Rails app tend
+    to rely heavily on databases and yet we rarely talk about them during meetups.
+    This talk explores some of the more unusual parts of working with databases in
+    a context of a typical RoR app.\n\nAuthors: Chris Hasiński\n\nVisuality talks:
+    Y20W[...]\n\nRESOURCES & LINKS: \n____________________________________________\nSQLite
+    appropriate uses: https://www.sqlite.org/whentouse.html\nPostgreSQL manual: https://www.postgresql.org/docs/\nPostgreSQL
+    on using explain: https://www.postgresql.org/docs/current/using-explain.html\nCitus
+    columnar storage: https://docs.citusdata.com/en/v11.1/admin_guide/table_management.html#columnar-storage\n\nOther
+    databases mentioned:\nMySQL, Clickhouse, Cockroach DB.\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram: https://www.instagram.com/visuality.pl/\nFacebook:
+    https://www.facebook.com/visualitypl\nLinkedin: https://www.linkedin.com/company/visualitypl/\nX:
+    https://twitter.com/visualitypl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: 50umESFnRL0
+
+- title: Rails Permanent Job - build a Ruby on Rails server using ServerEngine
+  raw_title: "[EN] Rails Permanent Job - build a Ruby on Rails server using ServerEngine
+    \ - Paweł Strzałkowski"
+  speakers:
+    - Paweł Strzałkowski
+  event_name: Ruby Warsaw Community Conference Summer Edition 2023
+  published_at: '2023-08-30'
+  description: "Video from the first edition of Ruby Warsaw Community Conference with
+    a presentation by Paweł Strzałkowski. The speaker introduces the concept of building
+    multiple process servers using Ruby on Rails framework. The speech describes a
+    helpful tool - Rails Permanent Job gem, which is a wrapper for ServerEngine gem.\n\nAdditional
+    links:\n- Rails Permanent Job gem - https://github.com/pstrzalk/rails_permanent_job\n-
+    ServerEngine gem - https://github.com/treasure-data/serverengine\n- Sneakers gem
+    (using ServerEngine) - https://github.com/jondot/sneakers\n\nPresentation plan:\n[0:23]
+    Beginning of the presentation\n[1:25] Games in Ruby on Rails\n[5:45] Using Cron
+    to perform scheduled actions\n[9:10] Custom rake tasks for handling sub-minute
+    intervals\n[12:20] Continuous read for a data feed\n[12:48] Do not use Sidekiq
+    for scheduling next jobs\n[15:45] Concurrent solutions\n[18:10] Introduction to
+    ServerEngine\n[21:00] ServerEngine code examples\n[23:55] Introduction to Rails
+    Permanent Job\n[25:17] Rails Permanent Job code examples\n[30:16] Ruby on Rails
+    game implementation presentation\n[31:56] Summary\n[33:34] Multiplayer Ruby on
+    Rails game showcase\n[35:08] Q&A\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram: https://www.instagram.com/visuality.pl/\nFacebook:
+    https://www.facebook.com/visualitypl\nLinkedin: https://www.linkedin.com/company/visualitypl/\nX:
+    https://twitter.com/visualitypl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: nRrxWJ4BExQ
+
+- title: ChatGPT for Legacy Ruby Application Refactoring
+  raw_title: "[EN] ChatGPT for Legacy Ruby Application Refactoring - Sergey Sergyenko"
+  speakers:
+    - Sergey Sergyenko
+  event_name: Ruby Warsaw Community Conference Summer Edition 2023
+  published_at: '2023-08-30'
+  description: "ChatGPT for Legacy Ruby Application Refactoring\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram: https://www.instagram.com/visuality.pl/\nFacebook:
+    https://www.facebook.com/visualitypl\nLinkedin: https://www.linkedin.com/company/visualitypl/\nX:
+    https://twitter.com/visualitypl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: zXfQ2QiOLLs

--- a/data/ruby-warsaw-community-conference/ruby-warsaw-community-conference-summer-edition-2024/videos.yml
+++ b/data/ruby-warsaw-community-conference/ruby-warsaw-community-conference-summer-edition-2024/videos.yml
@@ -1,0 +1,96 @@
+---
+- title: Production story and a brighter future with Rails 8
+  raw_title: "[EN] Production story and a brighter future with Rails 8 - Hana Harencarova"
+  speakers:
+    - Hana Harencarova
+  event_name: Ruby Warsaw Community Conference Summer Edition 2024
+  published_at: '2024-07-29'
+  description: "Hana Harencarová's presentation at the Ruby Warsaw Community Conference,
+    which took place on July 19, 2024, in Warsaw.\n\n\nBuilding for web and mobile
+    in 2024: Production story and a brighter future with Rails 8\n\nCurious about
+    how to build apps for web and mobile in 2024? Join me as we delve into a real-world
+    production story of building one. Together, we'll uncover the benefits and challenges
+    of creating a web application with native layers. We'll also discuss push notifications,
+    and app architecture that promotes easy feature releases. Finally, we'll look
+    at the promises of Rails 8 to simplify the development process in the future.\n\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\n\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram:  https://www.instagram.com/visuality.pl/\nFacebook:
+    \ https://www.facebook.com/visualitypl\nLinkedin: https://pl.linkedin.com/company/visualitypl\nX:
+    \ https://x.com/visuality.pl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: TDQ2wtmgeKw
+
+- title: '2000 Engineers, 2 millions lines of code: The history of a Rails monolith'
+  raw_title: "[EN] 2000 Engineers, 2 millions lines of code: The history of a Rails monolith - Cristian Planas"
+  speakers:
+    - Cristian Planas
+  event_name: Ruby Warsaw Community Conference Summer Edition 2024
+  published_at: '2024-07-29'
+  description: "Cristian Planas's presentation at the Ruby Warsaw Community Conference
+    took place on July 19, 2024, in Warsaw.\n\n2000 Engineers, 2 millions lines of
+    code: The history of a Rails monolith \n\nRails is the best framework for building
+    your startup. But what happens when the startup becomes a leading business? How
+    do companies that have Rails at the heart of its stack manage growth? How do you
+    maintain a growing application for 15 years in a constantly changing environment?
+    In this presentation Cristian Planas, Senior Staff Engineers at Zendesk, will
+    share with you his and his collegues' 10 years of experience in a company that
+    has succeeded by keeping Rails in its core. He will guide you through the life
+    of a Rails-centered organization, that scaled from zero to hundreds of millions
+    of users.\n\n____________________________________________\n\n► Looking for a dedicated
+    software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\n\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram:  https://www.instagram.com/visuality.pl/\nFacebook:
+    \ https://www.facebook.com/visualitypl\nLinkedin: https://pl.linkedin.com/company/visualitypl\nX:
+    \ https://x.com/visuality.pl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: CaJvhm1fRWg
+
+- title: 'Avoiding Pitfalls in Active Record: Practical Usage and Best Practices'
+  raw_title: "[EN] Avoiding Pitfalls in Active Record: Practical Usage and Best Practices - Viktor Schmidt"
+  speakers:
+    - Viktor Schmidt
+  event_name: Ruby Warsaw Community Conference Summer Edition 2024
+  published_at: '2024-07-29'
+  description: "Viktor Schmidt's presentation at the Ruby Warsaw Community Conference
+    took place on July 19, 2024, in Warsaw.\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\n\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram:  https://www.instagram.com/visuality.pl/\nFacebook:
+    \ https://www.facebook.com/visualitypl\nLinkedin: https://pl.linkedin.com/company/visualitypl\nX:
+    \ https://x.com/visuality.pl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: RuMJGm6tNKE
+
+- title: Fix Production Bugs Quickly - The Power of Structured Logging in Rails
+  raw_title: "[EN] Fix Production Bugs Quickly - The Power of Structured Logging in
+    Rails - John Gallagher"
+  speakers:
+    - John Gallagher
+  event_name: Ruby Warsaw Community Conference Summer Edition 2024
+  published_at: '2024-07-29'
+  description: "John Gallagher's presentation at the Ruby Warsaw Community Conference
+    took place on July 19, 2024, in Warsaw.\n\n\nFix Production Bugs Quickly - The
+    Power of Structured Logging in Rails\n\nRails apps can be a black box. Have you
+    ever tried to fix a bug where you just can’t understand what’s going on? This
+    talk will give you practical steps to improve the observability of your Rails
+    app, taking the time to understand and fix defects from hours or days to minutes.
+    Rails 8 will bring an exciting new feature: built-in structured logging. This
+    talk will delve into the transformative impact of structured logging on fixing
+    bugs and saving engineers time. Structured logging, as a cornerstone of observability,
+    offers a powerful way to handle logs compared to traditional text-based logs.
+    This session will guide you through the nuances of structured logging in Rails,
+    demonstrating how it can be used to gain better insights into your application’s
+    behavior. This talk will be a practical, technical deep dive into how to make
+    structured logging work with an existing Rails app.\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\n\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram:  https://www.instagram.com/visuality.pl/\nFacebook:
+    \ https://www.facebook.com/visualitypl\nLinkedin: https://pl.linkedin.com/company/visualitypl\nX:
+    \ https://x.com/visuality.pl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: 0ldZ0TcTWt4

--- a/data/ruby-warsaw-community-conference/ruby-warsaw-community-conference-winter-edition-2024/videos.yml
+++ b/data/ruby-warsaw-community-conference/ruby-warsaw-community-conference-winter-edition-2024/videos.yml
@@ -1,0 +1,95 @@
+---
+- title: Renaissance of Ruby on Rails
+  raw_title: "[EN] Renaissance of Ruby on Rails - Steven Baker"
+  speakers:
+    - Steven Baker
+  event_name: Ruby Warsaw Community Conference Winter Edition 2024
+  published_at: '2024-02-22'
+  description: "Renaissance of Ruby on Rails - Ruby on Rails blazed trails in popular
+    web application development with Convention Over Configuration, brought a version
+    of MVC to the masses. All of this in the beautiful, expressive, and enjoyable
+    Ruby programming language.\n\nBut web development moved away. Organisations wanted
+    to split their development teams, and add complexity to the process using micro-services,
+    bifurcating development teams, and complicating deployments with containerisation.
+    Ruby on Rails fell behind the popular curve, and Ruby on Rails entered the Dark
+    Ages.\n\nIn this talk, Steven will explore how the latest release of Ruby on Rails
+    delivers us out of the Dark Ages, and back into the freedom offered by Full-Stack.
+    You will see how, using just what’s built in to Rails, you can deliver highly
+    interactive applications, and take advantage of the benefits of containerised
+    deployments, without complicating your development and deployment workflows.\n\nLet’s
+    celebrate the Renaissance of Ruby on Rails together!\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram: https://www.instagram.com/visuality.pl/\nFacebook:
+    https://www.facebook.com/visualitypl\nLinkedin: https://www.linkedin.com/company/visualitypl/\nX:
+    https://twitter.com/visualitypl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: nrgaeiDlQbI
+
+- title: Zeitwerk Internals
+  raw_title: "[EN] Zeitwerk Internals - Xavier Noria"
+  speakers:
+    - Xavier Noria
+  event_name: Ruby Warsaw Community Conference Winter Edition 2024
+  published_at: '2024-02-22'
+  description: "Zeitwerk Internals - Zeitwerk is the Ruby gem responsible for autoloading
+    code in modern Rails applications. It also works with other web frameworks and
+    with Ruby gems.\n\nAfter attending this talk you’ll have a good understanding
+    of how Zeitwerk works. Going from a conceptual overview of the main ideas, down
+    to implementation details.\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram: https://www.instagram.com/visuality.pl/\nFacebook:
+    https://www.facebook.com/visualitypl\nLinkedin: https://www.linkedin.com/company/visualitypl/\nX:
+    https://twitter.com/visualitypl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: W8ZEOq9LTQU
+
+- title: 'Future- Proofing Ruby Gems: Strategies For Long-Term Maintenance'
+  raw_title: "[EN] Future- Proofing Ruby Gems: Strategies For Long-Term Maintenance
+    - Maciej Mensfeld"
+  speakers:
+    - Maciej Mensfeld
+  event_name: Ruby Warsaw Community Conference Winter Edition 2024
+  published_at: '2024-02-26'
+  description: "Future- Proofing Ruby Gems: Strategies For Long-Term Maintenance \n\nEmbark
+    on an advanced journey with Maciej, where he offers a deep dive into the planning
+    and foresight required when building Ruby OSS gems. This session transcends typical
+    development discussions, focusing on the unique considerations necessary for creating
+    open-source software that stands the test of time. Maciej will share insights
+    from his experience, highlighting the importance of thoughtful decision-making
+    in an environment where a simple fix is not always an option.\n\nAttendees will
+    learn how to avoid common pitfalls that lead to long-term issues, understand the
+    nuances of building non-standard applications, and gain a new perspective on the
+    delicate balance required to create robust, future-proof open-source software.
+    This talk is an invitation to think differently about software development, encouraging
+    a deep commitment to quality and sustainability in the OSS community.\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram: https://www.instagram.com/visuality.pl/\nFacebook:
+    https://www.facebook.com/visualitypl\nLinkedin: https://www.linkedin.com/company/visualitypl/\nX:
+    https://twitter.com/visualitypl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: haJr093oVX0
+
+- title: Implementing Business Archetypes in Rails
+  raw_title: "[EN] Implementing Business Archetypes in Rails - Michał Łęcicki"
+  speakers:
+    - Michał Łęcicki
+  event_name: Ruby Warsaw Community Conference Winter Edition 2024
+  published_at: '2024-02-26'
+  description: "Implementing Business Archetypes in Rails - An introduction into business
+    archetypes patterns: a great pill of knowledge on how to implement universal concepts
+    occurring in business and business software systems. A complex theory explained
+    with various Rails examples and practical recipes.\n____________________________________________\n\n►
+    Looking for a dedicated software development team? Contact us at: \n\nhttps://visuality.page.link/page\n\n►
+    SUBSCRIBE to learn more about software development: \nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\nhttp://bit.ly/SubscribeVisuality\n\n►
+    Read what clients say about us on Clutch.co:\n\nhttps://clutch.co/profile/visuality\n\n►
+    Find us here: \n\nInstagram: https://www.instagram.com/visuality.pl/\nFacebook:
+    https://www.facebook.com/visualitypl\nLinkedin: https://www.linkedin.com/company/visualitypl/\nX:
+    https://twitter.com/visualitypl\nDribble: https://dribbble.com/VISUALITY\nGitHub:
+    https://github.com/visualitypl"
+  video_id: _PLp0JQIuM0


### PR DESCRIPTION
This pull request adds the videos from the Summer 2023, Winter 2024 and the Summer 2024 events.

![CleanShot 2024-08-07 at 00 19 25](https://github.com/user-attachments/assets/c5f37371-a717-4400-8b4e-f8092d86f2b7)
