### PR TITLE
Cleanup data for RailsConf 2017 and 2018

### DIFF
--- a/data/railsconf/railsconf-2017/videos.yml
+++ b/data/railsconf/railsconf-2017/videos.yml
@@ -1,5 +1,5 @@
 ---
-- title: ": The Art & Craft of Secrets: Using the Cryptographic Toolbox"
+- title: "The Art & Craft of Secrets: Using the Cryptographic Toolbox"
   raw_title: 'RailsConf 2017: The Art & Craft of Secrets: Using the Cryptographic
     Toolbox by Michael  Swieton'
   speakers:
@@ -16,7 +16,7 @@
 
     Picking an encryption algorithm is like choosing a lock for your door. Some are better than others - but there's more to keeping burglars out of your house (or web site) than just the door lock. This talk will review what the crypto tools are and how they fit together with our frameworks to provide trust and privacy for our applications. We'll look under the hood of websites like Facebook, at game-changing exploits like Firesheep, and at how tools from our application layer (Rails,) our protocol layer (HTTP,) and our transport layer (TLS) combine build user-visible features like single sign-on.
   video_id: 6KAYq9vw_pY
-- title: ": Why Software Engineers Disagree About Everything"
+- title: "Why Software Engineers Disagree About Everything"
   raw_title: 'RailsConf 2017: Why Software Engineers Disagree About Everything by
     Haseeb Qureshi'
   speakers:
@@ -33,7 +33,7 @@
 
     Why are there are so many disagreements in software? Why don’t we all converge on the same beliefs or technologies? It might sound obvious that people shouldn't agree, but I want to convince you it’s weird that we don't. This talk will be a philosophical exploration of how knowledge converges within subcultures, as I explore this question through the worlds of software, online fraud, and poker.
   video_id: x07q6V4VXC8
-- title: 'RailsConf 2017: Opening Keynote by David Heinemeier Hansson'
+- title: 'Opening Keynote'
   raw_title: 'RailsConf 2017: Opening Keynote by David Heinemeier Hansson'
   speakers:
   - David Heinemeier Hansson
@@ -46,7 +46,7 @@
   published_at: '2017-05-05'
   description: 'RailsConf 2017: Opening Keynote by David Heinemeier Hansson'
   video_id: Cx6aGMC6MjU
-- title: ": Building Rails ActionDispatch::SystemTestCase Framework"
+- title: "Building Rails ActionDispatch::SystemTestCase Framework"
   raw_title: 'RailsConf 2017: Building Rails ActionDispatch::SystemTestCase Framework
     by Eileen Uchitelle'
   speakers:
@@ -63,7 +63,7 @@
 
     At the 2014 RailsConf DHH declared system testing would be added to Rails. Three years later, Rails 5.1 makes good on that promise by introducing a new testing framework: ActionDispatch::SystemTestCase. The feature brings system testing to Rails with zero application configuration by adding Capybara integration. After a demonstration of the new framework, we'll walk through what's uniquely involved with building OSS features & how the architecture follows the Rails Doctrine. We'll take a rare look at what it takes to build a major feature for Rails, including goals, design decisions, & roadblocks.
   video_id: sSn4B8orX70
-- title: ": Perusing the Rails Source Code - A Beginners Guide"
+- title: "Perusing the Rails Source Code - A Beginners Guide"
   raw_title: 'RailsConf 2017: Perusing the Rails Source Code - A Beginners Guide by
     Alex Kitchens'
   speakers:
@@ -80,7 +80,7 @@
 
     Open source projects like Rails are intimidating, especially as a beginner. It’s hard to look at the code and know what it does. But Ruby on Rails is more than just code. Written into it are years of research, discussions, and motivations. Also written into it are bugs, typos, and all of the pieces that make the code human. This talk outlines steps you can take to explore the inner workings of Rails and gain context on its design. Understanding how Rails works will allow you to write better Rails applications and better Ruby code. You will leave with many resources and tips on perusing Rails.
   video_id: Q_MpGRfnY5s
-- title: ": Teaching RSpec to Play nice with Rails"
+- title: "Teaching RSpec to Play nice with Rails"
   raw_title: 'RailsConf 2017: Teaching RSpec to Play nice with Rails by Sam Phippen'
   speakers:
   - Sam Phippen
@@ -98,7 +98,7 @@
 
     If you're looking to level up your testing, understand RSpec's internals a little better, or improve your Rails knowledge, this talk will have something for you. Some knowledge of RSpec's test types will be assumed.
   video_id: jyPfrK1y1nc
-- title: ": Uncertain Times: Securing Rails Apps and User Data"
+- title: "Uncertain Times: Securing Rails Apps and User Data"
   raw_title: 'RailsConf 2017: Uncertain Times: Securing Rails Apps and User Data by
     Krista Nelson'
   speakers:
@@ -117,7 +117,7 @@
 
     Security is a moving target and a full team effort, so whether you are a beginner or senior level Rails developer, this talk will cover important measures and resources to make sure your Rails app is best secured.
   video_id: rSuya_TFYso
-- title: ": Warning: May Be Habit Forming"
+- title: "Warning: May Be Habit Forming"
   raw_title: 'RailsConf 2017: Warning: May Be Habit Forming by Nickolas Means'
   speakers:
   - Nickolas Means
@@ -135,7 +135,7 @@
 
     Let’s talk about how to build goals the right way so that you’ll be all but guaranteed to hit them. We’ll work through the process of creating systems and nurturing habits to turn your brain into your biggest ally, no matter what you want to accomplish!
   video_id: xT_YaduPYlk
-- title: 'RailsConf 2017: Keynote by Justin Searls'
+- title: 'Keynote'
   raw_title: 'RailsConf 2017: Keynote by Justin Searls'
   speakers:
   - Justin Searls
@@ -148,7 +148,7 @@
   published_at: '2017-05-09'
   description: 'RailsConf 2017: Keynote by Justin Searls'
   video_id: V4fnzHxHXMI
-- title: ": Rough to Fine: Programming Lessons from Woodworking"
+- title: "Rough to Fine: Programming Lessons from Woodworking"
   raw_title: 'RailsConf 2017: Rough to Fine: Programming Lessons from Woodworking
     by Mark Simoneau'
   speakers:
@@ -165,7 +165,7 @@
 
     Woodworking has experienced quite a renaissance as of late, and a very popular style involves using power tools for rough work and hand tools for detail and precision work. Using both defines each woodworker's speed and ability to produce beautiful/functional pieces. The same can be true of developers. Automation, convention, powerful IDEs, generators and libraries can make each developer go from nothing to something very quickly, but what about diving deeper to get the precision, performance and beauty you need out of your applications? Come find out.
   video_id: 962UBsaLjtw
-- title: ": Upgrading a big application to Rails 5"
+- title: "Upgrading a big application to Rails 5"
   raw_title: 'RailsConf 2017: Upgrading a big application to Rails 5 by Rafael França'
   speakers:
   - Rafael França
@@ -181,7 +181,7 @@
 
     In this talk we would take a look in different strategies to upgrade Rails application to the newest version taking as example a huge monolithic Rails application. We will learn what were the biggest challenges and how they could be avoided. We will also learn why the changes were made in Rails and how they work.
   video_id: I-2Xy3RS1ns
-- title: ": The Arcane Art of Error Handling"
+- title: "The Arcane Art of Error Handling"
   raw_title: 'RailsConf 2017: The Arcane Art of Error Handling by Brad Urani'
   speakers:
   - Brad Urani
@@ -197,7 +197,7 @@
 
     With complexity comes errors, and unexpected errors lead to unexpected unhappiness. Join us and learn how to add contextual data to errors, design error hierarchies, take charge of control flow, create re-usable error handlers, and integrate with error reporting solutions. We'll talk about recoverable versus irrecoverable errors and discuss how and how not to use exceptions. From internationalization to background jobs, we'll cover the gamut. Regardless of your Rail proficiency, you'll learn why expecting the unexpected makes for happier developers, happier businesses and happier users.
   video_id: 9R4wlyWBP1k
-- title: ": Lightning Talks"
+- title: "Lightning Talks"
   raw_title: 'RailsConf 2017: Lightning Talks by Various Speakers'
   speakers:
   - Various Speakers
@@ -215,7 +215,7 @@
     \n43:44 Michael Hartl\n50:09 Ariel Caplan\n55:08 Alex Wood\n05:50 Jingyi Chen
     \n01:03:12 Lew Parker"
   video_id: KGi9wRHWvB0
-- title: ": An Optimistic Proposal for Making Horrible Code... Bearable"
+- title: "An Optimistic Proposal for Making Horrible Code... Bearable"
   raw_title: 'RailsConf 2017: An Optimistic Proposal for Making Horrible Code... Bearable
     by Joe Mastey'
   speakers:
@@ -236,7 +236,7 @@
 
     In the thousand mile journey, here are the first steps.
   video_id: hFuzIWz6Ynk
-- title: ": Built to last: A domain-driven approach to beautiful systems"
+- title: "Built to last: A domain-driven approach to beautiful systems"
   raw_title: 'RailsConf 2017: Built to last: A domain-driven approach to beautiful
     systems by Andrew Hao'
   speakers:
@@ -255,7 +255,7 @@
 
     Today, we'll move beyond prescriptive recipes and learn how to run a Context Mapping exercise. This strategic design tool helps you discover domain-specific system boundaries, leading to highly-cohesive and loosely-coupled outcomes. With code samples from real production code, we'll look at a domain-oriented approach to organizing code in a Rails codebase, applying incremental refactoring steps to build stable, lasting systems!
   video_id: 52qChRS4M0Y
-- title: ": Architecture: The Next Generation"
+- title: "Architecture: The Next Generation"
   raw_title: 'RailsConf 2017: Architecture: The Next Generation by Taylor Jones'
   speakers:
   - Taylor Jones
@@ -271,7 +271,7 @@
 
     As our applications grow, we start thinking of better ways to organize and scale our growing codebases. We've recently seen Microservices start to emerge as a prominent response to Monoliths, but is it all really worth it? What about our other options? We often romanticize leaving our current architecture situation because we believe it will cure what ails us. However, architecture certainly has no silver bullet . Beam up with me as we explore the past, present, and future of reconsidering architecture.
   video_id: lEVsTVp7UtQ
-- title: ": Breaking Bad - What Happens When You Defy Conventions?"
+- title: "Breaking Bad - What Happens When You Defy Conventions?"
   raw_title: 'RailsConf 2017: Breaking Bad - What Happens When You Defy Conventions?
     by Christoph Gockel'
   speakers:
@@ -290,7 +290,7 @@
 
     Come along to find out what happens when you don't want to have an app directory anymore. We will see what is needed in order to fight parts of the Rails convention and if it's worth it.
   video_id: gLHaa5oeyLc
-- title: ": Managing Unmanageable Complexity"
+- title: "Managing Unmanageable Complexity"
   raw_title: 'RailsConf 2017: Managing Unmanageable Complexity by Patrick Joyce'
   speakers:
   - Patrick Joyce
@@ -310,7 +310,7 @@
 
     In this session, we’ll see how surgeons, pilots, and builders have developed techniques to safely manage increasingly complex systems in life and death situations. We will learn how simple checklists improve communication, reduce preventable errors, and drive faster recovery time.
   video_id: yVgrNtz7KpA
-- title: 'RailsConf 2017: Keynote by Aaron Patterson'
+- title: 'Keynote'
   raw_title: 'RailsConf 2017: Keynote by Aaron Patterson'
   speakers:
   - Aaron Patterson
@@ -323,7 +323,7 @@
   published_at: '2017-05-10'
   description: 'RailsConf 2017: Keynote by Aaron Patterson'
   video_id: GnCJO8Ax1qg
-- title: ": Bebop to the Top - The Jazz Band As A Guide To Leadership"
+- title: "Bebop to the Top - The Jazz Band As A Guide To Leadership"
   raw_title: 'RailsConf 2017: Bebop to the Top - The Jazz Band As A Guide To Leadership
     by Michael Cain'
   speakers:
@@ -344,7 +344,7 @@
 
     Inspired by Max Dupree's Leadership Jazz, this talk will show you how to apply the principles of improvisation to your company/team and make your workplace more efficient, effective and fun!
   video_id: R0AY4ILjJQo
-- title: ": The Good Bad Bug: Learning to Embrace Mistakes"
+- title: "The Good Bad Bug: Learning to Embrace Mistakes"
   raw_title: 'RailsConf 2017: The Good Bad Bug: Learning to Embrace Mistakes by Jess
     Rudder'
   speakers:
@@ -364,7 +364,7 @@
 - title: ''
   raw_title: 'RailsConf 2017: Panel: Developer Happiness through Getting Involved'
   speakers:
-  - ": Panel: Developer Happiness through Getting Involved"
+  - "Panel: Developer Happiness through Getting Involved"
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/GOSla2Nl0Es/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/GOSla2Nl0Es/mqdefault.jpg
@@ -377,7 +377,7 @@
 
     We have amazing skills and abilities, but for a lot of us the missing piece is finding a way to give back. We have an amazing panel of people who have used their skills and talents from both previous careers and current to make the world a better place. Learn how they got involved, and in turn what you can do to get involved in areas you’re passionate about to fill this missing piece that will keep you happy throughout your career.
   video_id: GOSla2Nl0Es
-- title: ": Understanding ‘Spoon Theory’ and Preventing Burnout"
+- title: "Understanding ‘Spoon Theory’ and Preventing Burnout"
   raw_title: 'RailsConf 2017: Understanding ‘Spoon Theory’ and Preventing Burnout
     by Jameson Hampton'
   speakers:
@@ -394,7 +394,7 @@
 
     Spoon theory is a metaphor about the finite energy we each have to do things in a day. While a healthy, advantaged person may not have to worry about running out of ‘spoons,’ people with chronic illnesses or disabilities and members of marginalized communities often have to consider how they must ration their energy in order to get through the day. Understanding how 'spoons' can affect the lives of your developers and teammates can help companies lessen the everyday burdens on their underrepresented employees, leaving them more spoons to do their best work, avoid burnout and lead fulfilling lives.
   video_id: rPtUR4kDXeY
-- title: ": To Code Is Human"
+- title: "To Code Is Human"
   raw_title: 'RailsConf 2017: To Code Is Human by Don Werve'
   speakers:
   - Don Werve
@@ -412,11 +412,13 @@
 
     In this talk, we will combine the art of programming with the science of cognitive psychology, and emerge with a deeper understanding of how to leverage the limits of the human mind to sustainably craft software that is less buggy, easier to understand, and more adaptive in the face of change.
   video_id: yc8rYrBABTQ
-- title: ''
+- title: 'Panel: Better Hiring Practices for Fun and Profit'
   raw_title: 'RailsConf 2017: Panel: Better Hiring Practices for Fun and Profit'
   speakers:
-  - ": Panel: Better Hiring Practices for Fun"
-  - Profit
+    - Cecy Correa
+    - Pamela O. Vickers
+    - Heather Corallo
+    - Justin Herrick
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/nv94h-1n3FY/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/nv94h-1n3FY/mqdefault.jpg
@@ -429,7 +431,7 @@
 
     The average American worker will have 10 jobs before the age of 40. There's a great deal of opportunity and mobility in our industry, and yet, our hiring process is anything but pleasant or streamlined. The hiring process is time consuming for both candidates and employers, but we can do better! Let's explore the ways we can improve the hiring process by writing better job descriptions, utilizing systems that free us from unconscious biases, focusing beyond culture fit, and using better (more fun) technical interviewing methods.
   video_id: nv94h-1n3FY
-- title: ": We've Always Been Here: Women Changemakers in Tech"
+- title: "We've Always Been Here: Women Changemakers in Tech"
   raw_title: 'RailsConf 2017: We''ve Always Been Here: Women Changemakers in Tech
     by Hilary Stohs-Krause'
   speakers:
@@ -452,7 +454,7 @@
 
     From Radia Perlman to Sophie Wilson to Erica Baker, let's explore both tech’s forgotten heroes and its modern-day pioneers, and help end the silent erasure of women in technology.
   video_id: T3ojRN4CT7I
-- title: ": Leading When You're Not in Charge"
+- title: "Leading When You're Not in Charge"
   raw_title: 'RailsConf 2017: Leading When You''re Not in Charge by Scott Lesser'
   speakers:
   - Scott Lesser
@@ -468,10 +470,13 @@
 
     Just because you don't have lead / senior / manager / owner in your title, doesn't mean there isn't plenty of opportunity to lead. No matter where you are in your career, come discover how to communicate more effectively, embrace self-awareness, and influence those leading you. Don't wait for a title to tell you to lead. Take responsibility where you are, and let the titles come to you.
   video_id: m-WDmNoQmkg
-- title: ''
+- title: 'Panel: Becoming an engineering leader'
   raw_title: 'RailsConf 2017: Panel: Becoming an engineering leader'
   speakers:
-  - ": Panel: Becoming an engineering leader"
+    - Shay Howe
+    - Rebecca Miller-Webster
+    - Neha Batra
+    - Abel Martin
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/3wzCTUdaiwg/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/3wzCTUdaiwg/mqdefault.jpg
@@ -488,10 +493,13 @@
 
     Let talk with a group of folks at various stages of the leadership hierarchy about what they have and want to learn.
   video_id: 3wzCTUdaiwg
-- title: ''
+- title: "Panel: Ruby's Killer Feature: The Community"
   raw_title: 'RailsConf 2017: Panel: Ruby''s Killer Feature: The Community'
   speakers:
-  - ": Panel: Ruby's Killer Feature: The Community"
+    - Christopher Sexton
+    - Sean Marcia
+    - Latoya Allen
+    - Zuri Hunter
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/6w_cSs9weWw/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/6w_cSs9weWw/mqdefault.jpg
@@ -506,7 +514,7 @@
 
     The community around Ruby is really what sets it apart, and the cornerstone of it is the small local meetups. Come learn how to get involved, help out, or step up and start a local group of your own. We will discuss how to develop and nurture the group. Share our experiences in expanding a small group to larger events like unconferences or workshops. Find out how community leaders can help everyone build a solid network, assist newbies in kick-starting their career, and most importantly ensure that everyone feels welcome and safe.
   video_id: 6w_cSs9weWw
-- title: ": Processing Streaming Data at a Large Scale with Kafka"
+- title: "Processing Streaming Data at a Large Scale with Kafka"
   raw_title: 'RailsConf 2017: Processing Streaming Data at a Large Scale with Kafka
     by Thijs Cadier'
   speakers:
@@ -525,7 +533,7 @@
 
     In this talk we'll see how we can leverage Kafka to build and painlessly scale an analytics pipeline. We'll talk about Kafka's unique properties that make this possible, and we'll go through a full demo application step by step. At the end of the talk you'll have a good idea of when and how to get started with Kafka yourself.
   video_id: "-NMDqqW1uCE"
-- title: ": High Performance Political Revolutions"
+- title: "High Performance Political Revolutions"
   raw_title: 'RailsConf 2017: High Performance Political Revolutions by Braulio Carreno'
   speakers:
   - Braulio Carreno
@@ -547,10 +555,14 @@
 
     This presentation is about the lessons we learned building a high performance fundraising platform in Rails.
   video_id: fMcSPXMt0o0
-- title: ''
+- title: 'Panel: Performance... performance'
   raw_title: 'RailsConf 2017: Panel: Performance... performance'
   speakers:
-  - ": Panel: Performance... performance"
+    - Sam Saffron
+    - Richard Schneeman
+    - Eileen Uchitelle
+    - Nate Berkopec
+    - Rafael França
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/SMxlblLe_Io/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/SMxlblLe_Io/mqdefault.jpg
@@ -565,7 +577,7 @@
 
     In this panel the panelists will discuss their favorite performance related tools and guidelines. Expect to learn about changes in Ruby 2.4 and beyond that may help make your applications snappy and lean.
   video_id: SMxlblLe_Io
-- title: ": It's Dangerous to go Alone: Building Teams like an Organizer"
+- title: "It's Dangerous to go Alone: Building Teams like an Organizer"
   raw_title: 'RailsConf 2017: It''s Dangerous to go Alone: Building Teams like an
     Organizer by Colin Fleming'
   speakers:
@@ -582,7 +594,7 @@
 
     Leading an open source or community project means dealing with people challenges in addition to technical challenges -- how do we take a scattering of interested people and build a team with them? Turns out, we can adapt a bunch of practices we already use! Using a collaboration between a nonprofit and a civic group as a case study, we'll talk about ways to apply best practices from community organizers to our work. In particular, we'll talk about similarities between contemporary organizing and agile models, ways to build relationships with other team members, and making our work more sustainable.
   video_id: T3gEORIjKQo
-- title: ": Supporting Mental Health as an Effective Leader"
+- title: "Supporting Mental Health as an Effective Leader"
   raw_title: 'RailsConf 2017: Supporting Mental Health as an Effective Leader by Jesse
     James'
   speakers:
@@ -599,7 +611,7 @@
 
     As the stigma of speaking out about mental health conditions declines, leaders in the programming community are are being given many new opportunities to support their teams. In this session you will learn about the issues some of your team may face both in dealing with their own potential mental health difficulties and that of other team members. We will go over ways to support both the individual and team, how to advocate for team members with mental health conditions, and resources for further information and outreach for you and your team.
   video_id: UR-J7O5ZJ4Q
-- title: ": Inventing Friends: ActionCable + AVS = 3"
+- title: "Inventing Friends: ActionCable + AVS = 3"
   raw_title: 'RailsConf 2017: Inventing Friends: ActionCable + AVS = 3 by Jonan  Scheffler
     & Julian Cheal'
   speakers:
@@ -621,7 +633,7 @@
 
     Using the power of ActionCable we will explore how its possible to create an MMMOC: massively multiplayer online chatroom, that you can use TODAY to see your; Travis Build status, or deploy code to your favourite PAAS, let you know when the latest release of Rails is out. Using nothing but your voice and ActionCable.
   video_id: 7sqYy8G0Hrg
-- title: 'RailsConf 2017: Keynote by Marco Rogers'
+- title: 'Keynote'
   raw_title: 'RailsConf 2017: Keynote by Marco Rogers'
   speakers:
   - Marco Rogers
@@ -634,7 +646,7 @@
   published_at: '2017-05-16'
   description: 'RailsConf 2017: Keynote by Marco Rogers'
   video_id: g6fBRwi6cqc
-- title: ": Bayes is BAE"
+- title: "Bayes is BAE"
   raw_title: 'RailsConf 2017: Bayes is BAE by Richard Schneeman'
   speakers:
   - Richard Schneeman
@@ -650,7 +662,7 @@
 
     Before programming, before formal probability there was Bayes. He introduced the notion that multiple uncertain estimates which are related could be combined to form a more certain estimate. It turns out that this extremely simple idea has a profound impact on how we write programs and how we can think about life. The applications range from machine learning and robotics to determining cancer treatments. In this talk we'll take an in depth look at Bayses rule and how it can be applied to solve problems in programming and beyond.
   video_id: bQSzZrDDV80
-- title: ": Is it Food? An Introduction to Machine Learning"
+- title: "Is it Food? An Introduction to Machine Learning"
   raw_title: 'RailsConf 2017: Is it Food? An Introduction to Machine Learning by Matthew
     Mongeau'
   speakers:
@@ -667,7 +679,7 @@
 
     Machine Learning is no longer just an academic study. Tools like Tensorflow have opened new doorways in the world of application development. Learn about the current tools available and how easy it is to integrate them into your rails application. We'll start by looking at a real-world example currently being used in the wild and then delve into creating a sample application that utilizes machine learning.
   video_id: 8G709hKkthY
-- title: ": Accessibility (when you don't have time to read the manual)"
+- title: "Accessibility (when you don't have time to read the manual)"
   raw_title: 'RailsConf 2017: Accessibility (when you don''t have time to read the
     manual) by Katie Walsh'
   speakers:
@@ -690,7 +702,7 @@
 
     In this session, we will demystify the WCAG 2.0 basics. We’ll use Chrome Accessibility Dev Tools to discover and fix common issues. You will leave with a set of free and easy-to-use resources to start improving the accessibility of your application today.
   video_id: 5PTCbwzhwug
-- title: ": Goldilocks And The Three Code Reviews"
+- title: "Goldilocks And The Three Code Reviews"
   raw_title: 'RailsConf 2017: Goldilocks And The Three Code Reviews by Vaidehi Joshi'
   speakers:
   - Vaidehi Joshi
@@ -708,7 +720,7 @@
 
     We've probably all heard that peer code reviews can do wonders to a codebase. But not all type of code reviews are effective. Some of them seem to go on and on forever, while others pick at syntax and formatting but miss bugs. This talk explores what makes a strong code review and what makes a painful one. Join Goldilocks as she seeks to find a code review process that's neither too long nor too short, but just right!
   video_id: "-6EzycFNwzY"
-- title: ": Predicting Titanic Survivors with Machine Learning"
+- title: "Predicting Titanic Survivors with Machine Learning"
   raw_title: 'RailsConf 2017: Predicting Titanic Survivors with Machine Learning by
     Ju Liu'
   speakers:
@@ -725,7 +737,7 @@
 
     What's a better way to understand machine learning than a practical example? And who hasn't watched the 1997 classic with Jack and Rose? In this talk we will first take a look at some real historical data of the event. Then we will use amazing Python libraries to live code several of the most well known algorithms. This will help us understand some fundamental concepts of how machine learning works. When we're done, you should have a good mental framework to make sense of it in the modern world.
   video_id: 4l-aB_Sk41Y
-- title: ": Whose turn is it anyway? Augmented reality board games."
+- title: "Whose turn is it anyway? Augmented reality board games."
   raw_title: 'RailsConf 2017: Whose turn is it anyway? Augmented reality board games.
     by Dave Tapley'
   speakers:
@@ -742,7 +754,7 @@
 
     Board games are great, but who has time to keep track of what's going on when you just want to have fun? In the spirit of over-engineering we'll look at PitchCar -- probably one of the simplest games in the world -- and see how far we can go with web tech, image processing, and a bunch of math. Expect to see plenty of code, some surprising problems and solutions, and of course: A live demo.
   video_id: 01CFyu3SuIo
-- title: ": 5 Years of Rails Scaling to 80k RPS"
+- title: "5 Years of Rails Scaling to 80k RPS"
   raw_title: 'RailsConf 2017: 5 Years of Rails Scaling to 80k RPS by Simon Eskildsen'
   speakers:
   - Simon Eskildsen
@@ -758,7 +770,7 @@
 
     Shopify has taken Rails through some of the world's largest sales: Superbowl, Celebrity Launches, and Black Friday. In this talk, we will go through the evolution of the Shopify infrastructure: from re-architecting and caching in 2012, sharding in 2013, and reducing the blast radius of every point of failure in 2014. To 2016, where we accomplished running our 325,000+ stores out of multiple datacenters. It'll be whirlwind tour of the lessons learned scaling one of the world's largest Rails deployments for half a decade.
   video_id: 4dWJahMi5NI
-- title: 'RailsConf 2017: Keynote: Gen Z and the Future of Technology by Pamela Pavliscak'
+- title: 'Keynote: Gen Z and the Future of Technology'
   raw_title: 'RailsConf 2017: Keynote: Gen Z and the Future of Technology by Pamela
     Pavliscak'
   speakers:
@@ -773,7 +785,7 @@
   description: 'RailsConf 2017: Keynote: Gen Z and the Future of Technology by Pamela
     Pavliscak'
   video_id: iN1nOTQgmCY
-- title: ": Syntax Isn't Everything: NLP for Rubyists"
+- title: "Syntax Isn't Everything: NLP for Rubyists"
   raw_title: 'RailsConf 2017: Syntax Isn''t Everything: NLP for Rubyists by Aja Hammerly'
   speakers:
   - Aja Hammerly
@@ -789,7 +801,7 @@
 
     Natural Language Processing is an interesting field of computing. The way humans use language is nuanced and deeply context sensitive. For example, the word work can be both a noun and a verb. This talk will give an introduction to the field of NLP using Ruby. There will be demonstrations of how computers fail and succeed at human language. You'll leave the presentation with an understanding of both the challenges and the possibilities of NLP and some tools for getting started with it.
   video_id: Mmn20irnaS8
-- title: ": How to Write Better Code Using Mutation Testing"
+- title: "How to Write Better Code Using Mutation Testing"
   raw_title: 'RailsConf 2017: How to Write Better Code Using Mutation Testing by John
     Backus'
   speakers:
@@ -812,7 +824,7 @@
     Learn about features in Ruby and your dependencies that you didn’t previously know about
     This talk assumes a basic knowledge of Ruby and testing. The examples in this talk will almost certainly teach you something new about Ruby!
   video_id: uB7m9T7ymn8
-- title: ": A Clear-Eyed Look at Distributed Teams"
+- title: "A Clear-Eyed Look at Distributed Teams"
   raw_title: 'RailsConf 2017: A Clear-Eyed Look at Distributed Teams by Glenn Vanderburg
     & Maria Gutierrez'
   speakers:
@@ -832,7 +844,7 @@
 
     In this talk, we will look at the challenges and rewards of working in a distributed team setting based on several years of experience growing large distributed engineering teams.
   video_id: h8MLXbdOyNs
-- title: ": Distributed & Local: Getting the Best of Both Worlds"
+- title: "Distributed & Local: Getting the Best of Both Worlds"
   raw_title: 'RailsConf 2017: Distributed & Local: Getting the Best of Both Worlds
     by Ben Klang'
   speakers:
@@ -849,7 +861,7 @@
 
     Our company is traditional in many ways, one of which being the need to come into the office each day. Our team of software developers bucks that trend, spreading across 6 states and 4 countries. Dev teams consider themselves "Remote First", while DevOps and Application Support are "Local First." Each has adopted tools, habits, and practices to maximize their configuration. Each style has learned valuable lessons from the other. This presentation is about how our teams have evolved: the tools, the compromises, the wins and losses, and how we successfully blend Distributed and Concentrated teams.
   video_id: BdH8znxkNjI
-- title: ": The Effective Remote Developer"
+- title: "The Effective Remote Developer"
   raw_title: 'RailsConf 2017: The Effective Remote Developer by David Copeland'
   speakers:
   - David Copeland
@@ -867,7 +879,7 @@
 
     We'll learn what you can do to be your best self as a remote team member, as well as what you need from your environment, team, and company. It's not about technical stuff—it's the human stuff. We'll learn how can you be present and effective when you aren't physically there.
   video_id: zW7_AteiM4o
-- title: ": Distributed Tracing: From Theory to Practice"
+- title: "Distributed Tracing: From Theory to Practice"
   raw_title: 'RailsConf 2017: Distributed Tracing: From Theory to Practice by Stella
     Cotton'
   speakers:
@@ -884,7 +896,7 @@
 
     Application performance monitoring is great for debugging inside a single app. However, as a system expands into multiple services, how can you understand the health of the system as a whole? Distributed tracing can help! You’ll learn the theory behind how distributed tracing works. But we’ll also dive into other practical considerations you won’t get from a README, like choosing libraries for Ruby apps and polyglot systems, infrastructure considerations, and security.
   video_id: "-7i02Faw_KU"
-- title: ": Sorting Rubyists"
+- title: "Sorting Rubyists"
   raw_title: 'RailsConf 2017: Sorting Rubyists by Caleb Thompson'
   speakers:
   - Caleb Thompson
@@ -900,7 +912,7 @@
 
     Let's take a peek under the hood of the magical "sort" method, learning algorithms... by sorting audience members wearing numbers! Intimidated by the word "algorithm? Not sure what performance means? Confused by "Big O Notation"? Haven't even heard of best-, worst-, and average-case time complexities? No problem: we'll learn together! You can expect to come out knowing new things and with Benny Hill stuck in your head.
   video_id: KWoEt64UG_A
-- title: ": Tricks and treats for new developers"
+- title: "Tricks and treats for new developers"
   raw_title: 'RailsConf 2017: Tricks and treats for new developers by David Padilla'
   speakers:
   - David Padilla
@@ -920,7 +932,7 @@
 
     If you are about to join this fantastic community, this talk is for you.
   video_id: BZbW8FAvf00
-- title: ": Rack ‘em, Stack ‘em Web Apps"
+- title: "Rack ‘em, Stack ‘em Web Apps"
   raw_title: 'RailsConf 2017: Rack ‘em, Stack ‘em Web Apps by Jason Clark'
   speakers:
   - Jason Clark
@@ -940,7 +952,7 @@
 
     If you’ve heard of Rack but wondered where it fits in the Ruby web stack, here’s your chance!
   video_id: 3PnUV9QzB0g
-- title: ": Practical Debugging"
+- title: "Practical Debugging"
   raw_title: 'RailsConf 2017: Practical Debugging by Kevin Deisz'
   speakers:
   - Kevin Deisz
@@ -958,7 +970,7 @@
 
     In this talk you will learn practical techniques to make debugging easier. You will see how simple techniques from the ruby standard library can greatly increase your ability to keep your codebase clean and bug-free.
   video_id: oi4h30chCz8
-- title: ": In Relentless Pursuit of REST"
+- title: "In Relentless Pursuit of REST"
   raw_title: 'RailsConf 2017: In Relentless Pursuit of REST by Derek Prior'
   speakers:
   - Derek Prior
@@ -976,7 +988,7 @@
 
     RESTful architecture can narrow the responsibilities of your Rails controllers and make follow-on refactorings more natural. In this talk, you'll learn to refactor code to follow RESTful principles and to identify the positive impact those changes have throughout your application stack.
   video_id: HctYHe-YjnE
-- title: ": What’s my App *Really* Doing in Production?"
+- title: "What’s my App *Really* Doing in Production?"
   raw_title: 'RailsConf 2017: What’s my App *Really* Doing in Production? by Daniel
     Azuma'
   speakers:
@@ -993,7 +1005,7 @@
 
     When your Rails app begins serving public traffic, your users will make it behave in mysterious ways and find code paths you never knew existed. Understanding, measuring, and troubleshooting its behavior in production is a tough but crucial part of running a successful Rails app. In this talk, you’ll learn how to instrument, debug, and profile your app, using the capabilities of the Rails framework and the Ruby VM. You'll also study techniques for safely instrumenting a live running system, keeping latency to a minimum and avoiding side effects.
   video_id: 92CoJhv3tPU
-- title: ": Beyond Validates_Presence_of: Ensuring Eventual Consistency"
+- title: "Beyond validates_presence_of: Ensuring Eventual Consistency"
   raw_title: 'RailsConf 2017: Beyond Validates_Presence_of: Ensuring Eventual Consistency
     by Amy Unger'
   speakers:
@@ -1014,7 +1026,7 @@
 
     In this talk, I’ll introduce some data consistency issues you may see in your app when you begin introducing background jobs and external services. You’ll learn some patterns for handling failure so your data never gets out of sync and we’ll talk about strategies to detect when something is wrong.
   video_id: QpbQpwXhrSI
-- title: ": The Secret Life of SQL: How to Optimize Database Performance"
+- title: "The Secret Life of SQL: How to Optimize Database Performance"
   raw_title: 'RailsConf 2017: The Secret Life of SQL: How to Optimize Database Performance
     by Bryana Knight'
   speakers:
@@ -1031,7 +1043,7 @@
 
     There are a lot of database index and query best practices that sometimes aren't best practices at all. Need all users created this year? No problem! Slap an index over created_at! What about this year's active OR pending users, sorted by username? Are we still covered index-wise? Is the query as fast with 20 million users? Common rules of thumb for indexing and query crafting aren’t black and white. We'll discuss how to track down these exceptional cases and walk through some real examples. You'll leave so well equipped to improve performance, you won't be able to optimize fast enough!
   video_id: BuDWWadCqIw
-- title: ": Reporting on Rails - ActiveRecord and ROLAP Working Together"
+- title: "Reporting on Rails - ActiveRecord and ROLAP Working Together"
   raw_title: 'RailsConf 2017: Reporting on Rails - ActiveRecord and ROLAP Working
     Together by Tony Drake'
   speakers:
@@ -1050,7 +1062,7 @@
 
     Let's go on a journey through the world of Relational Online Analytical Processing (ROLAP) and see how this can apply to Rails. We'll also look at database considerations and finish with looking at a light DSL that works with ActiveRecord to help make your data dance.
   video_id: MczzCfTQGfU
-- title: ": Do Your Views Know Too Much?"
+- title: "Do Your Views Know Too Much?"
   raw_title: 'RailsConf 2017: Do Your Views Know Too Much? by Jason Charnes'
   speakers:
   - Jason Charnes
@@ -1066,7 +1078,7 @@
 
     The logical place to put view-related logic is... inside your view, right? "A little logic here... a little logic there..." but all of a sudden we hardly recognize our views. A quick glance through our code and we can't tell our Ruby apart from our HTML. Don't worry; this is a fun opportunity for some refactoring! Come see several approaches you can start using today to clean up your views.
   video_id: 9Hq9kL9pXuI
-- title: ": Portable Sessions with JSON Web Tokens"
+- title: "Portable Sessions with JSON Web Tokens"
   raw_title: 'RailsConf 2017: Portable Sessions with JSON Web Tokens by Lance Ivy'
   speakers:
   - Lance Ivy
@@ -1082,7 +1094,7 @@
 
     Ever wonder why applications use sessions and APIs use tokens? Must there really be a difference? JSON Web Tokens are an emerging standard for portable secure messages. We'll talk briefly about how they're built and how they earn your trust, then dig into some practical examples you can take back and apply to your own majestic monolith or serious services.
   video_id: s7G2VnuMVEw
-- title: ": Observing Chance: A Gold Master Test in Practice"
+- title: "Observing Chance: A Gold Master Test in Practice"
   raw_title: 'RailsConf 2017: Observing Chance: A Gold Master Test in Practice by
     Jake Worth'
   speakers:
@@ -1103,7 +1115,7 @@
 
     Testers of every experience level will leave this talk with a new technique for evaluating complex environments, and a broader conception of what a test can be.
   video_id: D9awDBUQvr4
-- title: ": What Comes After SOLID? Seeking Holistic Software Quality"
+- title: "What Comes After SOLID? Seeking Holistic Software Quality"
   raw_title: 'RailsConf 2017: What Comes After SOLID? Seeking Holistic Software Quality
     by Ariel Caplan'
   speakers:
@@ -1126,7 +1138,7 @@
 
     We'll set meaningful goals for well-rounded, high-quality software that solves important problems for real people.
   video_id: 5wYcD1nfnWw
-- title: ": Developer Happiness on the Front End with Elm"
+- title: "Developer Happiness on the Front End with Elm"
   raw_title: 'RailsConf 2017: Developer Happiness on the Front End with Elm by Kevin
     Yank'
   speakers:
@@ -1143,7 +1155,7 @@
 
     Ruby and Rails famously prioritised developer happiness, and took the world by storm. Elm, a new language that compiles to JavaScript, proves that putting developer happiness first can produce very different results on the front end! Born out of Haskell, Elm is as unlike Ruby as programming languages get, but in this session we’ll see how its particular blend of design decisions tackles everything that’s painful about front-end development, making it an excellent choice for the curious Rubyist’s next favorite language.
   video_id: C2npla7DwVk
-- title: ": Rails to Phoenix: How Elixir can level-you-up in Rails"
+- title: "Rails to Phoenix: How Elixir can level-you-up in Rails"
   raw_title: 'RailsConf 2017: Rails to Phoenix: How Elixir can level-you-up in Rails
     by Christian Koch'
   speakers:
@@ -1160,7 +1172,7 @@
 
     Elixir has rapidly developed into a mature language with an ever-growing library of packages that excels at running web apps. And because both Elixir and Phoenix were developed by Ruby / Rails programmers, the ease with which you can learn Elixir as a Ruby developer, is much greater than many other languages. With numerous code examples, this talk will discuss how learning a functional approach to handling web requests can improve what we do every day with Rails. This talk is aimed at people who have some familiarity with Rails but no experience with Elixir is necessary.
   video_id: fjrD0_OempI
-- title: ": React on Rails"
+- title: "React on Rails"
   raw_title: 'RailsConf 2017: React on Rails by Jo Cranford'
   speakers:
   - Jo Cranford
@@ -1180,7 +1192,7 @@
 
     Come along to this talk to hear how we migrated our app a piece at a time to use technologies that don’t always sit naturally alongside Rails. I will cover technical implementations and lessons learned.
   video_id: GW9qgIYfzEI
-- title: ": React Native & Rails, A Single Codebase for Web & Mobile"
+- title: "React Native & Rails, A Single Codebase for Web & Mobile"
   raw_title: 'RailsConf 2017: React Native & Rails, A Single Codebase for Web & Mobile
     by Ben Dixon'
   speakers:
@@ -1197,7 +1209,7 @@
 
     Rails made building CRUD apps efficient and fun. React Native, for the first time, does this for mobile Apps. Learn how to create a single React codebase for Android, iOS and Mobile Web, backed by a common Rails API.
   video_id: Q66tYU6ni48
-- title: ": A Survey of Surprisingly Difficult Things"
+- title: "A Survey of Surprisingly Difficult Things"
   raw_title: 'RailsConf 2017: A Survey of Surprisingly Difficult Things by Alex Boster'
   speakers:
   - Alex Boster
@@ -1213,7 +1225,7 @@
 
     Many seemingly simple "real-world" things end up being much more complicated than anticipated, especially if it's a developer's first time dealing with that particular thing. Classic examples include money and currency, time, addresses, human names, and so on. We will survey a number of these common areas and the state of best practices, or lack thereof, for handling them in Rails.
   video_id: aUk9981C-fQ
-- title: ": Implementing the Web Speech API for Voice Data Entry"
+- title: "Implementing the Web Speech API for Voice Data Entry"
   raw_title: 'RailsConf 2017: Implementing the Web Speech API for Voice Data Entry
     by Cameron Jacoby'
   speakers:
@@ -1232,7 +1244,7 @@
 
     In this talk, I’ll show you how to implement the Web Speech API in a few simple steps. I’ll also walk through a case study of using the API in a production Rails app. You’ll leave with an understanding of how to implement voice dictation on the web as well as criteria to evaluate if voice is a viable solution to a given problem.
   video_id: e5dR05QGzXA
-- title: ": Exploring the History of a 12-year-old Rails Application"
+- title: "Exploring the History of a 12-year-old Rails Application"
   raw_title: 'RailsConf 2017: Exploring the History of a 12-year-old Rails Application
     by Nathan Walls'
   speakers:
@@ -1253,7 +1265,7 @@
 
     We'll explore history through code and learn from some of the developers involved in the application over its lifecycle to build an understanding of where the application is now and how it became what it is.
   video_id: oh3OZ7GYuK0
-- title: ": Decouple Your Models with Form Objects"
+- title: "Decouple Your Models with Form Objects"
   raw_title: 'RailsConf 2017: Decouple Your Models with Form Objects by Andrew Markle'
   speakers:
   - Andrew Markle
@@ -1273,7 +1285,7 @@
     a deep dive on decoupling models and how you can leverage Trailblazer's Reform
     gem to make it even easier.
   video_id: d9vMENoqxEE
-- title: ": Rails 5.1: Awesome Features and Breaking Changes"
+- title: "Rails 5.1: Awesome Features and Breaking Changes"
   raw_title: 'RailsConf 2017: Rails 5.1: Awesome Features and Breaking Changes by
     Claudio B'
   speakers:
@@ -1294,7 +1306,7 @@
 
     In this talk, I will cover the improvements brought by Rails 5.1, explain the Core team’s motivations behind each feature, and illustrate the upgrade process to smoothly transition gems and apps from Rails 5.0 to Rails 5.1.
   video_id: 9CWjFtCbrrM
-- title: ": Tailoring Mentorship: Achieving the Best Fit"
+- title: "Tailoring Mentorship: Achieving the Best Fit"
   raw_title: 'RailsConf 2017: Tailoring Mentorship: Achieving the Best Fit by Jonathan
     Wallace'
   speakers:
@@ -1311,7 +1323,7 @@
 
     Are you a Rails expert? To someone just learning Rails, yes, you are. And you can mentor the next generation of experts.  What new skills will you develop by mentoring? And how does one find a mentee or mentor? In this talk, you'll learn how to establish effective, quality mentoring relationships where both parties grow their skills—and their career.  Mentoring accelerates your personal and career growth. Come learn how much you'll grow by sharing your knowledge and experience using practices like inquiry based learning, differentiated learning, and active listening.
   video_id: a9RiUIfIdx8
-- title: ": Your App Server Config is Wrong"
+- title: "Your App Server Config is Wrong"
   raw_title: 'RailsConf 2017: Your App Server Config is Wrong by Nate Berkopec'
   speakers:
   - Nate Berkopec
@@ -1331,7 +1343,7 @@
 
     You’ll be surprised by how much value you can deliver to your users by changing a few simple configuration settings.
   video_id: itbExaPqNAE
-- title: ": ​Recurring Background Jobs with Sidekiq-scheduler"
+- title: "​Recurring Background Jobs with Sidekiq-scheduler"
   raw_title: 'RailsConf 2017: ​Recurring Background Jobs with Sidekiq-scheduler by
     Andreas Fast & Gianfranco Zas'
   speakers:
@@ -1351,7 +1363,7 @@
 
     In this talk, we'll cover how sidekiq-scheduler does its job, different use cases, challenges when running on distributed environments, its future, how we distribute capacity over open source initiatives, and as a bonus, how to write your own Sidekiq extensions.
   video_id: OU4jFXoVjZo
-- title: ": Outside the (Web) Box: Using Ruby for Other Protocols"
+- title: "Outside the (Web) Box: Using Ruby for Other Protocols"
   raw_title: 'RailsConf 2017: Outside the (Web) Box: Using Ruby for Other Protocols
     by Danielle Adams'
   speakers:
@@ -1368,7 +1380,7 @@
 
     Ruby on Rails is a widely used web framework, using HTTP to serve users web pages and store data to databases. But what about serving different types of clients? Is it possible to integrate Rails with other protocol types to talk to other machines? Is it efficient? How would it work? I'm going to share my team's approach integrating a Ruby on Rails application with automation and warehouse hardware, such as barcode scanners and Zebra printers.
   video_id: 3tfMzhxYK2M
-- title: ": A Deep Dive Into Sessions"
+- title: "A Deep Dive Into Sessions"
   raw_title: 'RailsConf 2017: A Deep Dive Into Sessions by Justin Weiss'
   speakers:
   - Justin Weiss
@@ -1386,7 +1398,7 @@
 
     But sessions can be a little magical. What is a session? How does Rails know to show the right data to the right person? And how do you decide where you keep your session data?
   video_id: mqUbnZIY3OQ
-- title: ": Data Corruption: Stop the Evil Tribbles"
+- title: "Data Corruption: Stop the Evil Tribbles"
   raw_title: 'RailsConf 2017: Data Corruption: Stop the Evil Tribbles by Betsy Haibel'
   speakers:
   - Betsy Haibel
@@ -1402,7 +1414,7 @@
 
     Ever had a production bug that you fixed by changing production data? Ever felt like a bad developer for it? Don't. Bad data has countless causes: Weird user input. Race conditions under load. Heck, even changing business needs. We can't fully prevent data corruption, so what matters is how we recover. In this talk, you'll learn how to prevent and fix bad data at every level of your system. You'll learn UX techniques for incremental, mistake-reducing input. You'll learn how to future-proof validations. And you'll learn auditing techniques to catch bad data -- before your users do.
   video_id: kA8aR1ffoOg
-- title: ": ​Rails APIs: The Next Generation"
+- title: "​Rails APIs: The Next Generation"
   raw_title: 'RailsConf 2017:  ​Rails APIs: The Next Generation by Derek Carter'
   speakers:
   - Derek Carter
@@ -1420,7 +1432,7 @@
 
     Building a consistent API for a large and long-running monolithic API on a tool-segmented engineering team can sometimes feel like herding cats. REST, serializers, and Swagger: Oh my! Learn what worked (and didn’t!) as we go behind the scenes building Procore’s first open API.
   video_id: iTbTz8_ztIM
-- title: ": Deep Dive into Docker Containers for Rails Developers"
+- title: "Deep Dive into Docker Containers for Rails Developers"
   raw_title: 'RailsConf 2017: Deep Dive into Docker Containers for Rails Developers
     by Christopher Rigor'
   speakers:
@@ -1439,7 +1451,7 @@
     Docker containers but are unsure how they work, this talk is for you.\n\nYou’ll
     also learn how to run Rails in production-ready container environments like Kubernetes."
   video_id: 2c4fvXKec7Q
-- title: ": ​Introducing Helix: High-Performance Ruby Made Easy"
+- title: "​Introducing Helix: High-Performance Ruby Made Easy"
   raw_title: 'RailsConf 2017: ​Introducing Helix: High-Performance Ruby Made Easy
     by Godfrey Chan and Yehuda Katz'
   speakers:
@@ -1463,7 +1475,7 @@
 
     (This is not a re-run of Godfrey's talk from last year.)
   video_id: lBapt5YDDvg
-- title: ": Open Sourcing: Real Talk"
+- title: "Open Sourcing: Real Talk"
   raw_title: 'RailsConf 2017: Open Sourcing: Real Talk by Andrew Evans'
   speakers:
   - Andrew Evans
@@ -1481,7 +1493,7 @@
 
     Hired open-sources some useful abstractions from our Majestic Monolith® and we've learned a lot. Some tough lessons, and some cool knowledge. We'll cover: When & where should you pull something out of the code? Does it really help? What things are important to think about? What if it never takes off? We'll also look at some design patterns from our open-source work.
   video_id: aOyaYmUTzZI
-- title: ": Google Cloud Love Ruby"
+- title: "Google Cloud Love Ruby"
   raw_title: 'RailsConf 2017: Google Cloud Love Ruby by Remi Taylor'
   speakers:
   - Remi Taylor
@@ -1499,7 +1511,7 @@
 
     Ruby developers welcome! Our dedicated Google Cloud Platform Ruby team has built a great experience for Ruby developers using GCP. In this session, we'll walk through the steps to deploy, debug and scale a Ruby on Rails application on Google App Engine. You'll also learn about some of the exciting Ruby libraries available today for adding features to your app with GCP services like BigQuery and Cloud Vision API.
   video_id: MgJlwg2BrgY
-- title: ": ​Postgres at Any Scale​"
+- title: "​Postgres at Any Scale​"
   raw_title: 'RailsConf 2017: ​Postgres at Any Scale​ by Will Leinweber'
   speakers:
   - Will Leinweber
@@ -1519,7 +1531,7 @@
 
     First you'll learn how to take advantage of all PG has to offer for small scales, especially when it comes to keeping data consistent. Next you'll learn techniques for keeping apps running well at medium scales. And finally you'll learn how to take advantage of the open-source Citus extension that makes PG a distributed db, when your app joins the big leagues.
   video_id: _wU2dglywAU
-- title: ": Cultivating a Culture of Continuous Learning"
+- title: "Cultivating a Culture of Continuous Learning"
   raw_title: 'RailsConf 2017: Cultivating a Culture of Continuous Learning by Dave
     Ott and Dennis Eusebio'
   speakers:
@@ -1539,7 +1551,7 @@
 
     Tuft & Needle is a bootstrapped, Phoenix-based company that pioneered the disruption of a the mattress industry using a software startup’s mindset when it was founded in 2012 and has grown to over $100 million in annual revenue. A commitment to skill acquisition has led to a happier and more productive team, and is a core to the company’s success. In this session, learn how to cultivate a culture of continuous learning and skill acquisition through apprenticeships and group learning sessions.
   video_id: awTIU0K6nb4
-- title: ": ​Keeping Code Style Sanity in a 10-year-old Codebase"
+- title: "​Keeping Code Style Sanity in a 10-year-old Codebase"
   raw_title: 'RailsConf 2017: ​Keeping Code Style Sanity in a 10-year-old Codebase
     by Gabi Stefanini'
   speakers:

--- a/data/railsconf/railsconf-2018/videos.yml
+++ b/data/railsconf/railsconf-2018/videos.yml
@@ -1,5 +1,5 @@
 ---
-- title: ": The GraphQL Way: A new path for JSON APIs"
+- title: "The GraphQL Way: A new path for JSON APIs"
   raw_title: 'RailsConf 2018: The GraphQL Way: A new path for JSON APIs by Nick Quaranto'
   speakers:
   - Nick Quaranto
@@ -15,7 +15,7 @@
 
     Have you written JSON APIs in Rails a few times? Even if you’re escaped implementing a “render: :json” call, some day soon you’ll need to get JSON data out to a native client or your front-end framework. Your Rails apps might change, but the pitfalls for JSON APIs stay the same: They’re hard to discover, difficult to change from the client side, and documenting them is a pain. For your next app, or your current one, let’s consider GraphQL. I'll show you how to implement it in your app and offer real-world advice from making it work in an existing Rails app.
   video_id: QHoddukdqf0
-- title: ": Candy on Rails: Polymorphism & Rails 5"
+- title: "Candy on Rails: Polymorphism & Rails 5"
   raw_title: 'RailsConf 2018: Candy on Rails: Polymorphism & Rails 5 by Michael Cain'
   speakers:
   - Michael Cain
@@ -31,7 +31,7 @@
 
     Polymorphism is a mainstay of the Ruby on Rails stack, affording us a lean, concise way of relating objects in a dynamic way. Using a candy shop application, this presentation will pragmatically explain and demonstrate polymorphism and its benefits/usefulness in Rails.
   video_id: CD_ye_9lvEM
-- title: ": Why We Never Get to Web Accessibility 102"
+- title: "Why We Never Get to Web Accessibility 102"
   raw_title: 'RailsConf 2018: Why We Never Get to Web Accessibility 102 by Liz Certa'
   speakers:
   - Liz Certa
@@ -47,7 +47,7 @@
 
     Creating truly 100% accessible websites often requires specialized knowledge of the ins and outs of screen reader settings, browser defaults and HTML quirks, yet most of us still need to google how to turn on a screen reader. We attend "Web Accessibility 101" seminars and workshops over and over but very few of us end up with the kind of specialized knowledge necessary to make truly accessible websites. In this talk, we'll discuss why this is, and how we can eventually get to accessibility 102.
   video_id: gE8S4cUJFUo
-- title: ": Dropping Into B-Trees"
+- title: "Dropping Into B-Trees"
   raw_title: 'RailsConf 2018: Dropping Into B-Trees by David McDonald'
   speakers:
   - David McDonald
@@ -63,7 +63,7 @@
 
     Understanding indexes is key to demystifying database performance, and will have huge impact on one's ability to plan, contribute, and troubleshoot as one progresses in their career. Having said all that: many engineers still don’t really know what indexes ARE. Most simply know what indexes can DO. This presentation takes a look at the most commonly used index for any RDBMS: the B-tree. We will pull apart the data structure, discuss how it works, and briefly touch on some of the algorithms they use. With this baseline established, we will revisit a few common assumptions about indexes.
   video_id: 17XecHy9Pzg
-- title: ": Continuous Deployments and Data Sovereignty: A Case Study"
+- title: "Continuous Deployments and Data Sovereignty: A Case Study"
   raw_title: 'RailsConf 2018: Continuous Deployments and Data Sovereignty: A Case
     Study by Mike Calhoun'
   speakers:
@@ -80,7 +80,7 @@
 
     In any production rails application’s simplest form, there is one version of the app deployed to a single host or cloud provider of your choice, but what if there were laws and regulations in place that required your application to be replicated and maintained within the geographical boundaries of other countries. This is a requirement of countries that have data sovereignty laws and a regular hurdle to overcome when dealing with sensitive data such as protected health information. This talk provides a case study of how we devised an automatic deployment strategy to deploy to multiple countries.
   video_id: K27AZ-_PH0A
-- title: ": The Doctor Is In: Using checkups to find bugs in production"
+- title: "The Doctor Is In: Using checkups to find bugs in production"
   raw_title: 'RailsConf 2018: The Doctor Is In: Using checkups to find bugs in production
     by Ryan Laughlin'
   speakers:
@@ -112,7 +112,7 @@
   published_at: '2018-05-15'
   description: 'RailsConf 2018: Opening Keynote: FIXME by David Heinemeier Hansson'
   video_id: zKyv-IGvgGE
-- title: ": Devly, a multi-service development environment"
+- title: "Devly, a multi-service development environment"
   raw_title: 'RailsConf 2018: Devly, a multi-service development environment by Eric
     Hodel & Ezekiel Templin'
   speakers:
@@ -135,7 +135,7 @@
 
     We learned that the design of our tools must be guided by how teams work and communicate. To respond to these needs, Devly allows self-service, control, and safety so that developers can focus on their work.
   video_id: Zfv30fSpHBI
-- title: ": Operating Rails in Kubernetes"
+- title: "Operating Rails in Kubernetes"
   raw_title: 'RailsConf 2018: Operating Rails in Kubernetes by Kir Shatrov'
   speakers:
   - Kir Shatrov
@@ -153,7 +153,7 @@
 
     This presentation is about the lessons we learned while migrating hundreds of Rails apps within the organization to Kubernetes.
   video_id: KKtS0QD5ERM
-- title: ": Turbo Boosting Real-world Applications"
+- title: "Turbo Boosting Real-world Applications"
   raw_title: 'RailsConf 2018: Turbo Boosting Real-world Applications by Akira Matsuda'
   speakers:
   - Akira Matsuda
@@ -175,7 +175,7 @@
     Finding slow parts inside Rails, and significantly improving them
     Fixing existing slow libraries, or crafting ultimately performant alternatives
   video_id: y-wqo6LiqMo
-- title: ": Access Denied: the missing guide to authorization in Rails"
+- title: "Access Denied: the missing guide to authorization in Rails"
   raw_title: 'RailsConf 2018: Access Denied: the missing guide to authorization in
     Rails by Vladimir Dementyev'
   speakers:
@@ -192,7 +192,7 @@
 
     Rails brings us a lot of useful tools out-of-the-box, but there are missing parts too. For example, for such essential tasks as authorization we are on our own. Even if we choose a trending OSS solution, we still have to care about the way to keep our code maintainable, efficient, and, of course, bug-less. Working on Rails projects, I've noticed some common patterns in designing access systems as well as useful code techniques I'd like to share with you in this talk.
   video_id: NVwx0DARDis
-- title: ": Booleans are Easy - True or False?"
+- title: "Booleans are Easy - True or False?"
   raw_title: 'RailsConf 2018: Booleans are Easy - True or False? by Craig Buchek'
   speakers:
   - Craig Buchek
@@ -210,7 +210,7 @@
 
     We'll cover several anti-patterns in the use of booleans. We'll discuss why they're problematic, and explore some better alternatives.
   video_id: PkXTIfVN-3E
-- title: ": Automating Empathy: Test Your Docs with Swagger and Apivore"
+- title: "Automating Empathy: Test Your Docs with Swagger and Apivore"
   raw_title: 'RailsConf 2018: Automating Empathy: Test Your Docs with Swagger and
     Apivore by Ariel Caplan'
   speakers:
@@ -233,7 +233,7 @@
 
     With Swagger and Apivore as our weapons of choice, we'll write documentation that will make your APIs better, your clients more satisfied, and you happier.
   video_id: lqPZdvg49GU
-- title: ": Testing in Production"
+- title: "Testing in Production"
   raw_title: 'RailsConf 2018: Testing in Production by Aja Hammerly'
   speakers:
   - Aja Hammerly
@@ -249,7 +249,7 @@
 
     Test All the F***ing Time is one of the values of the Ruby community. But how many of us test in production in addition to running our test suites as part of CI? This talk will discuss a variety of approaches to testing in prod including canaries, blue-green deployment, beta and A/B tests, and general functional tests. I'll share a few times these techniques have found bugs before our users did and how you can use them today with your Rails Application.
   video_id: BZeylB8XCxg
-- title: ": Who Destroyed Three Mile Island?"
+- title: "Who Destroyed Three Mile Island?"
   raw_title: 'RailsConf 2018: Who Destroyed Three Mile Island? by Nickolas Means'
   speakers:
   - Nickolas Means
@@ -267,7 +267,7 @@
 
     Let’s let the incredibly complex failure at Three Mile Island teach us how to dig into our own incidents. We'll learn how the ideas behind just culture can help us learn from our mistakes and build stronger teams.
   video_id: YBRiffheLXE
-- title: ": Debugging Rails Itself"
+- title: "Debugging Rails Itself"
   raw_title: 'RailsConf 2018: Debugging Rails Itself by Sean Griffin'
   speakers:
   - Sean Griffin
@@ -285,7 +285,7 @@
 
     In this talk, we'll look at the process that goes into fixing a bug in Rails itself. You'll learn about every step from the initial report to when the fix is eventually committed. You'll learn how to navigate Rails' internals, and how to find the source of the problem -- even if you've never committed to Rails.
   video_id: IKOLEKxMRa0
-- title: ": Down The Rabbit Hole: An Adventure in Legacy Code"
+- title: "Down The Rabbit Hole: An Adventure in Legacy Code"
   raw_title: 'RailsConf 2018: Down The Rabbit Hole: An Adventure in Legacy Code by
     Loren Crawford'
   speakers:
@@ -302,7 +302,7 @@
 
     Legacy code is unpredictable and difficult to understand. Most of us will work with legacy code, so it’s important for us to understand its major pain points and their underlying causes. You’ ll come away from this talk with practical strategies to help you understand, improve, and even love legacy code.
   video_id: Dm2LdXLFrxw
-- title: ": The Life and Death of a Rails App"
+- title: "The Life and Death of a Rails App"
   raw_title: 'RailsConf 2018: The Life and Death of a Rails App by Olivier Lacan'
   speakers:
   - Olivier Lacan
@@ -318,7 +318,7 @@
 
     Now that it has become a mature web development framework, Rails is no longer the exclusive realm of burgeoning startups. Healthy small and large businesses have grown with Rails for years. Shrinking and dying companies too. In this talk we'll look at how Rails and its ecosystem of libraries and services can support both newborn and aging apps, and when it struggles to do so.
   video_id: zrR181LhOv4
-- title: ": Webpacking for the Journey Ahead"
+- title: "Webpacking for the Journey Ahead"
   raw_title: 'RailsConf 2018: Webpacking for the Journey Ahead by Taylor Jones'
   speakers:
   - Taylor Jones
@@ -334,7 +334,7 @@
 
     Webpack integration landed in Rails 5.1 to a bit of excitement and confusion. On one hand, folks who had been using Javascript frameworks like Angular and React now have a clearer way to tie in their client-side application into the asset pipeline. Yet, why would we want to do this? What’s the purpose of adding Webpack to Rails, and what’s the advantage of utilizing it? How does this affect javascript frameworks that aren’t Webpack friendly? In this talk, we’ll explore these ideas as well as the future of client side integrations into Rails.
   video_id: NeZ9aAH1Lp4
-- title: ": Stating the Obvious"
+- title: "Stating the Obvious"
   raw_title: 'RailsConf 2018: Stating the Obvious by Ernie Miller'
   speakers:
   - Ernie Miller
@@ -365,7 +365,7 @@
   published_at: '2018-05-16'
   description: 'RailsConf 2018: Keynote: Rails Doesn''t Scale by Mark Imbriaco'
   video_id: G2MdBtXonew
-- title: ": Using Databases to pull your applications weight"
+- title: "Using Databases to pull your applications weight"
   raw_title: 'RailsConf 2018: Using Databases to pull your applications weight by
     Harisankar P S'
   speakers:
@@ -382,7 +382,7 @@
 
     Most Rails applications out there in the world deal with the manipulation and presentation of data. So the speed of our application is proportional to how fast we can work with data. Rails is good with presenting data. And our Database is the one who is good at processing data. But we sometimes make the mistake of just using the database as a file cabinet, and using ruby to process. The database is built for crunching data and returning to us the results that we need. This talk is about how to optimize your database so as to speed up your existing Rails application.
   video_id: 3hYlghzakow
-- title: ": The Intelligence of Instinct"
+- title: "The Intelligence of Instinct"
   raw_title: 'RailsConf 2018: The Intelligence of Instinct by Emily Freeman'
   speakers:
   - Emily Freeman
@@ -402,7 +402,7 @@
 
     But sometimes fear isn’t life or death. Often, it’s code smell. It’s a bad feeling before a deploy. This talk will explore fear, instinct and denial. We’ll focus on our two brains — what Daniel Kahneman describes as System 1 and System 2. And we’ll look at how we can start to view “feelings” as pre-incident indicators.
   video_id: l0JtgRiaS4M
-- title: ": Don't Settle for Poor Names (or for Poor Design)"
+- title: "Don't Settle for Poor Names (or for Poor Design)"
   raw_title: 'RailsConf 2018: Don''t Settle for Poor Names (or for Poor Design) by
     Alistair McKinnell'
   speakers:
@@ -425,7 +425,7 @@
 
     By the end of this talk, you will have learned a process to get you started with improving names and improving design—a process simple enough for you to teach others.
   video_id: j5o-lUF_nJs
-- title: ": How We Made Our App So Fast it Went Viral in Japan"
+- title: "How We Made Our App So Fast it Went Viral in Japan"
   raw_title: 'RailsConf 2018: How We Made Our App So Fast it Went Viral in Japan by
     Ben Halpern'
   speakers:
@@ -442,7 +442,7 @@
 
     We put a lot of effort into web speed for our website dev.to. One day in November we woke to our greatest traffic day ever, and the source was Japanese Dev-Twitter catching wind of just how fast a site could be. American websites don't typically give so much care to global performance, but it pays off if you do. In this talk I will describe how we think about performance.
   video_id: Afy7H04X9Us
-- title: ": Keeping Moms Around for the Long Term"
+- title: "Keeping Moms Around for the Long Term"
   raw_title: 'RailsConf 2018: Keeping Moms Around for the Long Term by Tess Griffin'
   speakers:
   - Tess Griffin
@@ -460,7 +460,7 @@
 
     In this talk you'll hear stories from women in the programming community, struggles they have gone through, and why many of them left their jobs after or during maternity leave (including me). If you want to help your mom friends stick around and feel included, or if you are from a company who wants to support the growth of your mom employees, then this talk is for you.
   video_id: tX1SuRZ6zpk
-- title: ": Empathy through Acting"
+- title: "Empathy through Acting"
   raw_title: 'RailsConf 2018: Empathy through Acting by Roy Tomeij'
   speakers:
   - Roy Tomeij
@@ -478,7 +478,7 @@
 
     Let's talk about the fascinating acting techniques of Stanislavski, Strasberg, Adler & Meisner, and learn how you too can employ the Method to better understand (and work with) the people in your life.
   video_id: tZFeIk1-zOw
-- title: ": Lessons in Ethical Development I Learned From Star Wars"
+- title: "Lessons in Ethical Development I Learned From Star Wars"
   raw_title: 'RailsConf 2018: Lessons in Ethical Development I Learned From Star Wars
     by Jameson Hampton'
   speakers:
@@ -495,7 +495,7 @@
 
     Star Wars fans may have been excited about 2016’s release of Rogue One because of the courageous new rebel characters it introduced, but it also provided a lot more insight into the Empire's Corp of Engineers and how they ended up building the Death Star. As developers, we have a responsibility to think about the ethical implications of our work and how it might be used. This session will discuss ways of deciding for yourself what kinds of projects you are or aren't comfortable working and tips for self-accountability in your career - through the lens of characters we know and love from Star Wars.
   video_id: XcgJeeCpK4s
-- title: ": Blitzbuilding product with Rails - a crypto journey"
+- title: "Blitzbuilding product with Rails - a crypto journey"
   raw_title: 'RailsConf 2018: Blitzbuilding product with Rails - a crypto journey
     by YiTing "Xdite" Cheng'
   speakers:
@@ -516,7 +516,7 @@
 
     This is a sponsored talk by OTCBTC.
   video_id: onX_0ngn3G4
-- title: ": Encrypted Credentials on Rails 5.2: Secrets to Success"
+- title: "Encrypted Credentials on Rails 5.2: Secrets to Success"
   raw_title: 'RailsConf 2018: Encrypted Credentials on Rails 5.2: Secrets to Success
     by Christopher Rigor'
   speakers:
@@ -537,7 +537,7 @@
 
     This is a sponsored talk by Engine Yard.
   video_id: fS92ZDfLhng
-- title: ": Scaling the Software Artisan"
+- title: "Scaling the Software Artisan"
   raw_title: 'RailsConf 2018: Scaling the Software Artisan by Coraline Ada Ehmke'
   speakers:
   - Coraline Ada Ehmke
@@ -553,7 +553,7 @@
 
     In the late 1700s the discovery of the principle of interchangeable parts shifted the demand for the expertise of artisans from production to design and invention. This shift transformed Western civilization and opened the way for the industrial revolution. We face a similar opportunity now as one generation of software developers reaches its professional peak and a new wave of developers enter the field. This talk will trace the historical evolution of the artisan and explore how understanding this history can help us to maximize and multiply the impact of senior software developers.
   video_id: tHxssXfymOE
-- title: ": All Onboard: Cruising on the Mentorship"
+- title: "All Onboard: Cruising on the Mentorship"
   raw_title: 'RailsConf 2018: All Onboard: Cruising on the Mentorship by Gretchen
     Ziegler'
   speakers:
@@ -572,7 +572,7 @@
 
     Using their story as a guide, this talk will explore practical ways of structuring mentoring and onboarding processes. Whether your next hires are newbies or seasoned pros, you’ll walk away with strategies to help them code confidently.
   video_id: S7cYJumzuL4
-- title: ": Pairing: a guide to fruitful collaboration \U0001F353\U0001F351\U0001F350"
+- title: "Pairing: a guide to fruitful collaboration \U0001F353\U0001F351\U0001F350"
   raw_title: "RailsConf 2018: Pairing: a guide to fruitful collaboration \U0001F353\U0001F351\U0001F350
     by André Arko"
   speakers:
@@ -592,7 +592,7 @@
     speed of new features.) Pairing is a fantastic tool for your professional toolbox:
     let’s design, refine, and refactor, together."
   video_id: km7uGUEd4fk
-- title: ": Mechanically Confident"
+- title: "Mechanically Confident"
   raw_title: 'RailsConf 2018: Mechanically Confident by Adam Cuppy'
   speakers:
   - Adam Cuppy
@@ -612,7 +612,7 @@
 
     This talk will help you recognize and design habits, routines, and practices that embed confidence into the body.
   video_id: 6xnealmhEnM
-- title: ": The Practical Guide to Building an Apprenticeship"
+- title: "The Practical Guide to Building an Apprenticeship"
   raw_title: 'RailsConf 2018: The Practical Guide to Building an Apprenticeship by
     Max Tiu'
   speakers:
@@ -631,7 +631,7 @@
 
     In this talk, you'll learn from the mistakes I've made and wins I've had in creating an apprenticeship. From pitching the idea to growing your apprentices, you'll gain a step-by-step guide to successfully building your own apprenticeship program.
   video_id: 5sVg7DtZ0zk
-- title: ": So You’ve Got Yourself a Kafka: Event-Powered Rails Services"
+- title: "So You’ve Got Yourself a Kafka: Event-Powered Rails Services"
   raw_title: 'RailsConf 2018: So You’ve Got Yourself a Kafka: Event-Powered Rails
     Services by Stella Cotton'
   speakers:
@@ -648,7 +648,7 @@
 
     It’s easier than ever to integrate a distributed commit log system like Kafka into your stack. But once you have it, what do you do with it? Come learn the basics about Kafka and event-driven systems and how you can use them to power your Rails services. We’ll also venture beyond the theoretical to talk about practical considerations and unusual operational challenges that your event-driven Rails services might face, like monitoring, queue processing, and scaling slow consumers.
   video_id: Rzl4O1oaVy8
-- title: ": Some Funny Things Happened on The Way to A Service Ecosystem"
+- title: "Some Funny Things Happened on The Way to A Service Ecosystem"
   raw_title: 'RailsConf 2018: Some Funny Things Happened on The Way to A Service Ecosystem
     by Chris Hoffman'
   speakers:
@@ -665,7 +665,7 @@
 
     So this one time we ran Rails services over AMQP (instead of HTTP). You may be thinking “Why? Was that their first mistake?” It was not. From handling shared models poorly to deploying & operating services with inadequate tooling, we've made...so many mistakes. I'm glad we did; they helped us grow. We have patterns & practices for everything we’ve seen so far, from API contracts to distributed consensus protocols. Over this talk’s 40 minutes, you'll learn things it took us 3 years to grasp. Whether you have a monolith or pine for when you did, you'll be more prepared and better armed than we were.
   video_id: WtZUVzDGkTM
-- title: ": Broken APIs Break Trust: Tips for Creating and Updating APIs"
+- title: "Broken APIs Break Trust: Tips for Creating and Updating APIs"
   raw_title: 'RailsConf 2018: Broken APIs Break Trust: Tips for Creating and Updating
     APIs by Alex Wood'
   speakers:
@@ -687,7 +687,8 @@
     at actual examples of specific strategies that you can employ to keep your API
     backwards compatible without painting yourself into a corner."
   video_id: 4McL54Pd2Cs
-- title: ": Warden: the building block behind Devise"
+
+- title: "Warden: the building block behind Devise"
   raw_title: 'RailsConf 2018: Warden: the building block behind Devise by Leonardo
     Tegon'
   speakers:
@@ -706,7 +707,8 @@
 
     Behind the scenes, Devise uses Warden to handle authentication. In this talk, I'll explain what Warden is, why it's useful and how Devise takes advantage of it to build the most popular authentication gem for Rails.
   video_id: QBJ3G40fxHg
-- title: ": Building a Collaborative Text Editor"
+
+- title: "Building a Collaborative Text Editor"
   raw_title: 'RailsConf 2018: Building a Collaborative Text Editor by Justin Weiss'
   speakers:
   - Justin Weiss
@@ -726,7 +728,7 @@
 
     In this talk, you'll learn how to build a great collaborative experience, based on solid fundamental ideas.
   video_id: lmjMC2FRF-A
-- title: ": Ten Years of Rails Tutorials"
+- title: "Ten Years of Rails Tutorials"
   raw_title: 'RailsConf 2018: Ten Years of Rails Tutorials by Michael Hartl'
   speakers:
   - Michael Hartl
@@ -744,7 +746,7 @@
     and simplify. Leave with a deeper appreciation for where Rails came from and where
     it is today."
   video_id: MBL2jRL9crI
-- title: ": The Evolution of Rails Security"
+- title: "The Evolution of Rails Security"
   raw_title: 'RailsConf 2018: The Evolution of Rails Security by Justin Collins'
   speakers:
   - Justin Collins
@@ -760,7 +762,7 @@
 
     Rails has a reputation for being secure by default, but how deserved is that reputation? Let's take a look back at some of the low points in Rails security history: from the first Rails CVE, to the controversial GitHub mass assignment, the 2013 Rails apocalypse, and more recent remote code execution issues. Then we'll cheer ourselves up with the many cool security features Rails has added over the years! We'll cover auto-escaping, strong parameters, default security headers, secret storage, and less well-known features like per-form CSRF tokens and upcoming Content Security Policy support.
   video_id: Btrmc1wO3pc
-- title: ": The Code-Free Developer Interview"
+- title: "The Code-Free Developer Interview"
   raw_title: 'RailsConf 2018: The Code-Free Developer Interview by Pete Holiday'
   speakers:
   - Pete Holiday
@@ -778,7 +780,7 @@
 
     In this talk, you'll learn how to design an interview process which allows you to evaluate candidates without making them code for you.
   video_id: O3XRE0HvzJ8
-- title: ": Harry the Hedgehog Learns You A Communication"
+- title: "Harry the Hedgehog Learns You A Communication"
   raw_title: 'RailsConf 2018: Harry the Hedgehog Learns You A Communication by Laura
     Mosher'
   speakers:
@@ -795,7 +797,7 @@
 
     We know how to communicate — we do it on a daily basis, so why spend time perfecting something you feel you already know how to do? Well, what you say and how you say it impacts how you are understood and how others perceive you. In written communication, a single missing comma can wildly change the meaning of what you said. In this talk, we'll walk through 5 tips that improve how you communicate. Using real world examples, we'll show how common these pitfalls are and how to overcome them. You'll leave armed with the ability to positively impact your relationships through how you communicate.
   video_id: uT1ovJqIjt4
-- title: ": Draw a Crowd"
+- title: "Draw a Crowd"
   raw_title: 'RailsConf 2018: Draw a Crowd by Brittany Martin'
   speakers:
   - Brittany Martin
@@ -811,7 +813,7 @@
 
     Contextual Camouflage is an open-source gallery art installation built in RoR that guides visitors to anonymously report mental health disorders that affect themselves or their relationships. After users submit a disorder, they have the option to include anecdotes and demographic data for intervention researchers. The data is molded into an interactive real-time display using ActionCable. Come see how code can double as art and an educational tool.
   video_id: S9z-qRPdBac
-- title: ": Ales on Rails: Making a Smarter Brewery with Ruby"
+- title: "Ales on Rails: Making a Smarter Brewery with Ruby"
   raw_title: 'RailsConf 2018: Ales on Rails: Making a Smarter Brewery with Ruby by
     Ben Shippee'
   speakers:
@@ -828,7 +830,7 @@
 
     Rails is a great framework to empower people to work smarter, not harder. I'll be sharing the evolution of technology in a Pittsburgh brewery, from a simple MVP to a production application. This talk will explore how Ruby and Rails was leveraged to help manage brewery data, control aspects of the taproom environment, and automate the tedious parts of the job to a few clicks.
   video_id: f7pHXYw7Z1Q
-- title: ": Human Powered Rails: Automated Crowdsourcing In Your RoR App"
+- title: "Human Powered Rails: Automated Crowdsourcing In Your RoR App"
   raw_title: 'RailsConf 2018: Human Powered Rails: Automated Crowdsourcing In Your
     RoR App by Andy Glass'
   speakers:
@@ -861,7 +863,7 @@
   description: 'RailsConf 2018: Keynote: The Future of Rails 6: Scalable by Default
     by Eileen Uchitelle'
   video_id: 8evXWvM4oXM
-- title: ": Running a Business, Demystified"
+- title: "Running a Business, Demystified"
   raw_title: 'RailsConf 2018: Running a Business, Demystified by Todd Kaufman & Justin
     Searls'
   speakers:
@@ -881,7 +883,7 @@
 
     This talk is for anyone whose interest in starting a software company has ever been held back by fear, uncertainty or doubt. It assumes no knowledge of business jargon and will strive to explain each financial concept covered.
   video_id: kJEN5Dt2kKU
-- title: ": What's in a price? How to price your products and services"
+- title: "What's in a price? How to price your products and services"
   raw_title: 'RailsConf 2018: What''s in a price? How to price your products and services
     by Michael Herold'
   speakers:
@@ -900,7 +902,7 @@
 
     Instead of choosing a number by looking inward at your costs, you can use what programmers use best: an abstraction! You'll learn a model for picking the right price for your product and what that price communicates so you can confidently price your next great invention. You'll leave with an actionable list of next steps for pricing your future projects.
   video_id: DldgNBbH9aU
-- title: ": Reporting Live from the Ramp of Death"
+- title: "Reporting Live from the Ramp of Death"
   raw_title: 'RailsConf 2018: Reporting Live from the Ramp of Death by Thijs Cadier'
   speakers:
   - Thijs Cadier
@@ -918,7 +920,7 @@
 
     Coming to you live from the trenches of running an organically growing SaaS for five years, this is an honest –and sometimes brutal– story of perseverance, sacrifice and reward. Find out how to overcome the ramp, and why it isn't as bad as you might think.
   video_id: 5_ZhUCMxQ8M
-- title: ": Taking the Pain Out of Support Engineering"
+- title: "Taking the Pain Out of Support Engineering"
   raw_title: 'RailsConf 2018: Taking the Pain Out of Support Engineering by Cecy Correa'
   speakers:
   - Cecy Correa
@@ -934,7 +936,7 @@
 
     Production support is not a priority. No one on the team wants to work on support cards. Being on-call is a pain. Does this ring a bell? We've all been there! There is a better way to handle Support Engineering for your product. A way that will level up your team, and create positive support experiences for your customers. Drawing on 3+ years of Support Engineering at two different companies, I will share successful Support patterns and tools you can start using today to improve your product support.
   video_id: RvkM17lFxpA
-- title: ": Leveling Up a Heroic Team"
+- title: "Leveling Up a Heroic Team"
   raw_title: 'RailsConf 2018:  Leveling Up a Heroic Team by Aly Fulton'
   speakers:
   - Aly Fulton
@@ -950,7 +952,7 @@
 
     Your application is a dragon and here’s how we’re going to form a successful raiding party to come out victorious (with minimal casualties!). When entering the field of web development, I discovered that the parallels of building a strong multiplayer gaming community and optimizing companies for success were undeniable. Your quest, should you choose to accept it, is to listen to these parallels and use the lessons to strengthen your biggest asset-–your team–-to build a better company and a better web.
   video_id: mpnNiTuVSyw
-- title: ": Old-school Javascript in Rails"
+- title: "Old-school Javascript in Rails"
   raw_title: 'RailsConf 2018: Old-school Javascript in Rails by Graham Conzett'
   speakers:
   - Graham Conzett
@@ -979,7 +981,7 @@
   published_at: '2018-05-18'
   description: Keynote - Livable Code by Sarah Mei
   video_id: lI77oMKr5EY
-- title: ": Quick and easy browser testing using RSpec and Rails 5.1"
+- title: "Quick and easy browser testing using RSpec and Rails 5.1"
   raw_title: 'RailsConf 2018:  Quick and easy browser testing using RSpec and Rails
     5.1 by Sam Phippen'
   speakers:
@@ -998,7 +1000,7 @@
 
     In this talk, you'll learn about the new system specs in RSpec, how to set them up, and what benefits they provide. If you want to improve your RSpec suite with full stack testing this talk is for you!
   video_id: JD-28Oi7fxI
-- title: ": Build A Blog in 15 (more like 30) Minutes: Webpacker Edition"
+- title: "Build A Blog in 15 (more like 30) Minutes: Webpacker Edition"
   raw_title: 'RailsConf 2018: Build A Blog in 15 (more like 30) Minutes: Webpacker
     Edition by Sasha Grodzins'
   speakers:
@@ -1015,7 +1017,7 @@
 
     An ode to DHH's classic, let's build a blog with a Rails backend using a graphQL API and a React frontend. Through this live-coding session, you will learn how to set up an isomorphic app, the basic concepts of each library, and at the end have a fully functioning blog application! Follow along on your computer or clone the repo.
   video_id: f-qY37JIdg0
-- title: ": 6 degrees of JavaScript on Rails"
+- title: "6 degrees of JavaScript on Rails"
   raw_title: 'RailsConf 2018: 6 degrees of JavaScript on Rails by Michael Crismali'
   speakers:
   - Michael Crismali
@@ -1031,7 +1033,7 @@
 
     How much JavaScript you include in your Rails application can feel like a choice between basically none or a full JavaScript single page application backed by a Rails API. When you have a team of people whose confidence with JavaScript is all over the place, this can feel like an impossible choice. Fortunately, there are many options in the middle that can allow those with less JavaScript confidence to stretch and grow while those with more confidence can build UI components with fewer constraints.
   video_id: hXdJU2lpfsE
-- title: ": Look Before You Import: A Webpack Survival Guide"
+- title: "Look Before You Import: A Webpack Survival Guide"
   raw_title: 'RailsConf 2018: Look Before You Import: A Webpack Survival Guide by
     Ross Kaffenberger'
   speakers:
@@ -1065,7 +1067,7 @@
   published_at: '2018-05-18'
   description: Closing Keynote by Aaron Patterson
   video_id: cBFuZivrdT0
-- title: ": Putting Rails in a corner: Understanding database isolation"
+- title: "Putting Rails in a corner: Understanding database isolation"
   raw_title: 'RailsConf 2018: Putting Rails in a corner: Understanding database isolation
     by Emil Ong'
   speakers:
@@ -1084,7 +1086,7 @@
 
     This talk will discuss what database isolation levels are, how to set them in Rails applications, and Rails-specific situations where not choosing the right isolation level can lead to faulty behavior. We'll also talk about how testing code that sets isolation levels requires special care and what to expect to see when monitoring your apps.
   video_id: qwmviS2g1lA
-- title: ": Ten years of Rails upgrades"
+- title: "Ten years of Rails upgrades"
   raw_title: 'RailsConf 2018: Ten years of Rails upgrades by Jordan Raine'
   speakers:
   - Jordan Raine
@@ -1102,7 +1104,7 @@
 
     By looking at the past ten years of Rails upgrades at Clio (and other notable apps), let's see what we can learn. Gain insight into the tradeoffs between different timelines and approaches and learn practical ways to keep your app up-to-date.
   video_id: 6aCfc0DkSFo
-- title: ": Stop Testing, Start Storytelling"
+- title: "Stop Testing, Start Storytelling"
   raw_title: 'RailsConf 2018: Stop Testing, Start Storytelling by Mike Schutte'
   speakers:
   - Mike Schutte
@@ -1118,7 +1120,7 @@
 
     Stop trying to be a computer; you're a human! You know what humans are good at? Storytelling. Stop trying to write tests just to get a green test suite, and start telling rich, descriptive stories. Once you have a good story, then you can worry about the implementation details (wait, is testing a form of abstraction and encapsulation?!). In this talk, we look at writing tests as simply telling stories to the test suite. By telling stories about the application (methods, controllers, features, &c.) the suite holds the storyteller accountable for making those stories become, and stay, true.
   video_id: "-vTZzOssR7A"
-- title: ": Deploying any Rails application to any cloud in minutes"
+- title: "Deploying any Rails application to any cloud in minutes"
   raw_title: 'RailsConf 2018: Deploying any Rails application to any cloud in minutes
     by Khash Sajadi'
   speakers:
@@ -1137,7 +1139,7 @@
 
     This is a sponsored talk by Cloud 66.
   video_id: DOmTzBRcFT8
-- title: ": Engineering Engineering: More than the sum of our parts"
+- title: "Engineering Engineering: More than the sum of our parts"
   raw_title: 'RailsConf 2018: Engineering Engineering: More than the sum of our parts
     by Vietor Davis'
   speakers:
@@ -1156,7 +1158,7 @@
 
     This is a sponsored talk by Procore.
   video_id: 7vTtOoCiKao
-- title: ": Minitest 6: test feistier!"
+- title: "Minitest 6: test feistier!"
   raw_title: 'RailsConf 2018: Minitest 6: test feistier! by Ryan Davis'
   speakers:
   - Ryan Davis
@@ -1172,7 +1174,7 @@
 
     Minitest 5 ships with ruby and is the standard test framework for rails. It already provides a traditional unit test framework, spec DSL, mocks, stubs, test randomization, parallelization, machine agnostic benchmarking, and tons of assertions all in under 2kloc. So what would Minitest 6 do differently? Hopefully to the end user, not much will change, and yet it will be worlds apart from Minitest 5. Come see how you can massively speed up your rails test runs and improve your testing practices by upgrading your test framework.
   video_id: l-ZNxvFo4lw
-- title: ": An Atypical 'Performance' Talk"
+- title: "An Atypical 'Performance' Talk"
   raw_title: 'RailsConf 2018: An Atypical ''Performance'' Talk by Chris Arcand'
   speakers:
   - Chris Arcand
@@ -1188,7 +1190,7 @@
 
     A mixture of a talk on programming and a live classical music recital. Listen to a former-orchestral-clarinetist-turned-developer talk about parallelisms between music performance and programming - such as complexity, imposter syndrome, and true concentration - with live performances throughout!
   video_id: 0Lllf9OjO4k
-- title: ": Giving your Heroku App highly-available PostgreSQL"
+- title: "Giving your Heroku App highly-available PostgreSQL"
   raw_title: 'RailsConf 2018: Giving your Heroku App highly-available PostgreSQL by
     Jake Varghese'
   speakers:
@@ -1207,7 +1209,7 @@
 
     This is a sponsored talk by Compose, an IBM company
   video_id: GJK5CimW0Kw
-- title: ": “API?” – How LendingHome Approaches “Legacy” Technologies"
+- title: "“API?” – How LendingHome Approaches “Legacy” Technologies"
   raw_title: 'RailsConf 2018: “API?” – How LendingHome Approaches “Legacy” Technologies
     by Sam Aarons'
   speakers:
@@ -1228,7 +1230,7 @@
 
     This is a sponsored talk by LendingHome.
   video_id: sKGoWVykxa0
-- title: ": Re-graphing The Mental Model of The Rails Router"
+- title: "Re-graphing The Mental Model of The Rails Router"
   raw_title: 'RailsConf 2018: Re-graphing The Mental Model of The Rails Router by
     Vaidehi Joshi'
   speakers:
@@ -1245,7 +1247,7 @@
 
     Rails is incredibly powerful because of its abstractions. For years, developers have been able to hit the ground running and be productive without having to know the in's and out's of the core computer science concepts that fuel this framework. But just because something is hidden away doesn't mean that it's not worth knowing! In this talk, we'll unpack the CS fundamentals that are used in the Rails router. Together, we'll demystify the graph data structure that lies under the hood of the router in order to understand how a simple structure allows for routing to actually work in a Rails app.
   video_id: lEC-QoZeBkM
-- title: ": Inside Active Storage: a code review of Rails' new framework"
+- title: "Inside Active Storage: a code review of Rails' new framework"
   raw_title: 'RailsConf 2018: Inside Active Storage: a code review of Rails'' new
     framework by Claudio Baccigalupo'
   speakers:
@@ -1269,7 +1271,7 @@
 - title: ''
   raw_title: 'RailsConf 2018: Engine Yard - Shawn Herman'
   speakers:
-  - ": Engine Yard - Shawn Herman"
+  - "Engine Yard - Shawn Herman"
   event_name: RailsConf 2018
   thumbnail_xs: https://i.ytimg.com/vi/42fRu7C1qWU/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/42fRu7C1qWU/mqdefault.jpg
@@ -1282,7 +1284,7 @@
 - title: ''
   raw_title: 'RailsConf 2018: GitHub - Tal Safran'
   speakers:
-  - ": GitHub - Tal Safran"
+  - "GitHub - Tal Safran"
   event_name: RailsConf 2018
   thumbnail_xs: https://i.ytimg.com/vi/0we4EHpMCMM/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/0we4EHpMCMM/mqdefault.jpg
@@ -1305,7 +1307,7 @@
   published_at: '2018-05-18'
   description: ''
   video_id: hZ2-Vsq8ZCU
-- title: ": Up And Down Again: A Migration's Tale"
+- title: "Up And Down Again: A Migration's Tale"
   raw_title: 'RailsConf 2018: Up And Down Again: A Migration''s Tale by Derek Prior'
   speakers:
   - Derek Prior
@@ -1328,7 +1330,7 @@
 - title: ''
   raw_title: 'RailsConf 2018: Lightning Talks'
   speakers:
-  - ": Lightning Talks"
+  - "Lightning Talks"
   event_name: RailsConf 2018
   thumbnail_xs: https://i.ytimg.com/vi/Ld414EypQzg/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/Ld414EypQzg/mqdefault.jpg
@@ -1349,7 +1351,7 @@
     - Barret Clark & Brittany Alexander \n01:08:19 - Jordan Byron \n01:10:41 - Mike
     Wheeler \n01:14:24 - Kenny Browne"
   video_id: Ld414EypQzg
-- title: ": Upgrading Rails at Scale"
+- title: "Upgrading Rails at Scale"
   raw_title: 'RailsConf 2018: Upgrading Rails at Scale by Edouard Chin'
   speakers:
   - Edouard Chin
@@ -1365,7 +1367,7 @@
 
     Upgrading Rails at Shopify has always been a tedious and slow process. One full upgrade cycle was taking as much time as it takes to release a new Rails version. Having a full time dedicated team working solely on upgrading our platform wasn’t the solution but instead a proper process and toolkit. In this talk I’d like to share the different techniques and strategies that allowed to perform our smoothest and fastest Rails upgrade ever.
   video_id: N2B5V4ozc6k
-- title: ": Postgres 10, Performance, and You"
+- title: "Postgres 10, Performance, and You"
   raw_title: 'RailsConf 2018: Postgres 10, Performance, and You by Gabe Enslein'
   speakers:
   - Gabe Enslein
@@ -1381,7 +1383,7 @@
 
     Postgres 10 is out this year, with a whole host of features you won't want to miss. Join the Heroku data team as we take a deep dive into parallel queries, native json
   video_id: 8gXdLAM6B1w
-- title: ": Hot Swapping Our Rails Front End In Secret - A Rebrand Story"
+- title: "Hot Swapping Our Rails Front End In Secret - A Rebrand Story"
   raw_title: 'RailsConf 2018: Hot Swapping Our Rails Front End In Secret - A Rebrand
     Story by Chris LoPresto'
   speakers:
@@ -1404,7 +1406,7 @@
 
     Constraint breeds creativity.
   video_id: Egumr5KiTNI
-- title: ": Actionable Tactics for Leveling Up Junior Devs"
+- title: "Actionable Tactics for Leveling Up Junior Devs"
   raw_title: 'RailsConf 2018: Actionable Tactics for Leveling Up Junior Devs by Sumeet
     Jain'
   speakers:
@@ -1421,7 +1423,7 @@
 
     We are told that junior developers are a secret weapon, but this alleged "competitive advantage" is so elusive! Typical advice about evolving talent can be broad, un-relatable, and impractical. Aren't there any specific and actionable tactics that teams can employ for leveling up new devs? (Yes, there are!)
   video_id: K0vxOBIyhF0
-- title: ": Your first contribution (and beyond)"
+- title: "Your first contribution (and beyond)"
   raw_title: 'RailsConf 2018: Your first contribution (and beyond) by Dinah Shi'
   speakers:
   - Dinah Shi
@@ -1437,7 +1439,7 @@
 
     Do you keep telling yourself you want to get into open source? Have you been thinking about contributing to Rails? Don’t know where to get started? Right here! Come learn about how to find an interesting issue to work on, set up your dev environment, and ask for help when you get stuck. We’ll also talk about what happens after the first patch and where to go from there.
   video_id: SUD9rj0rRxg
-- title: ": Ruby: A Family History"
+- title: "Ruby: A Family History"
   raw_title: 'RailsConf 2018: Ruby: A Family History by Geoffrey Litt'
   speakers:
   - Geoffrey Litt
@@ -1455,7 +1457,7 @@
 
     In this talk, we’ll take a tour of these languages and their myriad influences on Ruby, to better understand the foundations of our tools, improve our ability to use them to their full potential, and imagine how they might be further improved.
   video_id: ELMbK8aHo7w
-- title: ": Five Sharding Data Models and Which is Right"
+- title: "Five Sharding Data Models and Which is Right"
   raw_title: 'RailsConf 2018: Five Sharding Data Models and Which is Right by Craig
     Kerstiens'
   speakers:
@@ -1474,7 +1476,7 @@
 
     This is a sponsored talk by Citus Data.
   video_id: RO6lIW5KQkw
-- title: ": Using Skylight to Solve Real-World Performance Problems"
+- title: "Using Skylight to Solve Real-World Performance Problems"
   raw_title: 'RailsConf 2018: Using Skylight to Solve Real-World Performance Problems
     by Yehuda, Godfrey & Krystan'
   speakers:
@@ -1493,7 +1495,7 @@
 
     This is a sponsored talk by Skylight
   video_id: QlMqObmQCrI
-- title: ": Containerizing Rails: Techniques, Pitfalls, & Best Practices"
+- title: "Containerizing Rails: Techniques, Pitfalls, & Best Practices"
   raw_title: 'RailsConf 2018: Containerizing Rails: Techniques, Pitfalls, & Best Practices
     by Daniel Azuma'
   speakers:
@@ -1512,7 +1514,7 @@
 
     This is a sponsored talk by Google Cloud Platform.
   video_id: kG2vxYn547E
-- title: ": Here's to history: programming through archaeology"
+- title: "Here's to history: programming through archaeology"
   raw_title: 'RailsConf 2018: Here''s to history: programming through archaeology
     by Eleanor Kiefel Haggerty'
   speakers:
@@ -1529,7 +1531,7 @@
 
     Does your git log output resemble an archaeological site from 500BC? Ransacked by Persians with some Spartan conflict? When we code and commit, our decisions, for better or worse, are preserved. As though in an archaeological record. Thanks to the archaeological record we can understand entire human cultures, but how much do we understand about the decisions developers are making today? Applying the same practices archaeologists utilise can help us understand the decisions developers are making in 2018.
   video_id: zXas0xT5JGA
-- title: ": Knobs, buttons & switches: Operating your application at scale"
+- title: "Knobs, buttons & switches: Operating your application at scale"
   raw_title: 'RailsConf 2018: Knobs, buttons & switches: Operating your application
     at scale by Amy Unger'
   speakers:
@@ -1550,7 +1552,7 @@
 
     You’ll walk away from this talk with tools you can have on hand to ensure you remain in control even when your application is under stress.
   video_id: KjfYoHxmCmI
-- title: ": Here’s to the crazy ones"
+- title: "Here’s to the crazy ones"
   raw_title: 'RailsConf 2018: Here’s to the crazy ones by James Adam'
   speakers:
   - James Adam


### PR DESCRIPTION
There were some stray semi-colons in the title, the event/speaker name in the title or missing speakers in the list