### PR TITLE
RubyConf data cleanup + RubyConf 2022 videos

### DIFF
--- a/data/rubyconf/playlists.yml
+++ b/data/rubyconf/playlists.yml
@@ -22,6 +22,16 @@
   videos_count: 79
   slug: rubyconf-2022-mini
 
+- id: PLE7tQUdRKcyZYz0O3d9ZDdo0-BkOWhrSk
+  title: 'RubyConf 2022'
+  description: RubyConf Houston 2022
+  published_at: '2023-02-28'
+  channel_id: UCWnPjmqvljcafA0z2U1fwKQ
+  year: '2022'
+  videos_count: 79
+  metadata_parser: Youtube::VideoMetadata
+  slug: rubyconf-2022
+
 - id: PLE7tQUdRKcyZ13yKsi3ID6a4MWDxSw-LE
   title: RubyConf 2023
   description:

--- a/data/rubyconf/playlists.yml
+++ b/data/rubyconf/playlists.yml
@@ -14,22 +14,13 @@
   slug: rubyconf-2021
 
 - id: PLE7tQUdRKcyZYz0O3d9ZDdo0-BkOWhrSk
-  title: "RubyConf 2022 Mini"
+  title: "RubyConf Mini 2022"
   description: RubyConf Mini held in Providence, RI
   published_at: "2023-02-28"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2022"
   videos_count: 79
   slug: rubyconf-2022-mini
-
-- id: PLE7tQUdRKcyZYz0O3d9ZDdo0-BkOWhrSk
-  title: "RubyConf 2022 Mini"
-  description: RubyConf Mini held in Providence, RI
-  published_at: "2023-02-28"
-  channel_id: UCWnPjmqvljcafA0z2U1fwKQ
-  year: "2022"
-  videos_count: 79
-  slug: rubyconf-2022-mini-2
 
 - id: PLE7tQUdRKcyZ13yKsi3ID6a4MWDxSw-LE
   title: RubyConf 2023

--- a/data/rubyconf/playlists.yml
+++ b/data/rubyconf/playlists.yml
@@ -12,16 +12,27 @@
   videos_count: 102
   metadata_parser: Youtube::VideoMetadata
   slug: rubyconf-2021
+
 - id: PLE7tQUdRKcyZYz0O3d9ZDdo0-BkOWhrSk
-  title: "RubyConf 2022: Mini and Houston"
-  description: RubyConf Mini held in Providence, RI and RubyConf Houston 2022
+  title: "RubyConf 2022 Mini"
+  description: RubyConf Mini held in Providence, RI
   published_at: "2023-02-28"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2022"
   videos_count: 79
-  slug: rubyconf-2022-mini-and-houston
+  slug: rubyconf-2022-mini
+
+- id: PLE7tQUdRKcyZYz0O3d9ZDdo0-BkOWhrSk
+  title: "RubyConf 2022 Mini"
+  description: RubyConf Mini held in Providence, RI
+  published_at: "2023-02-28"
+  channel_id: UCWnPjmqvljcafA0z2U1fwKQ
+  year: "2022"
+  videos_count: 79
+  slug: rubyconf-2022-mini-2
+
 - id: PLE7tQUdRKcyZ13yKsi3ID6a4MWDxSw-LE
-  title: RubyConf 2023 (San Diego)
+  title: RubyConf 2023
   description:
     RubyConf is the annual fall conference for Ruby enthusiasts to gather
     and enjoy talks about new projects, meet and network with other Ruby developers,
@@ -30,4 +41,4 @@
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2023"
   videos_count: 23
-  slug: rubyconf-2023-san-diego
+  slug: rubyconf-2023

--- a/data/rubyconf/rubyconf-2021/videos.yml
+++ b/data/rubyconf/rubyconf-2021/videos.yml
@@ -7,6 +7,7 @@
   published_at: "2022-08-09"
   description: ""
   video_id: yj0dYow4B7E
+
 - title: Some Assembly Required
   raw_title: RubyConf 2021 - Some Assembly Required by Aaron Patterson
   speakers:
@@ -18,16 +19,16 @@
 
     Let's write a JIT for Ruby, in Ruby! We're going to learn how a JIT works from the ground up by building TenderJIT, a pure Ruby JIT compiler. First, we'll learn how Ruby's virtual machine works, then we'll learn how to plug a JIT in to the virtual machine. Finally, we'll generate machine code from our Ruby programs. By the end of the presentation we'll have a working JIT that converts Ruby code in to machine code all written in pure Ruby! But don't forget: some assembly is required!
   video_id: 4vDfegrjUtQ
+
 - title: "Keynote: Finding Purpose and Cultivating Spirituality by Andrea Guendelman"
-  raw_title:
-    "RubyConf 2021 - Keynote: Finding Purpose and Cultivating Spirituality
-    by Andrea Guendelman"
+  raw_title: "RubyConf 2021 - Keynote: Finding Purpose and Cultivating Spirituality by Andrea Guendelman"
   speakers:
     - Andrea Guendelman
   event_name: RubyConf 2021
   published_at: "2022-08-09"
   description: "Keynote: Finding Purpose and Cultivating Spirituality by Andrea Guendelman"
   video_id: G5ZdlqqhYEM
+
 - title: Your Team, as Saga
   raw_title: RubyConf 2021 - Your Team, as Saga by Betsy Haibel
   speakers:
@@ -39,10 +40,9 @@
 
     Software systems are made of code, and the people who work on them. But most of all, they're made of the stories those people tell. Heroic legends of shipping to deadline, spooky ghost stories of refactors gone bad... and a lot of sci-fi, projecting out into a utopian (or dystopian) future. How can you edit this story to make it go right? In this talk, we'll apply fiction-writing tricks to the art of engineering roadmapping. We'll learn how to build narratives, develop our characters, and world-build our way to healthier teams and healthier code.
   video_id: pdxWY5Ebm2k
+
 - title: Delightfully Fashionable Lemurs in Decorating Ruby
-  raw_title:
-    RubyConf 2021 - Delightfully Fashionable Lemurs in Decorating Ruby by
-    Brandon Weaver
+  raw_title: RubyConf 2021 - Delightfully Fashionable Lemurs in Decorating Ruby by Brandon Weaver
   speakers:
     - Brandon Weaver
   event_name: RubyConf 2021
@@ -54,6 +54,7 @@
 
     Join the lemurs on a fashion-filled journey through decoration patterns in Ruby including tricks with method, define_method, method_added, and Module#prepend.
   video_id: vLQEsG5MM8E
+
 - title: Parsing Ruby
   raw_title: RubyConf 2021 - Parsing Ruby by Kevin Newton
   speakers:
@@ -64,6 +65,7 @@
     Since Ruby's inception, there have been many different projects that parse Ruby code. This includes everything from development tools to Ruby implementations themselves. This talk dives into the technical details and tradeoffs of how each of these tools parses and subsequently understands your applications. After, we'll discuss how you can do the same with your own projects using the Ripper standard library. You'll see just how far we can take this library toward building useful development tools.
 
   video_id: EXKsRKmkrns
+
 - title: Taking the 737 to the Max
   raw_title: RubyConf 2021 - Taking the 737 to the Max by Nickolas Means
   speakers:
@@ -76,6 +78,7 @@
     The 737 MAX entered service seven years later as the result of that and hundreds of other choices along the way. Let’s look at some of those choices in context to understand how the 737 MAX went so very wrong. We’ll learn a thing or two along the way about making better decisions ourselves and as teams.
 
   video_id: MfU8CrenyMo
+
 - title: On Being an Early Career Dev in Your 30s
   raw_title: RubyConf 2021 - On Being an Early Career Dev in Your 30s by Ben Greenberg
   speakers:
@@ -88,6 +91,7 @@
     In this talk, we will cover practical steps for navigating specific challenges related to hiring and being hired as a second-career dev. If approached with intention and thoughtfulness, the benefits can be immense for all involved.
 
   video_id: BFopVe4xyyw
+
 - title: Q&A with Matz
   raw_title: RubyConf 2021 - Q&A with Matz by Evan Phoenix & Yukihiro Matsumoto (Matz)
   speakers:
@@ -97,20 +101,18 @@
   published_at: "2022-08-09"
   description: ""
   video_id: tAdb766lzX8
+
 - title: "Keynote: On the Care and Feeding of Feedback Cycles by Elisabeth Hendrickson"
-  raw_title:
-    "RubyConf 2021 - Keynote: On the Care and Feeding of Feedback Cycles
-    by Elisabeth Hendrickson"
+  raw_title: "RubyConf 2021 - Keynote: On the Care and Feeding of Feedback Cycles by Elisabeth Hendrickson"
   speakers:
     - Elisabeth Hendrickson
   event_name: RubyConf 2021
   published_at: "2022-08-09"
   description: ""
   video_id: qHPguCNzVbU
+
 - title: "Fake Your Test Away: How To Abuse Your Test Doubles"
-  raw_title:
-    "RubyConf 2021 - Fake Your Test Away: How To Abuse Your Test Doubles
-    by Jenny Shih"
+  raw_title: "RubyConf 2021 - Fake Your Test Away: How To Abuse Your Test Doubles by Jenny Shih"
   speakers:
     - Jenny Shih
   event_name: RubyConf 2021
@@ -119,6 +121,7 @@
     You probably already know: In a unit test, use test doubles to sub real dependencies. You probably also know: In reality, things are not so easy. What do you do if the dependencies span multiple layers? What if the dependencies are implicit? If we can't find the best level of isolation, test doubles can be unwieldy very quickly and they will make the test, as well as the future you, miserable. In this talk, we will look at symptoms that produce unreliable and unmaintainable tests, and develop a strategy that will make your test suite more resilient and actually enjoyable.
 
   video_id: 4oJX-AN0J5k
+
 - title: The Mindset of Debugging
   raw_title: RubyConf 2021 - The Mindset of Debugging by Kyle d'Oliveira
   speakers:
@@ -129,21 +132,19 @@
     We, as developers, spend a large portion of our time debugging software. Sometimes the problems are easy to understand, but many times they are not and we are thrown into unfamiliar code and are expected to quickly find the problem and craft a solution. However, honing the skill of debugging doesn’t come up as much as it should. In this talk, I’ll go through a generic approach to debugging that can be applied and built upon to help you excel as you move through your career solving problems for a living.
 
   video_id: LitTV2k_X34
+
 - title: Your First Open-Source Contribution
-  raw_title:
-    RubyConf 2021 - Your First Open-Source Contribution by Rachael Wright
-    Munn
+  raw_title: RubyConf 2021 - Your First Open-Source Contribution by Rachael Wright Munn
   speakers:
-    - Rachael Wright Munn
+    - Rachael Wright-Munn
   event_name: RubyConf 2021
   published_at: "2022-08-09"
   description: |-
     Is open-source intimidating? Are you nervous about your code being rejected by the maintainers? Or maybe you just don’t know where to start. I know those nerves well. Let’s talk about it. We'll go step-by-step through the process of finding an issue, creating a PR, and collaborating with maintainers. Let’s get you that first open-source PR!
   video_id: z3WLFQd9PXA
+
 - title: I Read It But Don’t Get It, or How to Tackle Technical Texts
-  raw_title:
-    RubyConf 2021 - I Read It But Don’t Get It, or How to Tackle Technical
-    Texts by Steve Lynch
+  raw_title: RubyConf 2021 - I Read It But Don’t Get It, or How to Tackle Technical Texts by Steve Lynch
   speakers:
     - Steve Lynch
   event_name: RubyConf 2021
@@ -157,6 +158,7 @@
     will outline those techniques while also providing concrete questions that can
     be used during reading to help you stay \n\n"
   video_id: NdjG55NiX8o
+
 - title: The Audacious Array
   raw_title: RubyConf 2021 - The Audacious Array by Ariel Caplan
   speakers:
@@ -171,6 +173,7 @@
     Understanding arrays deeply is a powerful step forward in writing concise, beautiful, semantic Ruby.
 
   video_id: RKlbn3KuN5k
+
 - title: To mock, or not to mock?
   raw_title: RubyConf 2021 - To mock, or not to mock? by Emily Giurleo
   speakers:
@@ -183,10 +186,9 @@
     So… how do we know when to use mocks in our tests? In this talk, we’ll identify three important questions that can help us make that decision. By the end of the talk, you will have a framework in mind to help you answer the question: to mock, or not to mock?
 
   video_id: mD7zm3MFPuA
+
 - title: Blank Page Panic! Creating Confidence with TDD
-  raw_title:
-    RubyConf 2021 - Blank Page Panic! Creating Confidence with TDD by Elayne
-    Juten
+  raw_title: RubyConf 2021 - Blank Page Panic! Creating Confidence with TDD by Elayne Juten
   speakers:
     - Elayne Juten
   event_name: RubyConf 2021
@@ -195,6 +197,7 @@
     Have you ever stared at a blank feature spec file hoping for tests to magically appear? Well, you’re not alone! In this talk we’ll take a look at how the combination of Test-Driven Development, pseudocode and RSpec can help get you to your initial commit with confidence, one RSpec error at a time!
 
   video_id: OtfzxlddWDY
+
 - title: The art of deleting code
   raw_title: RubyConf 2021 - The art of deleting code by Claudio Baccigalupo
   speakers:
@@ -209,6 +212,7 @@
     We will see how git can help, with commands like blame, log --follow, and bisect. We will talk about static analysis, and running code coverage in development. We will explain how Ruby meta-programming can conflict with the "Find in Project" approach. We will show how to be nice to reviewers when submitting Pull Requests that delete code.
 
   video_id: nBZn2nE3yDE
+
 - title: Learning Ractor with Raft
   raw_title: RubyConf 2021 - Learning Ractor with Raft by Micah Gates
   speakers:
@@ -223,6 +227,7 @@
     In this session we’ll build a simple Raft implementation from scratch using Ractor. Ractor is one of the most exciting new features of Ruby, and modeling a distributed system is a great way to see what it can offer.
 
   video_id: 13QyqsFShc4
+
 - title: Vertical Assignment in Ruby
   raw_title: RubyConf 2021 - Vertical Assignment in Ruby by Kevin Kuchta
   speakers:
@@ -233,8 +238,9 @@
     Ruby's long had leftward assignment (x = 3) and recently got rightward assignment (3 = or greater x). The problem here is obvious: we need a vertical assignment operator. In a complete abdication of good taste and common sense, this talk will walk through correcting this heinous oversight. We'll abuse otherwise-respectable metaprogramming tools like Ripper and TracePoint to add a fully functional vequals operator. While this talk is almost 100% bad-ideas-by-volume, you'll learn a few tricks that you can use in your day-to-day work (or at least to terrify your co-workers).
 
   video_id: B2nBB70uy6M
-- title: ubyConf 2021 - Keeping Developers Happy with a Fast CI
-  raw_title: ubyConf 2021 - Keeping Developers Happy with a Fast CI by Christian Bruckmayer
+
+- title: Keeping Developers Happy with a Fast CI
+  raw_title: RubyConf 2021 - Keeping Developers Happy with a Fast CI by Christian Bruckmayer
   speakers:
     - Christian Bruckmayer
   event_name: RubyConf 2021
@@ -245,10 +251,9 @@
     At Shopify we have more than 170,000 Ruby tests and we add 30,000 more annually. The sheer amount of tests and their growth requires some aggressive methods. We will illustrate some of our techniques including monitoring, test selection, timeouts and the 80/20 rule. If you have experience in writing tests and want to learn tricks on how to speed up your test suite, this talk is for you!
 
   video_id: XgKfeD-20ts
+
 - title: "Schrödinger's Error: Living In the grey area of Exceptions"
-  raw_title:
-    "RubyConf 2021 - Schrödinger's Error: Living In the grey area of Exceptions
-    by Sweta Sanghavi"
+  raw_title: "RubyConf 2021 - Schrödinger's Error: Living In the grey area of Exceptions by Sweta Sanghavi"
   speakers:
     - Sweta Sanghavi
   event_name: RubyConf 2021
@@ -259,10 +264,9 @@
     In this talk, we’ll discuss what makes exception management difficult, tools to triage and respond to exceptions, and processes for more collective and effective exception management. We'll also explore some related opinions from you, my dear colleagues.
 
   video_id: B1yIAhnkjDY
+
 - title: Automating Legacy Desktop Applications with JRuby and Sikuli
-  raw_title:
-    RubyConf 2021- Automating Legacy Desktop Applications with JRuby and
-    Sikuli by Chris Cha
+  raw_title: RubyConf 2021- Automating Legacy Desktop Applications with JRuby and Sikuli by Chris Cha
   speakers:
     - Chris Cha
   event_name: RubyConf 2021
@@ -271,6 +275,7 @@
     Desktop applications supporting line-of-business, enterprise functions live on as massive, complex beasts. Without an easy route into its internals and modernization falling by the wayside, it's up to you to make sure any small change doesn't break — well — everything. In this talk, we'll discuss the journey of bringing up a Windows VM to poke at an app using screenshots, image recognition, and Minitest to create our own Robotic Process Automation (RPA) framework.
 
   video_id: Oqh7ueTLlwo
+
 - title: Ruby Archaeology
   raw_title: RubyConf 2021 - Ruby Archaeology by Nick Schwaderer
   speakers:
@@ -288,10 +293,9 @@
     And for the brave: how can you set up an environment to run Ruby 1.8 code from ~2008 on a modern machine?
 
   video_id: 9ai2nL93mt0
+
 - title: "Service Objects With Dry.rb: Monads and Transactions"
-  raw_title:
-    "RubyConf 2021 - Service Objects With Dry.rb: Monads and Transactions
-    by Paul Sadauskas"
+  raw_title: "RubyConf 2021 - Service Objects With Dry.rb: Monads and Transactions by Paul Sadauskas"
   speakers:
     - Paul Sadauskas
   event_name: RubyConf 2021
@@ -300,6 +304,7 @@
     Service objects are an important tool in your toolbox, and Dry.rb's Transaction library is one of the most powerful, and one of the most magic. It's a "business transaction" DSL, and has error handling as a primary concern. We'll start by exploring Monads in Ruby (they're not scary!). Then we'll see how that simple concept unlocks another level of service objects that are far more robust and testable, and how to wire them all together with Dry::Transaction. Finally we'll touch on extending transactions with custom steps, and how to integrate them into an existing application.
 
   video_id: HOmCJq2LOZ4
+
 - title: The Science and Magic of Debugging
   raw_title: RubyConf 2021 - The Science and Magic of Debugging by Vaidehi Joshi
   speakers:
@@ -314,6 +319,7 @@
     In this talk, we'll learn what makes debugging hard, and the cognitive process behind it. We'll also explore using the scientific method as a debugging process model in order to help us get better at finding the bugs in our own Ruby programs. Let's become better debuggers together!
 
   video_id: CidxJ_rJVBw
+
 - title: How to Make a Gem of a Gem
   raw_title: RubyConf 2021 - How to Make a Gem of a Gem by Justin Searls
   speakers:
@@ -328,6 +334,7 @@
     Answering those questions is… harder. That's why the remaining 15 minutes of this talk will compress a decade of design missteps, dependency regrets, and versioning nightmares into actionable advice to help ensure that your next gem is a great one.
 
   video_id: tKzu-3m0ZZY
+
 - title: How GitHub uses linters
   raw_title: RubyConf 2021 - How GitHub uses linters by Joel Hawksley
   speakers:
@@ -338,10 +345,9 @@
     The GitHub code base is growing at over 25% every year through contributions from over 1000 engineers, clocking in at 1.7+ million lines of Ruby. In this talk, we'll share how we use linters to keep our codebase healthy by ensuring best practices are applied consistently, feedback loops are as short as possible, and code reviews bring the most value, all without creating too much friction.
 
   video_id: cY2-KGOvBD0
+
 - title: Building Native Extensions. This Could Take A While...
-  raw_title:
-    RubyConf 2021 - Building Native Extensions. This Could Take A While...
-    by Mike Dalessio
+  raw_title: RubyConf 2021 - Building Native Extensions. This Could Take A While... by Mike Dalessio
   speakers:
     - Mike Dalessio
   event_name: RubyConf 2021
@@ -352,10 +358,9 @@
     This talk will provide a deep look at the techniques and toolchain used to ship native versions of Nokogiri (a commonly-used rubygem), and will discuss why human trust is an important requirement. Gem maintainers will learn how to build native versions of their own gems, and developers will learn how to use and deploy pre-compiled packages
 
   video_id: jtpOci5o50g
+
 - title: "Dishonest Software: Fighting Back Against the Industry Norms"
-  raw_title:
-    "RubyConf 2021 - Dishonest Software: Fighting Back Against the Industry
-    Norms by Jason Meller"
+  raw_title: "RubyConf 2021 - Dishonest Software: Fighting Back Against the Industry Norms by Jason Meller"
   speakers:
     - Jason Meller
   event_name: RubyConf 2021
@@ -372,6 +377,7 @@
     Explore how engineers can advocate for the data privacy rights of others
 
   video_id: "-svFoj2beT8"
+
 - title: Problem Solving Through Pair Programming
   raw_title: RubyConf 2021 - Problem Solving Through Pair Programming by Emily Harber
   speakers:
@@ -384,12 +390,11 @@
     In this talk, I’ll give you the How and Why of pair programming with your mentee, as well as practical actionable advice to have more productive, educational, and even fun pairing sessions. You’ll come away from this talk excited for your next pairing session, where you’ll write better quality code with a longer shelf life, and give your mentee programming superpowers they couldn’t achieve on their own.
 
   video_id: YXsbz_9itFU
+
 - title: Why we worry about all the wrong things
-  raw_title:
-    RubyConf 2021 - Why we worry about all the wrong things by Hilary Stohs
-    Krause
+  raw_title: RubyConf 2021 - Why we worry about all the wrong things by Hilary Stohs Krause
   speakers:
-    - Hilary Stohs Krause
+    - Hilary Stohs-Krause
   event_name: RubyConf 2021
   published_at: "2022-08-09"
   description: |-
@@ -400,6 +405,7 @@
     In this talk, we’ll explore root causes of fear and anxiety, and discover how we can start to deliberately rewrite our “instincts”. This will allow us to redirect our worry toward what actually matters, and channel it into productive outcomes that make us safer, happier and less stressed, both at work and in our personal lives.
 
   video_id: qTnSZVYCxok
+
 - title: Reframing Shame & Embracing Mistakes
   raw_title: RubyConf 2021 - Reframing Shame & Embracing Mistakes by Jameson Hampton
   speakers:
@@ -410,10 +416,9 @@
     Imposter syndrome is rampant among tech workers and there are so many ways that we put ourselves down and minimize our own accomplishments without even realizing it - and shame is a powerful and dangerous emotion. But everyone makes mistakes and in fact, making mistakes and learning from them makes us smarter! The tenets of cognitive behavioral therapy suggest that these kinds of harmful thought patterns are automatic, ingrained in us from years of practice. This talk will help you identify some of those thought patterns so you can challenge them and reframe them in healthier ways!
 
   video_id: 3_BFqbZVlpE
-- title: "Contractualism + Software Engineering: We're All In This..."
-  raw_title:
-    "RubyConf 2021 - Contractualism + Software Engineering: We're All In
-    This... by Katya Dreyer Oren"
+
+- title: "Contractualism + Software Engineering: We're All In This Together"
+  raw_title: "RubyConf 2021 - Contractualism + Software Engineering: We're All In This... by Katya Dreyer Oren"
   speakers:
     - Katya Dreyer Oren
   event_name: RubyConf 2021
@@ -424,6 +429,7 @@
     As engineers, we are constantly confronted with decisions, from the tiny – “how thick should this border box be?” – to the huge – “how will this algorithm affect the world?” How do we make those decisions? Come learn about contractualism, or how to treat your users as a part of a larger community. We’ll discuss the concept of the “user stack,” anyone who will use or be influenced by your work. Understanding the principles of contractualism and how to apply them makes it easier for you to make ethical decisions as a software engineer, and convince others at your organization to listen.
 
   video_id: 2jkw-YW-SMs
+
 - title: The Algorithm Ate My Homework
   raw_title: RubyConf 2021 - The Algorithm Ate My Homework by Yechiel Kalmenson
   speakers:
@@ -440,6 +446,7 @@
     We may not leave with all the answers, but hopefully, we will spark a conversation about the questions we should be asking.
 
   video_id: I3ggfUMgjsI
+
 - title: Squashing Security Bugs with Rubocop
   raw_title: RubyConf 2021 - Squashing Security Bugs with Rubocop by Omar
   speakers:
@@ -454,10 +461,9 @@
     This talk will cover how Betterment uses Rubocop to detect vulnerabilities and the thought process that went into this work.
 
   video_id: 75TtHyn5uLQ
-- title: "Gradual Typing in Ruby - A Three Year..."
-  raw_title:
-    RubyConf 2021 - Gradual Typing in Ruby - A Three Year... by Ufuk Kayserilioglu,
-    Alexandre Terrasa
+
+- title: "Gradual Typing in Ruby - A Three Year Retrospective"
+  raw_title: RubyConf 2021 - Gradual Typing in Ruby - A Three Year... by Ufuk Kayserilioglu, Alexandre Terrasa
   speakers:
     - Ufuk Kayserilioglu
     - Alexandre Terrasa
@@ -469,10 +475,9 @@
     The road to get here was not easy, though. We had to work with our developers to solve the right problems at the right levels of abstraction to ensure the adoption was healthy. This talk will go over some of the challenges and some of our wins along the way. It will also help you decide if gradual typing might work for your codebase and your team, as well.
 
   video_id: ntXKTEaWjPM
+
 - title: "Acidic Jobs: A Layman's Guide to Job Bliss"
-  raw_title:
-    "RubyConf 2021 - Acidic Jobs: A Layman's Guide to Job Bliss by Stephen
-    Margheim"
+  raw_title: "RubyConf 2021 - Acidic Jobs: A Layman's Guide to Job Bliss by Stephen Margheim"
   speakers:
     - Stephen Margheim
   event_name: RubyConf 2021
@@ -481,10 +486,9 @@
     Background jobs have become an essential component of any Ruby infrastructure, and, as the Sidekiq Best Practices remind us, it is essential that jobs be "idempotent and transactional." But how do we make our jobs idempotent and transactional? In this talk, we will explore various techniques to make our jobs robust and ACIDic.
 
   video_id: l7hIYegfOKk
+
 - title: "Joyful Polyglot: Beautiful insights from many languages"
-  raw_title:
-    "RubyConf 2021 - Joyful Polyglot: Beautiful insights from many languages
-    by Nick Barone"
+  raw_title: "RubyConf 2021 - Joyful Polyglot: Beautiful insights from many languages by Nick Barone"
   speakers:
     - Nick Barone
   event_name: RubyConf 2021
@@ -493,10 +497,9 @@
     Every language teaches you something beautiful, leading new and experienced programmers alike to novel and joyful ways to think about code. Would you benefit from a broader bag of programming concepts, or are you just curious about what can be learned when venturing outside your current box? From C++'s template metaprogramming to Scala's companion objects and more, this talk will explore a multitude of different programming languages and how the ideas and principles exemplified by each can be used by any other - but specifically, Ruby.
 
   video_id: dXCvQCOZs78
+
 - title: "Drones Galore: controlling multiple drones using mruby/ruby"
-  raw_title:
-    "RubyConf 2021 - Drones Galore: controlling multiple drones using mruby/ruby
-    by Shashank Daté"
+  raw_title: "RubyConf 2021 - Drones Galore: controlling multiple drones using mruby/ruby by Shashank Daté"
   speakers:
     - Shashank Daté
   event_name: RubyConf 2021
@@ -505,6 +508,7 @@
     mruby is a lightweight implementation of the Ruby language. This talk focuses on how mruby differs from ruby, how its build system works, how to optimize its configuration for controlling a certain category (Tello) of programmable drones. It will include - flight control using UDP sockets in mruby - multiple drone control using Fibers in murby - multiple drone control using using Ruby Actors The talk will end with a demo of multi-drone acrobatics.
 
   video_id: BxXwoBp9gT8
+
 - title: "Mixed Reality Robotics Simulation with Ruby"
   raw_title: RubyConf 2021 - Mixed Reality Robotics Simulation with Ruby by Kota Weaver
   speakers:
@@ -519,10 +523,9 @@
     Join us in an exploration of this dynamic and interactive robot exploration lab!
 
   video_id: axQzs1moNUQ
-- title: "Achieving Fast Method Metaprogramming: Lessons from.."
-  raw_title:
-    "RubyConf 2021 - Achieving Fast Method Metaprogramming: Lessons from..
-    by Jemma Issroff, Jacob Evelyn"
+
+- title: "Achieving Fast Method Metaprogramming: Lessons from MemoWise"
+  raw_title: "RubyConf 2021 - Achieving Fast Method Metaprogramming: Lessons from.. by Jemma Issroff, Jacob Evelyn"
   speakers:
     - Jemma Issroff
     - Jacob Evelyn
@@ -532,10 +535,9 @@
     Are dynamically generated methods always slow? In this talk, we’ll recount our journey developing MemoWise, Ruby’s most performant memoization gem. It’s a tale of benchmark-driven development, unexpected object allocations, and learning to love eval. We’ll cover common performance problems in Ruby metaprogramming and the arcane techniques we used to overcome them.
 
   video_id: uV3LqxFBSII
+
 - title: "YJIT - Building a new JIT Compiler inside CRuby"
-  raw_title:
-    RubyConf 2021 - YJIT - Building a new JIT Compiler inside CRuby by Maxime
-    Chevalier Boisvert
+  raw_title: RubyConf 2021 - YJIT - Building a new JIT Compiler inside CRuby by Maxime Chevalier Boisvert
   speakers:
     - Maxime Chevalier Boisvert
   event_name: RubyConf 2021
@@ -544,10 +546,9 @@
     TruffleRuby together with Truffle Regex can now execute Ruby Regexps up to 40 times faster than CRuby! This is possible by just-in-time compiling Ruby Regexps to machine code by using Truffle Regex, a Truffle language for regular expressions. Truffle Regex uses finite-state machines, a much faster alternative to backtracking regexp engines. Because of the unique capability of GraalVM to inline across languages, the Ruby code and the Regexp are optimized and compiled together for ultimate performance.
 
   video_id: fqxkjb7wPy4
+
 - title: "Compiling Ruby to Native Code with Sorbet & LLVM"
-  raw_title:
-    RubyConf 2021 - Compiling Ruby to Native Code with Sorbet & LLVM by Jake
-    Zimmerman & Trevor Elliott
+  raw_title: RubyConf 2021 - Compiling Ruby to Native Code with Sorbet & LLVM by Jake Zimmerman & Trevor Elliott
   speakers:
     - Jake Zimmerman
     - Trevor Elliott
@@ -559,6 +560,7 @@
     In this talk, we’ll cover why we built it, how it works, and share preliminary results from compiling Stripe’s production Ruby code. It’s not quite ready for prime time yet, but we’re interested in sharing our approach and getting early feedback on the design.
 
   video_id: mCVwbrsWOlE
+
 - title: "Improving CVAR performance in Ruby 3.1"
   raw_title: RubyConf 2021 - Improving CVAR performance in Ruby 3.1 by Eileen Uchitelle
   speakers:
@@ -571,6 +573,7 @@
     In this talk we'll look at the language design of class variables, learn about how they work, and, deep dive into how we improved their performance in Ruby 3.1 by adding a cache! We'll look at the cache design and real-world benchmarks showing how much faster they are regardless of the size of the inheritance chain.
 
   video_id: Y3tSf8FwHUw
+
 - title: "Optimizing Partial Backtraces in Ruby 3"
   raw_title: RubyConf 2021 - Optimizing Partial Backtraces in Ruby 3 by Jeremy Evans
   speakers:
@@ -581,6 +584,7 @@
     Backtraces are very useful tools when debugging problems in Ruby programs. Unfortunately, backtrace generation is expensive for deep callstacks. In older versions of Ruby, this is true even if you only want a partial backtrace, such as a single backtrace frame. Thankfully, Ruby 3 has been optimized so that it no longer processes unnecessary backtrace frames, which can greatly speed up the generation of partial backtraces. Join me for an interesting look a Ruby backtraces, how they are generated, how we optimized partial backtraces in Ruby 3, and how we fixed bugs in the optimization in 3.0.1.
 
   video_id: GSlQEtEjmHM
+
 - title: A message from Engineyard
   raw_title: RubyConf 2021 - A message from Engineyard by Rahul Subramaniam EY
   speakers:
@@ -589,10 +593,9 @@
   published_at: "2022-08-09"
   description: ""
   video_id: F2RoYrMLJ48
-- title: "Sorbet at Grailed: Typing a Large Rails Codebase to Ship with..."
-  raw_title:
-    "RubyConf 2021 - Sorbet at Grailed: Typing a Large Rails Codebase to
-    Ship with... by Jose Rosello"
+
+- title: "Sorbet at Grailed: Typing a Large Rails Codebase to Ship with Confidence"
+  raw_title: "RubyConf 2021 - Sorbet at Grailed: Typing a Large Rails Codebase to Ship with... by Jose Rosello"
   speakers:
     - Jose Rosello
   event_name: RubyConf 2021
@@ -605,6 +608,7 @@
     Ever since we started gradually typing our codebase with Sorbet, we’ve been able to make intrusive changes faster and confidently. In this talk, we’ll walk you through our prior art, challenges, learnings, and big benefits of typing our codebase.
 
   video_id: jYqRV0Kt2ZI
+
 - title: Scaling Happy Engineering Teams
   raw_title: RubyConf 2021 - Scaling Happy Engineering Teams by Zaid Zawaideh
   speakers:
@@ -615,6 +619,7 @@
     Scaling engineering organizations doesn't have to mean chaos, stress or losing the ability to have impact. In this talk I'll explain the principles we are applying at Wrapbook for scaling our Engineering teams to provide a healthy, happy and productive environment for people to do their best work.
 
   video_id: o04lx5kv_7Y
+
 - title: "Cultivating Developer-Centric DSLs"
   raw_title: RubyConf 2021 - Cultivating Developer-Centric DSLs by Jake Anderson
   speakers:
@@ -625,6 +630,7 @@
     Writing boilerplate code can be draining. Breaking things out into classes and modules doesn't always make this process more enjoyable either. At Weedmaps, we've developed a suite of Domain Specific Languages (DSLs) for the vast majority of our workflows. This includes things like query objects all the way to crawlers. Done right, these tools allow team members to accomplish more with less. Done wrong, team members would have been better off writing everything from scratch. This talk is meant for those who want to build better tooling around repetitive workflows. It's also for those that want to better understand how some of these tools work under the hood. Embrace the magic!
 
   video_id: 8VvgEQdp5YQ
+
 - title: "Rswag: Automated API Documentation"
   raw_title: "RubyConf 2021 - Rswag: Automated API Documentation by Sarah Reid"
   speakers:
@@ -638,10 +644,9 @@
     another? This talk is for you! We’ll explore all of these problems and discover
     how Rswag can solve them for you.
   video_id: 47PwEkVs2uc
+
 - title: "Just-in-Time Compiling Ruby Regexps on TruffleRuby"
-  raw_title:
-    RubyConf 2021 - Just-in-Time Compiling Ruby Regexps on TruffleRuby by
-    Benoit Daloze and Josef Haider
+  raw_title: RubyConf 2021 - Just-in-Time Compiling Ruby Regexps on TruffleRuby by Benoit Daloze and Josef Haider
   speakers:
     - Benoit Daloze
     - Josef Haider
@@ -656,10 +661,9 @@
     inline across languages, the Ruby code and the Regexp are optimized and compiled
     together for ultimate performance.
   video_id: JuVklIz1gts
+
 - title: Dismantling Dystopian Futures with Humane Factories
-  raw_title:
-    RubyConf 2021 - Dismantling Dystopian Futures with Humane Factories by
-    Anthony Navarre
+  raw_title: RubyConf 2021 - Dismantling Dystopian Futures with Humane Factories by Anthony Navarre
   speakers:
     - Anthony Navarre
   event_name: RubyConf 2021
@@ -668,10 +672,9 @@
     The terminal glowed a sickly pale green, reflecting in her lenses. “What do you mean, RecordInvalid?” she scoffed, and set to the task of debugging the factory. Hairs stood up on her neck as she realized the implications of her findings — she could practically smell the corrosion, but it was nobody’s fault. It was everyone’s fault. Data was long ago divorced from the human lives they were intended to improve. Dmitry bolted upright in a sweat. She was safe at home — it was all a dream, at least for now. There was still time. She started her morning routine, but breakfast was the last thing on her mind. She didn’t know all the factors, but she knew where to begin. Join me in this whimsical exploration of some not-so-whimsical tactics to put your test factories to work in some unconventional ways.
 
   video_id: aEEexQ7dESQ
+
 - title: "Workshop: Fundamentals of Joint Cognitive Systems"
-  raw_title:
-    "RubyConf 2021 - Workshop: Fundamentals of Joint Cognitive Systems by
-    Laura Maguire, John Allspaw"
+  raw_title: "RubyConf 2021 - Workshop: Fundamentals of Joint Cognitive Systems by Laura Maguire, John Allspaw"
   speakers:
     - Laura Maguire
     - John Allspaw
@@ -681,10 +684,9 @@
     If we take the wayback machine to the time before there was Resilience Engineering, we find Cognitive Systems Engineering. Central to CSE is the concept of Joint Cognitive Systems - human/machine teaming based on principles of shared cognitive efforts, not simply dividing the work to be done across humans and machines. This thought-provoking and interactive workshop will give you a whole new lens to think about your work and the problems you face working on and with highly automated systems using a combination of lecture, discussion and hands on exercises.
 
   video_id: 4uWjAMqmxQw
+
 - title: "Workshop: Intentional Team Building"
-  raw_title:
-    "RubyConf 2021 - Workshop: Intentional Team Building by Alex Robinson,
-    Will Mitchell"
+  raw_title: "RubyConf 2021 - Workshop: Intentional Team Building by Alex Robinson, Will Mitchell"
   speakers:
     - Alex Robinson
     - Will Mitchell
@@ -694,10 +696,9 @@
     How do you build effective teams? What are the determining factors? In this collaborative workshop we will explore how to identify the values underpinning your team dynamics and explore techniques to cultivate effective teams built around intentional values.
 
   video_id: yATlt3hYvDk
+
 - title: "Soup to Nuts: Build a video game using Ruby!"
-  raw_title:
-    "RubyConf 2021 - Soup to Nuts: Build a video game using Ruby! by Amir
-    Rajan"
+  raw_title: "RubyConf 2021 - Soup to Nuts: Build a video game using Ruby! by Amir Rajan"
   speakers:
     - Amir Rajan
   event_name: RubyConf 2021
@@ -710,6 +711,7 @@
     You’ll be given a free, unrestricted commercial license of DragonRuby Game Toolkit (this is the game engine we’ll be using during the workshop).
 
   video_id: jVen5yzrNeY
+
 - title: "Workshop: Run your first game day"
   raw_title: "RubyConf 2021 - Workshop: Run your first game day by Thai Wood"
   speakers:
@@ -722,10 +724,9 @@
     You'll learn how to run table top game days, including how to set them up, how to design scenarios and how to encourage participation, all with techniques supported by real word experience and supported by research.
 
   video_id: xqye3wo68uc
+
 - title: "RubyCond 2021 - Workshop: Tackling Technical Debt: An Analytical Approach"
-  raw_title:
-    "RubyCond 2021 - Workshop: Tackling Technical Debt: An Analytical Approach
-    by Chelsea Troy"
+  raw_title: "RubyCond 2021 - Workshop: Tackling Technical Debt: An Analytical Approach by Chelsea Troy"
   speakers:
     - Chelsea Troy
   event_name: RubyConf 2021
@@ -736,10 +737,9 @@
     In this workshop, you will learn how to measure tech debt and address the areas of highest need first. You’ll learn to identify high leverage code changes and separate those from renovations. You’ll also learn about the skills tech teams can use to prevent and reduce tech debt.
 
   video_id: DwW7zlNulbQ
+
 - title: "All comments must be haiku! Custom linting with RuboCop"
-  raw_title:
-    RubyConf 2021 - All comments must be haiku! Custom linting with RuboCop
-    by Scott Moore, Kari Silva
+  raw_title: RubyConf 2021 - All comments must be haiku! Custom linting with RuboCop by Scott Moore, Kari Silva
   speakers:
     - Scott Moore
     - Kari Silva
@@ -755,10 +755,9 @@
     how to build powerful custom tooling to enforce almost any standard we can think of!
 
   video_id: z9SwpkYa_Gc
+
 - title: "Clean RSpec: A Workshop on Ruby Testing Craftsmanship"
-  raw_title:
-    "RubyConf 2021 - Clean RSpec: A Workshop on Ruby Testing Craftsmanship
-    by Jesse Spevack"
+  raw_title: "RubyConf 2021 - Clean RSpec: A Workshop on Ruby Testing Craftsmanship by Jesse Spevack"
   speakers:
     - Jesse Spevack
   event_name: RubyConf 2021
@@ -767,10 +766,9 @@
     Testing has been a feature of the Ruby community for a long time. Why then are our spec files often so incomprehensible? In this workshop, I will share some ground rules for writing maintainable tests that will ensure that new teammates along with future-you can understand your test suite. We will use the RSpec testing framework to introduce several testing code-smells. For each smell, I will provide a demonstration on how to refactor the test along with time to practice for workshop participants. This workshop is geared towards anyone looking to hone their Ruby testing craft.
 
   video_id: e4HORZgt8-U
+
 - title: "Workshop: How to use flamegraphs to find performance problems"
-  raw_title:
-    "RubyConf 2021 - Workshop: How to use flamegraphs to find performance
-    problems by Jade Dickinson"
+  raw_title: "RubyConf 2021 - Workshop: How to use flamegraphs to find performance problems by Jade Dickinson"
   speakers:
     - Jade Dickinson
   event_name: RubyConf 2021
@@ -779,10 +777,9 @@
     Slow Ruby code can be a puzzle, but it doesn’t have to be that way. In this workshop you will see how fun it can be to use flamegraphs to find performance problems. You’ll get the most out of this session if you know you have slow areas in your Ruby application, and would like to learn how to find the code responsible.
 
   video_id: ALkoG4xNgD0
+
 - title: "Workshop: A Gentle Introduction to Docker for Rubyists"
-  raw_title:
-    "RubyConf 2021 - Workshop: A Gentle Introduction to Docker for Rubyists
-    by Jason Swett"
+  raw_title: "RubyConf 2021 - Workshop: A Gentle Introduction to Docker for Rubyists by Jason Swett"
   speakers:
     - Jason Swett
   event_name: RubyConf 2021
@@ -791,6 +788,7 @@
     Have you heard about how great Docker supposedly is, but you're not sure exactly what all the fuss is about, or even what Docker is or why people use it? Or maybe you understand what Docker is but you've never worked with it before. In this workshop, you'll learn exactly what Docker is and why you'd want to use it, and you'll come away with your own fully Dockerized Ruby application.
 
   video_id: 9hVNjr_iHko
+
 - title: "Surprise! Inspiring Resilience"
   raw_title: RubyConf 2021 - Surprise! Inspiring Resilience by Cory Watson
   speakers:
@@ -802,6 +800,7 @@
 
     In this talk we'll bring examples from outside tech. We’re talking aircraft carriers, race cars, priceless works of art, and hard-fought wisdom from across the accomplishments of humans and even nature itself. Join me in marveling at they ways things keep working, and we’ll get some cool ideas for how to create resilience in your organization or systems.
   video_id: 0Fr8Kpe8Ro4
+
 - title: Picoruby and PRK Firmware
   raw_title: "RubyConf 2021 - Picoruby and PRK Firmware by Hitoshi Hasumi"
   speakers:
@@ -815,6 +814,7 @@
 
     The ultimate goal is certainly not a small one --- let's make Ruby comparable to projects such as MicroPython, CircuitPython or Lua in terms of viability as a scripting language on Board!
   video_id: ZfIz34PK4zs
+
 - title: "Using Monads for Elegant Error Handling"
   raw_title: RubyConf 2021 - Using Monads for Elegant Error Handling by John Gallagher
   speakers:
@@ -828,10 +828,9 @@
 
     You'll refactor an existing app to use a functional style and see first hand how easy monads are to use and how they can make your code incredibly clean and expressive.
   video_id: Nkg8tKOZccU
+
 - title: "Why Did We Rewrite Our Main Product Four Times?"
-  raw_title:
-    RubyConf 2021 - Why Did We Rewrite Our Main Product Four Times? by Leon
-    Hu
+  raw_title: RubyConf 2021 - Why Did We Rewrite Our Main Product Four Times? by Leon Hu
   speakers:
     - Leon Hu
   event_name: RubyConf 2021
@@ -845,10 +844,9 @@
     complexity, we poured in countless hours to come up with the perfect design. We
     have a thing or two to share about solving a seemingly trivial problem.'
   video_id: w8q_Uymv-bM
+
 - title: How to stop breaking other people's things
-  raw_title:
-    RubyConf 2021 - How to stop breaking other people's things by Lisa Karlin
-    Curtis
+  raw_title: RubyConf 2021 - How to stop breaking other people's things by Lisa Karlin Curtis
   speakers:
     - Lisa Karlin Curtis
   event_name: RubyConf 2021
@@ -858,10 +856,9 @@
 
     This talk will cover how you can: (a) Get really good at identifying what changes might break someone’s integration (b) Help your API consumers to build integrations that are resilient to these kinds of changes (c) Release potentially breaking changes as safely as possible
   video_id: rmixCWytaJ8
+
 - title: Harness the power of functions to build composable rack applications
-  raw_title:
-    RubyConf 2021 - Harness the power of functions to build composable rack
-    applications by Marc Busqué
+  raw_title: RubyConf 2021 - Harness the power of functions to build composable rack applications by Marc Busqué
   speakers:
     - Marc Busqué
   event_name: RubyConf 2021
@@ -874,6 +871,7 @@
     by plugging small process units that progressively create a response from a given
     request.
   video_id: Tv6_RAM4S6k
+
 - title: Engineering at Root
   raw_title: RubyConf 2021 - Engineering at Root by Maria Moore
   speakers:
@@ -887,10 +885,9 @@
 
     Maria will share more about how we built an insurance company from scratch and how our Engineering teams continue to unbreak the insurance industry every day.
   video_id: O15ifnV0UiI
-- title: "Control methods like a pro: A guide to Ruby's awesomeness, ..."
-  raw_title:
-    "RubyConf 2021 - Control methods like a pro: A guide to Ruby's awesomeness,
-    ... by Masafumi Okura"
+
+- title: "Control methods like a pro: A guide to Ruby's awesomeness, a.k.a metaprogramming"
+  raw_title: "RubyConf 2021 - Control methods like a pro: A guide to Ruby's awesomeness,... by Masafumi Okura"
   speakers:
     - Masafumi Okura
   event_name: RubyConf 2021
@@ -900,10 +897,9 @@
 
     Do you know that methods are objects in Ruby? We can manipulate method objects just like other object, meaning that we can store them in variables, get information from them and wrap them in other objects like Proc. In this talk, I'll show a real-world example of manipulating methods. I'll cover from the basic such as listing available methods and getting a method object to the difference between Method and UnboundMethod and redefining methods with original method object.
   video_id: fJsoWMFypxU
+
 - title: "Minimize Your Circus Factor: Building resilient teams"
-  raw_title:
-    "RubyConf 2021 - Minimize Your Circus Factor: Building resilient teams
-    by Mercedes Bernard"
+  raw_title: "RubyConf 2021 - Minimize Your Circus Factor: Building resilient teams by Mercedes Bernard"
   speakers:
     - Mercedes Bernard
   event_name: RubyConf 2021
@@ -913,6 +909,7 @@
 
     After a year+ in a pandemic, many are considering taking new roles or extended PTO. It's more important than ever to invest in minimizing our "circus factor" and building resilient teams so that everyone can unplug and do what's best for them with as little stress as possible. In this talk, we'll discuss low-friction changes you can make today so that if you join the circus tomorrow your team is empowered and enabled for continued success.
   video_id: jBMSWBND0WU
+
 - title: "Managing Out: Strategies for Leveling Up"
   raw_title: "RubyConf 2021 - Managing Out: Strategies for Leveling Up by Mina Slater"
   speakers:
@@ -929,10 +926,9 @@
     disciplines of Design and Product and externally with stakeholders and/or product
     owners.'
   video_id: fKbO0RRdx6w
+
 - title: Hello, computer. Writing Ruby with voice recognition
-  raw_title:
-    RubyConf 2021 - Hello, computer. Writing Ruby with voice recognition
-    by Nat Budin
+  raw_title: RubyConf 2021 - Hello, computer. Writing Ruby with voice recognition by Nat Budin
   speakers:
     - Nat Budin
   event_name: RubyConf 2021
@@ -942,6 +938,7 @@
 
     When my finger was injured last year, I had a long recovery period, and during that time, I learned to code using voice recognition software. In this talk, I’ll tell the whole story and demo the tool I learned.
   video_id: g-xnh8mszQU
+
 - title: Optimizing Ruby's Memory Layout
   raw_title: RubyConf 2021 - Optimizing Ruby's Memory Layout by Peter Zhu & Matt Valentine-House
   speakers:
@@ -954,6 +951,7 @@
 
     Join us as we explore how our Variable Width Allocation project will move system heap memory into Ruby heap memory, reducing system heap allocations and giving us finer control of the memory layout to optimize for performance.
   video_id: 3c7ijPD6Jlk
+
 - title: Beware the Dreaded Dead End!!
   raw_title: RubyConf 2021 - Beware the Dreaded Dead End!! by Richard Schneeman
   speakers:
@@ -966,6 +964,7 @@
     it. In this talk we'll cover lexing, parsing, and indentation informed syntax
     tree search that power that dead_end Ruby library.
   video_id: 7CTn2m1ME5A
+
 - title: Dungeons and Collaboration
   raw_title: RubyConf 2021 - Dungeons and Collaboration by Rolen Le
   speakers:
@@ -977,10 +976,9 @@
 
     Having played Dungeons and Dragons for almost a decade and playing remotely for half that time, I have learned lessons that have taught me how to interact as a developer on a distributed team. From general online etiquette to building great teams, I will discuss tips and tricks of roleplaying that can make someone a better coworker.
   video_id: 9-7OCakUEIw
+
 - title: Perceptual Learning == More Ruby Experts?
-  raw_title:
-    RubyConf 2021 - Perceptual Learning == More Ruby Experts? by Stefanni
-    Brasil
+  raw_title: RubyConf 2021 - Perceptual Learning == More Ruby Experts? by Stefanni Brasil
   speakers:
     - Stefanni Brasil
   event_name: RubyConf 2021
@@ -992,10 +990,9 @@
 
     In this talk, we'll learn how to create expertise based on PL's techniques, and how you can apply them to become an expert Ruby developer.
   video_id: 5lJDjciN-us
+
 - title: The Intro to Abstraction I Wish I'd Received
-  raw_title:
-    RubyConf 2021 - The Intro to Abstraction I Wish I'd Received by Stephanie
-    Minn
+  raw_title: RubyConf 2021 - The Intro to Abstraction I Wish I'd Received by Stephanie Minn
   speakers:
     - Stephanie Minn
   event_name: RubyConf 2021
@@ -1005,10 +1002,9 @@
 
     We’ll also dig into a real-world example of fighting a troublesome abstraction and learn strategies for identifying when one no longer works for you—the first step toward imagining new abstractions for your code to take shape.
   video_id: m0dC5RmxcFk
+
 - title: Optimizing Production Performance with MRI JIT
-  raw_title:
-    RubyConf 2021 - Optimizing Production Performance with MRI JIT by Takashi
-    Kokubun
+  raw_title: RubyConf 2021 - Optimizing Production Performance with MRI JIT by Takashi Kokubun
   speakers:
     - Takashi Kokubun
   event_name: RubyConf 2021
@@ -1018,10 +1014,9 @@
 
     In this talk, you'll learn some tricks to make sure it happens on your production application. Get the easy speedup of your application for free!
   video_id: MpHczwoVNSU
+
 - title: Parallel testing with Ractors - Putting CPU's to work
-  raw_title:
-    RubyConf 2021 - Parallel testing with Ractors - Putting CPU's to work
-    by Vinicius Stock
+  raw_title: RubyConf 2021 - Parallel testing with Ractors - Putting CPU's to work by Vinicius Stock
   speakers:
     - Vinicius Stock
   event_name: RubyConf 2021
@@ -1031,6 +1026,7 @@
 
     Let’s find the answers to these questions by building a test framework built on Ractors, from scratch. We’ll compare the current solutions for parallelization and what advantages or limitations Ractors bring when used in this context.
   video_id: rdwvvDMmsAQ
+
 - title: Debugging Product Teams
   raw_title: RubyConf 2021 - Debugging Product Teams by Amy Newell
   speakers:
@@ -1046,10 +1042,9 @@
 
     “Debugging” a team is a lot like caring for a complex distributed software system: it’s less about fixes, and more about observation, hypotheses, intervention, and more observation. Whatever your role, these are skills you can learn and apply right now, on your own teams.
   video_id: CoaYjkVRhiE
+
 - title: This is not a talk about airplane crashes
-  raw_title:
-    RubyConf 2021 - This is not a talk about airplane crashes by Andromeda
-    Yelton
+  raw_title: RubyConf 2021 - This is not a talk about airplane crashes by Andromeda Yelton
   speakers:
     - Andromeda Yelton
   event_name: RubyConf 2021
@@ -1065,6 +1060,7 @@
 
     (CW: injury, death.)
   video_id: 9Z58SSn6ZXo
+
 - title: Async Ruby
   raw_title: RubyConf 2021 - Async Ruby by Bruno Sutic
   speakers:
@@ -1076,6 +1072,7 @@
 
     This talk is suitable for both beginners and experts, and is relevant for you if you're making web requests in ruby. It will introduce you to some the most impressive async features and explain its core concepts.
   video_id: LvfQTFNgYbI
+
 - title: A History of Compiling Ruby
   raw_title: RubyConf 2021 - A History of Compiling Ruby by Chris Seaton
   speakers:
@@ -1090,10 +1087,9 @@
     all? It turns out that we can trace the major advances in compiler research from
     the last couple of decades through Ruby!
   video_id: Idy9fryWGS8
+
 - title: Golf Scripting with Ruby - Helping Santa Schedule Christmas
-  raw_title:
-    RubyConf 2021 - Golf Scripting with Ruby - Helping Santa Schedule Christmas
-    by Ely Alvarado
+  raw_title: RubyConf 2021 - Golf Scripting with Ruby - Helping Santa Schedule Christmas by Ely Alvarado
   speakers:
     - Ely Alvarado
   event_name: RubyConf 2021
@@ -1107,10 +1103,9 @@
     to make it as short as possible. You’ll learn a few secret shortcuts built into
     Ruby that you probably don’t know about."
   video_id: d4QwyojCbX0
-- title: "Black Swan Events in Open Source: That time..."
-  raw_title:
-    "RubyConf 2021 - Black Swan Events in Open Source: That time... by Julia
-    Ferraioli and Amanda Casari"
+
+- title: "Black Swan Events in Open Source: That time we broke the internet"
+  raw_title: "RubyConf 2021 - Black Swan Events in Open Source: That time... by Julia Ferraioli and Amanda Casari"
   speakers:
     - Julia Ferraioli
     - Amanda Casari
@@ -1121,6 +1116,7 @@
 
     This talk will explore a series of events in open source history, some of which came as a surprise to users of the open source project and industry as a whole, had a wide and long-lasting impact on technology, or was inappropriately rationalized after the fact with the benefit of hindsight.
   video_id: bF4i7t7hpI4
+
 - title: "debug.gem: Ruby's new debug functionality"
   raw_title:
     "RubyConf 2021 - debug.gem: Ruby's new debug functionality by Koichi
@@ -1142,6 +1138,7 @@
     And more useful features!
     In this talk, I'll introduce useful features of this new debugger and tips for Ruby development.
   video_id: s74tfFk2txM
+
 - title: Beyond Blameless
   raw_title: RubyConf 2021- Beyond Blameless by Rein Henrichs
   speakers:
@@ -1158,10 +1155,9 @@
     baby of learning out with the bathwater of blaming, we also lose opportunities
     to become more resilient.
   video_id: l2CdjZUAmb0
+
 - title: The Intentional Plan for Intersectionality
-  raw_title:
-    RubyConf 2021 - The Intentional Plan for Intersectionality by Shailvi
-    Wakhlu
+  raw_title: RubyConf 2021 - The Intentional Plan for Intersectionality by Shailvi Wakhlu
   speakers:
     - Shailvi Wakhlu
   event_name: RubyConf 2021
@@ -1173,6 +1169,7 @@
     nationality, disability, education, etc. This talk highlights the fierce urgency
     of now, in planning for intersectionality.
   video_id: ua0TL4zRAIU
+
 - title: Programming with Something
   raw_title: RubyConf 2021 - Programming with Something by Tom Stuart
   speakers:
@@ -1186,10 +1183,9 @@
     to store executable code as data in Ruby, and explore how to write different kinds
     of programs that process it.
   video_id: KwMuTJ_3Ljg
+
 - title: Enjoy Ruby Programming in IDE and TypeProf
-  raw_title:
-    RubyConf 2021 - Enjoy Ruby Programming in IDE and TypeProf by Yusuke
-    Endoh
+  raw_title: RubyConf 2021 - Enjoy Ruby Programming in IDE and TypeProf by Yusuke Endoh
   speakers:
     - Yusuke Endoh
   event_name: RubyConf 2021
@@ -1204,6 +1200,7 @@
     which is a type analysis tool bundled in Ruby 3.0. In this talk, we demonstrate
     our prototype, and present its roadmap.
   video_id: 6lfAJeGHbfY
+
 - title: "Whimsy: Art, Beats & Code"
   raw_title: "RubyConf 2021 - Whimsy: Art, Beats & Code by Rachel Green"
   speakers:
@@ -1212,6 +1209,7 @@
   published_at: "2022-08-09"
   description: ""
   video_id: 06xEs0py8qo
+
 - title: "Whimsy: Babies just want to have fun"
   raw_title: "RubyConf 2021 - Whimsy: Babies just want to have fun by Ali Ibrahim"
   speakers:
@@ -1220,17 +1218,17 @@
   published_at: "2022-08-09"
   description: ""
   video_id: hLl-uQFh3fA
+
 - title: "Whimsy: Put That Test Down! You don't know where it's been"
-  raw_title:
-    "RubyConf 2021 - Whimsy: Put That Test Down! You don't know where it's
-    been by Michael Dalessio"
+  raw_title: "RubyConf 2021 - Whimsy: Put That Test Down! You don't know where it's been by Michael Dalessio"
   speakers:
     - Michael Dalessio
   event_name: RubyConf 2021
   published_at: "2022-08-09"
   description: ""
   video_id: cWzsmOw-AFw
-- title: "Keynote: Beyond Ruby3.0 by Yukihiro (Matz) Matsumoto"
+
+- title: "Keynote: Beyond Ruby3.0"
   raw_title: "RubyConf 2021 - Keynote: Beyond Ruby3.0 by Yukihiro (Matz) Matsumoto"
   speakers:
     - Yukihiro Matsumoto

--- a/data/rubyconf/rubyconf-2022-mini/videos.yml
+++ b/data/rubyconf/rubyconf-2022-mini/videos.yml
@@ -2,7 +2,7 @@
   raw_title: "RubyConf Mini 2022: Weaving and seaming mocks by Vladimir Dementyev"
   speakers:
     - Vladimir Dementyev
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     To mock or not mock is an important question, but let's leave it apart and admit that we, Rubyists, use mocks in our tests.
@@ -16,7 +16,7 @@
   raw_title: "RubyConf Mini 2022: Here Be Dragons: The Hidden Gems of Tech Debt by Ernesto Tagwerker"
   speakers:
     - Ernesto Tagwerker
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     How do you find the most unmaintainable code in your codebase? What will you prioritize in your next technical debt spike, and why?
@@ -28,7 +28,7 @@
   raw_title: "RubyConf Mini 2022: Looking Into Peephole Optimizations by Maple Ong"
   speakers:
     - Maple Ong
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Did you know Ruby optimizes your code before executing it? If so, ever wonder how that works? The Ruby VM performs various optimizations on bytecode before executing them, one of them called peephole optimizations. Let’s learn about how some peephole optimizations work and how these small changes impact the execution of Ruby’s bytecode. Do these small changes make any impact on the final runtime? Let's find out - experience reading bytecode is not needed!
@@ -37,8 +37,8 @@
 - title: How We Implemented Salary Transparency (And Why It Matters)
   raw_title: "RubyConf Mini: How We Implemented Salary Transparency (And Why It Matters) by Hilary Stohs Krause"
   speakers:
-    - Hilary Stohs Krause
-  event_name: "RubyConf 2022: Mini and Houston"
+    - Hilary Stohs-Krause
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Depending on where you live, money can be a prickly topic in the workplace; however, survey after survey shows it’s also a conversation many employees actively want started. Data also shows that transparency around wages increases trust and job satisfaction and improves gender and racial salary equity.
@@ -51,7 +51,7 @@
   speakers:
     - Chelsea Kaufman
     - Adam Cuppy
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Starting an internship doesn’t have to reduce your team's progress. On the contrary, a quality internship can benefit interns and senior folks. And, it doesn't take much to set up and start. We've done over 100!
@@ -63,7 +63,7 @@
   raw_title: "RubyConf Mini 2022: Knowing When To Walk Away by Lindsay Kelly"
   speakers:
     - Lindsay Kelly
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Picture this: the job you've always wanted. Doing exactly the kind of work you want. Having great coworkers and management. But then something shifts, and the dream becomes closer to a nightmare. How do you identify these things happening? How do you raise concerns in an appropriate way? And as a last resort, how do you know when it's the right choice to walk away?
@@ -73,7 +73,7 @@
   raw_title: "RubyConf Mini 2022: Functional programming for fun and profit!! by Jenny Shih"
   speakers:
     - Jenny Shih
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Functional programming brings you not just fun, but also profit!
@@ -87,7 +87,7 @@
   raw_title: "RubyConf Mini 2022: Teaching Ruby to Count by Joël Quenneville"
   speakers:
     - Joël Quenneville
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Ruby has some of the best tooling in the business for working with iteration and data series. By leveraging its full power, you can build delightful interfaces for your objects.
@@ -100,7 +100,7 @@
   speakers:
     - Alan Ridlehoover
     - Fito von Zastrow
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Mechanical coffee machines are amazing! You drop in a coin, listen for the clink, make a selection, and the machine springs to life, hissing, clicking, and whirring. Then the complex mechanical ballet ends, splashing that glorious, aromatic liquid into the cup. Ah! C’est magnifique!
@@ -112,7 +112,7 @@
   raw_title: "RubyConf Mini 2022: We Need Someone Technical on the Call by Brittany Martin"
   speakers:
     - Brittany Martin
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     A DM. The dreaded message. “They want someone technical on the call.”
@@ -124,7 +124,7 @@
   raw_title: "RubyConf Mini 2022: Making .is_a? Fast by John Hawthorn"
   speakers:
     - John Hawthorn
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Until Ruby 3.2 the `is_a?` method can be a surprising performance bottleneck. It be called directly or through its various synonyms like case statements, rescue statements, protected methods, `Module#===` and more! Recently `is_a?` and its various flavours have been optimized and it's now faster and runs in constant time. Join me in the journey of identifying it as a bottleneck in production, implementing the optimization, squashing bugs, and finally turning it into assembly language in YJIT.
@@ -134,7 +134,7 @@
   raw_title: "RubyConf Mini 2022: From Start to Published, Create a game with Ruby! by Cameron Gose"
   speakers:
     - Cameron Gose
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: We'll be building a game in Ruby from start to finish using the DragonRuby GameToolkit. Finally we'll publish it so that your new creation can be shared.
   video_id: -dz9KGYMT24
@@ -143,7 +143,7 @@
   raw_title: "RubyConf Mini 2022: Anyone Can Play Guitar (With Ruby) by Kevin Murphy"
   speakers:
     - Kevin Murphy
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     I've got the blues. I've been looking for the perfect guitar tone, but haven't found it. To amp up my mood, let's teach a computer to play the guitar through an amplifier.
@@ -156,7 +156,7 @@
   speakers:
     - Rose Wiegley
     - Ufuk Kayserilioglu
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: Curious about Shopify’s relationship with Ruby? Got questions on projects Shopify Ruby on Rails Engineers are currently working on? Join Rose Wiegley (Sr Staff Developer), Ufuk Kayserilioglu (Production Engineering Manager), and other Shopify Engineers for a 30-minute office hours session dedicated to answering your questions on Ruby, Shopify’s relationship with Ruby, and life at Shopify!
   video_id: 37DkMimLG4A
@@ -165,7 +165,7 @@
   raw_title: "RubyConf Mini 2022: Keynote: Learning DNS by Julia Evans"
   speakers:
     - Julia Evans
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: ""
   video_id: HoG2T0aJvfY
@@ -174,7 +174,7 @@
   raw_title: "RubyConf Mini 2022: Zen and the Art of Incremental Automation by Aji Slater"
   speakers:
     - Aji Slater
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Automation doesn’t have to be all or nothing. Automating manual processes is a practice that one can employ via simple principles. Broad enough to be applied to a range of workflows, flexible enough to be tailored to an individual’s personal development routines; these principles are not in themselves complex, and can be performed regularly in the day to day of working in a codebase.
@@ -185,7 +185,7 @@
   raw_title: "RubyConf Mini 2022: Syntax Tree by Kevin Newton"
   speakers:
     - Kevin Newton
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: Syntax Tree is a new toolkit for interacting with the Ruby parse tree. It can be used to analyze, inspect, debug, and format your Ruby code. In this talk we'll walk through how it works, how to use it in your own applications, and the exciting future possibilities enabled by Syntax Tree.
   video_id: Ieq6SKtYJD4
@@ -193,7 +193,7 @@
 - title: Lightning Talks
   raw_title: "RubyConf Mini 2022: Lightning Talks"
   speakers: []
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: ""
   video_id: IfzO_yyiYmw
@@ -202,7 +202,7 @@
   raw_title: "RubyConf Mini 2022: Who Wants to be a Ruby Engineer? by Drew Bragg"
   speakers:
     - Drew Bragg
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Welcome to the Ruby game show where one lucky contestant tries to guess the output of a small bit of Ruby code. Sound easy? Here's the challenge: the snippets come from some of the weirdest parts of the Ruby language. The questions aren't easy. Get enough right to be crowned a (some sort of something) Ruby Engineer and win a fabulous, mysterious prize.
@@ -212,7 +212,7 @@
   raw_title: "RubyConf Mini 2022: Keynote by Barbara Tannenbaum"
   speakers:
     - Barbara Tannenbaum
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: ""
   video_id: JpimJspmess
@@ -221,7 +221,7 @@
   raw_title: "RubyConf Mini 2022: Solo: Building Successful Web Apps By Your Lonesome by Jeremy Smith"
   speakers:
     - Jeremy Smith
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Whether by choice or by circumstance, you may find yourself developing a web application alone. Congratulations! You've got the house to yourself and no one telling you what to do. But at the same time, there's no one to share the burden or make up for your shortcomings. How do you build well and ensure project success? We'll look at the pros and cons of working alone, what kinds of projects are well-suited to solo development, strategies for professional growth, and development and operational processes that will save you time and help you sleep better at night.
@@ -231,7 +231,7 @@
   raw_title: "RubyConf Mini 2022: Empathetic Pair Programming with Nonviolent Communication by Stephanie Minn"
   speakers:
     - Stephanie Minn
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Pair programming is intimate. It’s the closest collaboration we do as software developers. When it goes well, it feels great! But when it doesn’t, you might be left feeling frustrated, discouraged, or withdrawn.
@@ -243,7 +243,7 @@
   raw_title: "RubyConf Mini 2022: TDD on the Shoulders of Giants by Jared Norman"
   speakers:
     - Jared Norman
-  event_name: "RubyConf 2022: Mini and Houston"
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Getting started with TDD is hard enough without having to also navigate a programming language barrier. Many of the best books on testing focus on very different languages like Java, making it tricky to apply their advice in Ruby, especially if you're new to testing. I'll go through the most important practices and techniques that we can pull from the testing literature and show how they can be applied in your day-to-day Ruby development. You'll learn how to make the most of testing in Ruby using the patterns, practices, and techniques that popularized TDD in the first place.

--- a/data/rubyconf/rubyconf-2022-mini/videos.yml
+++ b/data/rubyconf/rubyconf-2022-mini/videos.yml
@@ -2,7 +2,7 @@
   raw_title: "RubyConf Mini 2022: Weaving and seaming mocks by Vladimir Dementyev"
   speakers:
     - Vladimir Dementyev
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     To mock or not mock is an important question, but let's leave it apart and admit that we, Rubyists, use mocks in our tests.
@@ -16,7 +16,7 @@
   raw_title: "RubyConf Mini 2022: Here Be Dragons: The Hidden Gems of Tech Debt by Ernesto Tagwerker"
   speakers:
     - Ernesto Tagwerker
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     How do you find the most unmaintainable code in your codebase? What will you prioritize in your next technical debt spike, and why?
@@ -28,7 +28,7 @@
   raw_title: "RubyConf Mini 2022: Looking Into Peephole Optimizations by Maple Ong"
   speakers:
     - Maple Ong
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Did you know Ruby optimizes your code before executing it? If so, ever wonder how that works? The Ruby VM performs various optimizations on bytecode before executing them, one of them called peephole optimizations. Let’s learn about how some peephole optimizations work and how these small changes impact the execution of Ruby’s bytecode. Do these small changes make any impact on the final runtime? Let's find out - experience reading bytecode is not needed!
@@ -38,7 +38,7 @@
   raw_title: "RubyConf Mini: How We Implemented Salary Transparency (And Why It Matters) by Hilary Stohs Krause"
   speakers:
     - Hilary Stohs-Krause
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Depending on where you live, money can be a prickly topic in the workplace; however, survey after survey shows it’s also a conversation many employees actively want started. Data also shows that transparency around wages increases trust and job satisfaction and improves gender and racial salary equity.
@@ -51,7 +51,7 @@
   speakers:
     - Chelsea Kaufman
     - Adam Cuppy
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Starting an internship doesn’t have to reduce your team's progress. On the contrary, a quality internship can benefit interns and senior folks. And, it doesn't take much to set up and start. We've done over 100!
@@ -63,7 +63,7 @@
   raw_title: "RubyConf Mini 2022: Knowing When To Walk Away by Lindsay Kelly"
   speakers:
     - Lindsay Kelly
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Picture this: the job you've always wanted. Doing exactly the kind of work you want. Having great coworkers and management. But then something shifts, and the dream becomes closer to a nightmare. How do you identify these things happening? How do you raise concerns in an appropriate way? And as a last resort, how do you know when it's the right choice to walk away?
@@ -73,7 +73,7 @@
   raw_title: "RubyConf Mini 2022: Functional programming for fun and profit!! by Jenny Shih"
   speakers:
     - Jenny Shih
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Functional programming brings you not just fun, but also profit!
@@ -87,7 +87,7 @@
   raw_title: "RubyConf Mini 2022: Teaching Ruby to Count by Joël Quenneville"
   speakers:
     - Joël Quenneville
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Ruby has some of the best tooling in the business for working with iteration and data series. By leveraging its full power, you can build delightful interfaces for your objects.
@@ -100,7 +100,7 @@
   speakers:
     - Alan Ridlehoover
     - Fito von Zastrow
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Mechanical coffee machines are amazing! You drop in a coin, listen for the clink, make a selection, and the machine springs to life, hissing, clicking, and whirring. Then the complex mechanical ballet ends, splashing that glorious, aromatic liquid into the cup. Ah! C’est magnifique!
@@ -112,7 +112,7 @@
   raw_title: "RubyConf Mini 2022: We Need Someone Technical on the Call by Brittany Martin"
   speakers:
     - Brittany Martin
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     A DM. The dreaded message. “They want someone technical on the call.”
@@ -124,7 +124,7 @@
   raw_title: "RubyConf Mini 2022: Making .is_a? Fast by John Hawthorn"
   speakers:
     - John Hawthorn
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Until Ruby 3.2 the `is_a?` method can be a surprising performance bottleneck. It be called directly or through its various synonyms like case statements, rescue statements, protected methods, `Module#===` and more! Recently `is_a?` and its various flavours have been optimized and it's now faster and runs in constant time. Join me in the journey of identifying it as a bottleneck in production, implementing the optimization, squashing bugs, and finally turning it into assembly language in YJIT.
@@ -134,7 +134,7 @@
   raw_title: "RubyConf Mini 2022: From Start to Published, Create a game with Ruby! by Cameron Gose"
   speakers:
     - Cameron Gose
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: We'll be building a game in Ruby from start to finish using the DragonRuby GameToolkit. Finally we'll publish it so that your new creation can be shared.
   video_id: -dz9KGYMT24
@@ -143,7 +143,7 @@
   raw_title: "RubyConf Mini 2022: Anyone Can Play Guitar (With Ruby) by Kevin Murphy"
   speakers:
     - Kevin Murphy
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     I've got the blues. I've been looking for the perfect guitar tone, but haven't found it. To amp up my mood, let's teach a computer to play the guitar through an amplifier.
@@ -156,7 +156,7 @@
   speakers:
     - Rose Wiegley
     - Ufuk Kayserilioglu
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: Curious about Shopify’s relationship with Ruby? Got questions on projects Shopify Ruby on Rails Engineers are currently working on? Join Rose Wiegley (Sr Staff Developer), Ufuk Kayserilioglu (Production Engineering Manager), and other Shopify Engineers for a 30-minute office hours session dedicated to answering your questions on Ruby, Shopify’s relationship with Ruby, and life at Shopify!
   video_id: 37DkMimLG4A
@@ -165,7 +165,7 @@
   raw_title: "RubyConf Mini 2022: Keynote: Learning DNS by Julia Evans"
   speakers:
     - Julia Evans
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: ""
   video_id: HoG2T0aJvfY
@@ -174,7 +174,7 @@
   raw_title: "RubyConf Mini 2022: Zen and the Art of Incremental Automation by Aji Slater"
   speakers:
     - Aji Slater
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Automation doesn’t have to be all or nothing. Automating manual processes is a practice that one can employ via simple principles. Broad enough to be applied to a range of workflows, flexible enough to be tailored to an individual’s personal development routines; these principles are not in themselves complex, and can be performed regularly in the day to day of working in a codebase.
@@ -185,7 +185,7 @@
   raw_title: "RubyConf Mini 2022: Syntax Tree by Kevin Newton"
   speakers:
     - Kevin Newton
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: Syntax Tree is a new toolkit for interacting with the Ruby parse tree. It can be used to analyze, inspect, debug, and format your Ruby code. In this talk we'll walk through how it works, how to use it in your own applications, and the exciting future possibilities enabled by Syntax Tree.
   video_id: Ieq6SKtYJD4
@@ -193,7 +193,7 @@
 - title: Lightning Talks
   raw_title: "RubyConf Mini 2022: Lightning Talks"
   speakers: []
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: ""
   video_id: IfzO_yyiYmw
@@ -202,17 +202,17 @@
   raw_title: "RubyConf Mini 2022: Who Wants to be a Ruby Engineer? by Drew Bragg"
   speakers:
     - Drew Bragg
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Welcome to the Ruby game show where one lucky contestant tries to guess the output of a small bit of Ruby code. Sound easy? Here's the challenge: the snippets come from some of the weirdest parts of the Ruby language. The questions aren't easy. Get enough right to be crowned a (some sort of something) Ruby Engineer and win a fabulous, mysterious prize.
   video_id: JoZo9uGuXQw
 
-- title: Keynote by Barbara Tannenbaum
+- title: "Keynote: Persuasive Communication"
   raw_title: "RubyConf Mini 2022: Keynote by Barbara Tannenbaum"
   speakers:
     - Barbara Tannenbaum
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: ""
   video_id: JpimJspmess
@@ -221,7 +221,7 @@
   raw_title: "RubyConf Mini 2022: Solo: Building Successful Web Apps By Your Lonesome by Jeremy Smith"
   speakers:
     - Jeremy Smith
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Whether by choice or by circumstance, you may find yourself developing a web application alone. Congratulations! You've got the house to yourself and no one telling you what to do. But at the same time, there's no one to share the burden or make up for your shortcomings. How do you build well and ensure project success? We'll look at the pros and cons of working alone, what kinds of projects are well-suited to solo development, strategies for professional growth, and development and operational processes that will save you time and help you sleep better at night.
@@ -231,7 +231,7 @@
   raw_title: "RubyConf Mini 2022: Empathetic Pair Programming with Nonviolent Communication by Stephanie Minn"
   speakers:
     - Stephanie Minn
-  event_name: RubyConf 2022 Mini
+  event_name: RubyConf Mini 2022
   published_at: "2023-02-28"
   description: |-
     Pair programming is intimate. It’s the closest collaboration we do as software developers. When it goes well, it feels great! But when it doesn’t, you might be left feeling frustrated, discouraged, or withdrawn.
@@ -239,12 +239,139 @@
     To navigate the vulnerability of sharing our keyboard and code, let’s learn about nonviolent communication (NVC), an established practice of deep listening to ourselves and others. We’ll cover real-life examples and how to apply the four tenets of NVC– observations, feelings, needs, and requests– to bring more joy and fulfillment the next time you pair.
   video_id: Tzlyrra00Z0
 
-- title: TDD on the Shoulders of Giants
-  raw_title: "RubyConf Mini 2022: TDD on the Shoulders of Giants by Jared Norman"
+- title: 'Sponsor Panel'
+  raw_title: 'RubyConf Mini 2022: Sponsor Panel'
+  speakers:
+    - Emily Samp
+    - Geoffrey Lessel
+    - Ryan Laughlin
+    - Ufuk Kayserilioglu
+    - Someone at Shopify
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: ''
+  video_id: exxUz9k03s4
+
+- title: 'Podcast Panel'
+  raw_title: 'RubyConf Mini 2022: Podcast Panel'
+  speakers:
+    - Brittany Martin
+    - Julie J
+    - Drew Bragg
+    - Joël Quenneville
+    - Andy Croll
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: ''
+  video_id: gOq7PJ-0ngA
+
+- title: 'Who Wants to be a Ruby Engineer?'
+  raw_title: 'RubyConf Mini 2022: Who Wants to be a Ruby Engineer? by Drew Bragg'
+  speakers:
+    - Drew Bragg
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: 'Welcome to the Ruby game show where one lucky contestant tries to
+    guess the output of a small bit of Ruby code. Sound easy? Here''s the challenge:
+    the snippets come from some of the weirdest parts of the Ruby language.  The questions
+    aren''t easy. Get enough right to be crowned a (some sort of something) Ruby Engineer
+    and win a fabulous, mysterious prize.'
+  video_id: JoZo9uGuXQw
+
+- title: 'TDD on the Shoulders of Giants'
+  raw_title: 'RubyConf Mini 2022: TDD on the Shoulders of Giants by Jared Norman'
   speakers:
     - Jared Norman
-  event_name: RubyConf 2022 Mini
-  published_at: "2023-02-28"
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: Getting started with TDD is hard enough without having to also navigate
+    a programming language barrier. Many of the best books on testing focus on very
+    different languages like Java, making it tricky to apply their advice in Ruby,
+    especially if you're new to testing. I'll go through the most important practices
+    and techniques that we can pull from the testing literature and show how they
+    can be applied in your day-to-day Ruby development. You'll learn how to make the
+    most of testing in Ruby using the patterns, practices, and techniques that popularized
+    TDD in the first place.
+  video_id: V8Sx8h7KZZQ
+
+- title: 'Crystal for Rubyists'
+  raw_title: 'RubyConf Mini 2022: Crystal for Rubyists by Kirk Haines'
+  speakers:
+    - Kirk Haines
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: Crystal is a Ruby-like compiled language that was originally built
+    using Ruby. Its syntax is remarkably similar to Ruby's, which generally makes
+    it straightforward for a Ruby programmer to start using Crystal. There are some
+    notable, and interesting differences between the languages, however. In this workshop,
+    let's learn some Crystal while we learn a little about the similarities and the
+    differences between the two languages.
+  video_id: YmsSmp4yjOc
+
+- title: 'RubyGems.org MFA: The Past, Present and Future'
+  raw_title: 'RubyConf Mini 2022: RubyGems.org MFA: The Past, Present and Future by Jenny Shen'
+  speakers:
+    - Jenny Shen
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: "What do Ruby’s rest-client, Python’s ctx, and npm’s ua-parser-js have
+    in common? \n\nThey all suffered account takeovers that were preventable. Attackers
+    aim to take control of a legitimate RubyGems.org user account and then use it
+    to upload malicious code. It might dial home. It might steal your keys. Perhaps
+    it will encrypt your disk. Or all of the above! Don’t you wish it couldn’t happen?\n\nMFA
+    prevents 99.9% of account takeover attacks. Come learn about MFA, the history
+    of RubyGems.org MFA support, the new MFA policy for top gems, and what’s on the
+    horizon."
+  video_id: YxVGMvwJsHQ
+
+- title: 'The Case Of The Vanished Variable - A Ruby Mystery Story'
+  raw_title: 'RubyConf Mini 2022: The Case Of The Vanished Variable - A Ruby Mystery Story by Nadia Odunayo'
+  speakers:
+    - Nadia Odunayo
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: After a stressful couple of days at work, Deirdre Bug is looking forward
+    to a quiet evening in. But her plans are thwarted when the phone rings. “I know
+    I’m the last person you want to hear from…but...I need your help!” Follow Deirdre
+    as she embarks on an adventure that features a looming Demo Day with serious prize
+    money up for grabs, a trip inside the walls of one of the Ruby community’s most
+    revered institutions, and some broken code that appears to be much more simple
+    than meets the eye.
+  video_id: a63aSvHu18c
+
+- title: 'Declare Victory with Class Macros'
+  raw_title: 'RubyConf Mini 2022: Splitwise Sponsor Session: Declare Victory with Class Macros by Jess Hottenstein'
+  speakers:
+    - Jess Hottenstein
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
   description: |-
-    Getting started with TDD is hard enough without having to also navigate a programming language barrier. Many of the best books on testing focus on very different languages like Java, making it tricky to apply their advice in Ruby, especially if you're new to testing. I'll go through the most important practices and techniques that we can pull from the testing literature and show how they can be applied in your day-to-day Ruby development. You'll learn how to make the most of testing in Ruby using the patterns, practices, and techniques that popularized TDD in the first place.
-  video_id: V8Sx8h7KZZ
+    How can we write classes that are easy to understand? How can we write Ruby in a declarative way? How can we use metaprogramming without introducing chaos?
+
+    Come learn the magic behind the first bit of metaprogramming we all encounter with Ruby - attr_reader. From there, we can learn how different gems use class macros to simplify our code. Finally, we’ll explore multiple ways we can make our own class macros to make our codebase easier to read and extend.
+  video_id: aMfHqajixeM
+
+- title: 'Keynote: Leading From Where You Are'
+  raw_title: 'RubyConf Mini 2022: Keynote by Rose Wiegley'
+  speakers:
+    - Rose Wiegley
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: ''
+  video_id: c_HhfehMBHE
+
+- title: 'The Three-Encoding Problem'
+  raw_title: 'RubyConfMini 2022: The Three-Encoding Problem by Kevin Menard'
+  speakers:
+    - Kevin Menard
+  event_name: RubyConf Mini 2022
+  published_at: '2023-02-28'
+  description: You’ve probably heard of UTF-8 and know about strings, but did you
+    know that Ruby supports more than 100 other encodings? In fact, your application
+    probably uses three encodings without you realizing it. Moreover, encodings apply
+    to more than just strings. In this talk, we’ll take a look at Ruby’s fairly unique
+    approach to encodings and better understand the impact they have on the correctness
+    and performance of our applications. We’ll take a look at the rich encoding APIs
+    Ruby provides and by the end of the talk, you won’t just reach for force_encoding
+    when you see an encoding exception.
+  video_id: eoD0MsBpDXk

--- a/data/rubyconf/rubyconf-2022/videos.yml
+++ b/data/rubyconf/rubyconf-2022/videos.yml
@@ -277,7 +277,7 @@
     - Landon Gray
     - Jenner La Fave
     - Alexander Momchilov
-    - StackOverflow Embedded
+    - Andrew Gauger
     - Casey Watts
     - Keith Bennett
     - Craig Buchek

--- a/data/rubyconf/rubyconf-2022/videos.yml
+++ b/data/rubyconf/rubyconf-2022/videos.yml
@@ -1,0 +1,738 @@
+---
+- title: 'From beginner to expert, and back again'
+  raw_title: 'RubyConf 2022: From beginner to expert, and back again by Michael Toppa'
+  speakers:
+    - Michael Toppa
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: '"In the beginner''s mind there are many possibilities, in the expert''s
+    mind there are few." - Shunryu Suzuki, from "Zen Mind, Beginner''s Mind" The Japanese
+    Zen term shoshin translates as “beginner’s mind” and refers to a paradox: the
+    more you know about a subject, the more likely you are to close your mind to further
+    learning. In contrast, the beginner’s state of mind is judgment free. It’s open,
+    curious, available, and present. We’ll draw on examples of these mindsets from
+    fields as varied as aviation and geology, and discover lessons we can apply to
+    the world of software development.'
+  video_id: UcFBtBOo0dk
+
+- title: 'Change the Climate Before Changing the Weather'
+  raw_title: 'RubyConf 2022: Change the Climate Before Changing the Weather by Ben Greenberg'
+  speakers:
+    - Ben Greenberg
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Unless you're self-employed you work for a system. That system is comprised
+    of its own culture in decision making, inclusivity, and a lot more. As one person
+    in a system how can you make an impact on it? Sometimes you can’t change the weather,
+    but you can change the climate in your own room. You may even find that if you
+    change the temperature in enough rooms, surprisingly, you end up changing the
+    weather. In this talk, we’ll discuss a process of systems change that is ground
+    up, going from the micro to the macro. You’ll leave more empowered to start changing
+    the climate in your own workplace.
+  video_id: OidmT2LhOdA
+
+- title: "Simulated Annealing: The Most Metal Algorithm Ever 🤘"
+  raw_title: "RubyConf 2022: Simulated Annealing: The Most Metal Algorithm Ever 🤘 by Chris Bloom"
+  speakers:
+    - Chris Bloom
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Simulated annealing is a fascinating algorithm that's designed to help
+    find a particular type of solution (near-optimal, aka "good enough") to a particular
+    type of problem (constrained optimization). It's inspired by the science of metallurgy,
+    and because it's grounded in a real-world process I find it incredibly approachable.
+    In this talk I'll explain in plain terms about what simulated annealing is, what
+    a constrained optimization problem is, why you might want a "good enough" solution,
+    and how we can use the Annealing gem to add simulated annealing to our Ruby apps.
+  video_id: REMwU_dZ0ow
+
+- title: 'Ruby Lambdas'
+  raw_title: 'RubyConf 2022: Ruby Lambdas by Keith Bennett'
+  speakers:
+    - Keith Bennett
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Object Oriented Design is powerful for organizing software behavior,
+    but without the benefit of lambdas' code-as-data flexibility, it often fails to
+    reduce solutions to their simplest form. Although Ruby's Enumerable functionality
+    is widely appreciated, its lambdas generally are not. This presentation introduces
+    the developer to lambdas, and shows how they can be used to write software that
+    is cleaner, simpler, and more flexible. We'll go through lots of code fragments,
+    exploring diverse ways of exploiting their power and identifying reusable functional
+    design patterns along the way.
+  video_id: lxSoqjJSd38
+
+- title: 'Building Native GUI Apps in Ruby'
+  raw_title: 'RubyConf 2022: Building Native GUI Apps in Ruby by Andy Maleh'
+  speakers:
+    - Andy Maleh
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Ruby is an excellent choice for building desktop apps with a native
+    GUI (Graphical User Interface) that looks familiar on Mac, Windows, and Linux.
+    In fact, Ruby pushes the boundaries of developing such apps in brand new ways
+    not seen in web development by supporting very lightweight and declarative GUI
+    syntax including bidirectional data-binding, thanks to Glimmer DSL for LibUI,
+    a gem that won a Fukuoka Ruby 2022 Special Award. In this talk, I will cover concepts
+    like the GUI DSL, data-binding, custom controls, area graphics, drag & drop, MVC/MVP
+    pattern, and scaffolding, with sample demos.
+  video_id: w3tOrHDbbFA
+
+- title: 'In Defense of Ruby Metaprogramming'
+  raw_title: 'RubyConf 2022: In Defense of Ruby Metaprogramming By Noel Rappin'
+  speakers:
+    - Noel Rappin
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: If you’ve learned Ruby recently, you’ve likely been told to avoid using
+    Ruby’s metaprogramming features because they are “dangerous”. Here at RubyConf,
+    we laugh at danger. Or at least chuckle nervously at it. Ruby’s flexibility is
+    one of the features that makes Ruby powerful, and ignoring it limits what you
+    can do with the language. Plus, metaprogramming is fun. Let’s talk about when
+    it makes sense to metaprogram, what parts of Ruby to use, and how to do it safely.
+    You’ll leave with the tools to effectively metaprogram in your code.
+  video_id: o1XvgJoH_tE
+
+- title: 'Pushing to master - adopting trunk based development'
+  raw_title: 'RubyConf 2022: Pushing to master - adopting trunk based development by Dylan Blakemore'
+  speakers:
+    - Dylan Blakemore
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Trunk based development is a scary practice to adopt for engineers
+    used to git flow or github flow. But there is ample evidence to show that it leads
+    to higher quality code and faster delivery. So why are so many resistant to pushing
+    to master? In this talk, we'll go over why TBD can be scary, what challenges are
+    involved in pushing for team and company adoption, and how to overcome those challenges
+  video_id: 1sKFkV19XAc
+
+- title: 'Improving the development experience with language servers'
+  raw_title: 'RubyConf 2022: Improving the development experience with language servers by Vinicius Stock'
+  speakers:
+    - Vinicius Stock
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'Providing a state of the art development experience greatly contributes
+    to Ruby’s goal of making developers happy. A complete set of editor features can
+    make a big difference in helping navigate and understand our Ruby code. Let’s
+    explore a modern way of enhancing editor functionality: the language server protocol
+    (LSP). What it is, how to implement it and how an LSP server like the Ruby LSP
+    can make writing Ruby even better.'
+  video_id: zxdb-xCcHdE
+
+- title: 'A Tale of Two Flamegraphs: Continuous Profiling in Ruby'
+  raw_title: 'RubyConf 2022: A Tale of Two Flamegraphs: Continuous Profiling in Ruby by Ryan Perry'
+  speakers:
+    - Ryan Perry
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'This talk will dive deep into the internals of one of the fastest
+    growing profiling gems: Pyroscope. Pyroscope is unique because it is actually
+    a ruby gem of another ruby gem written in rust; Pyroscope extends the popular
+    rbspy project as a foundation to not only collect profiling data, but also to
+    tag and analyze that data as well. You can think of Pyroscope as what you would
+    get if rbspy and speedscope had a baby. We’ll start with the internals and end
+    with an example of how two flamegraphs can be used to tell a story about your
+    applications performance.'
+  video_id: 8niNCkiF2Xo
+
+- title: 'Everything a Microservice: The Worst Possible Intro to dRuby'
+  raw_title: 'RubyConf 2022: Everything a Microservice: The Worst Possible Intro to dRuby by Kevin Kuchta'
+  speakers:
+    - Kevin Kuchta
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'Microservices are great, but I think we can all agree: we need more
+    of them and they should be micro-er. What''s the logical limit here? What if every
+    object was remote in a language where everything''s an object? Let''s take a look
+    at dRuby, the distributed programming module you''ve never heard of, and use it
+    to achieve that deranged goal! You''ll learn about a nifty little corner of the
+    standard library while we attempt to reach the illogical conclusion of today''s
+    hottest architecture trend. Be warned: those sitting in the first few rows may
+    get poorly-marshaled data on them.'
+  video_id: nrJP9Qr2AXQ
+
+- title: '1.5 is the Midpoint Between 0 and Infinity'
+  raw_title: 'RubyConf 2022: 1.5 is the Midpoint Between 0 and Infinity by Peter Zhu'
+  speakers:
+    - Peter Zhu
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: What’s the midpoint between 0 and infinity? Well, the answer differs
+    depending on whether you are asking a mathematician, philosopher, or a Ruby developer.
+    I’m not a mathematician or a philosopher, but I am a Ruby developer, so I can
+    tell you that 1.5 is the midpoint between 0 and infinity. In this talk, we'll
+    discuss the binary search algorithm, IEEE 754 floating-point numbers, and a clever
+    trick Ruby uses to perform binary search on floating-point ranges.
+  video_id: RQsH54GK85M
+
+- title: 'Using JRuby: What, When, How, and Why'
+  raw_title: 'RubyConf 2022: Using JRuby: What, When, How, and Why by Charles Nutter'
+  speakers:
+    - Charles Nutter
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'JRuby has just been updated for Ruby 3.1 support, bringing compatibility
+    up to date for the most widely-deployed alternative Ruby implementation! This
+    talk will teach you all about JRuby: what is it, when should you use it, how to
+    get started and why it matters. Learn why Ruby shops around the world choose JRuby
+    for world-class concurrency, GC, JIT, and cross-platform support.'
+  video_id: zLX9o_cEen4
+
+- title: 'Building a Commercial Game Engine using mRuby and SDL'
+  raw_title: 'RubyConf 2022: Building a Commercial Game Engine using mRuby and SDL by Amir Rajan'
+  speakers:
+    - Amir Rajan
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: What does it take to build a cross platform game engine in Ruby? How
+    do you render to the screen? How is the simulation and rendering pipeline orchestrated?
+    Why is Ruby a viable option is to begin with? These questions and more will be
+    answered by Amir. Be a part of this renaissance and see how Ruby can be used for
+    so much more than server side web development.
+  video_id: YVcl1Oy6QFM
+
+- title: 'Writing Ruby, just not in English!'
+  raw_title: 'RubyConf 2022: Writing Ruby, just not in English! by Ratnadeep Deshmane (rtdp)'
+  speakers:
+    - Ratnadeep Deshmane
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: My talk shows how to write Ruby in a non-English language and the benefits
+    of doing so. This will certainly be a great help for people who don’t speak English.
+    It also helps get a better programming perspective for seasoned developers who
+    don’t have English as their first language. I will also demo the tooling that
+    I have developed, using which one can quickly create a new spoken language variant
+    of Ruby and start programming in Spanish, Portuguese etc.
+  video_id: g8PgM5WGyhQ
+
+- title: 'This Old App'
+  raw_title: 'RubyConf 2022: This Old App by Lori M Olson'
+  speakers:
+    - Lori M Olson
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: What could renovating an old house have in common with upgrading an
+    old app? *Everything!* Let me show you how this old house renovation project proceeds,
+    from planning to scheduling, demolition to finishing, and how every stage directly
+    relates the lessons learned from app upgrades over the course of my career.
+  video_id: "-q9b5wlXr0c"
+
+- title: 'Never again without a contract: dry-validation'
+  raw_title: 'RubyConf 2022: Never again without a contract: dry-validation by Espartaco Palma'
+  speakers:
+    - Espartaco Palma
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'The same as you shouldn''t work without a contract, our systems should
+    accept external inputs without one, a written, clear and enforceable one. Define
+    the structure & expected payload being aware of their schema, structure & types.
+    Using dry-schema or dry-validation this part is a matter of a few lines of codes
+    covering most of the cases you may find with the cherry-on-top: error handling
+    out-of-the-box and if this not enough with optional pattern matching for results.'
+  video_id: _lMw7guragc
+
+- title: 'Boutique machine generated gems'
+  raw_title: 'RubyConf 2022: Boutique machine generated gems by CJ Avilla'
+  speakers:
+    - CJ Avilla
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: What if writing boilerplate for Ruby gems were automated using familiar
+    UI building blocks? Many Rubyists are familiar with components for generating
+    clean HTML with higher-level frameworks. Unfortunately, many developers are unaware
+    they can generate clean Ruby code that is as beautiful as their UIs. This talk
+    will explore how we automatically created a generator to produce high-quality
+    ruby and docs for a popular gem. I'll show how to use this approach to keep gems
+    up-to-date with fast-moving APIs, release new versions frequently, and provide
+    an excellent developer experience.
+  video_id: aV1obsuDmjU
+
+- title: "The Power of 'No'"
+  raw_title: "RubyConf 2022: The Power of 'No' by Glenn Harmon"
+  speakers:
+    - Glenn Harmon
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Have you ever attended a meeting that you wish you hadn’t? Have you
+    ever been happy that plans were canceled because you never really wanted to go
+    in the first place? Saying no is hard and can be truly challenging when faced
+    with the prospect of feeling like maybe you’ll let someone down. Another reason
+    saying no is hard is the feeling or FOMO, or the Fear Of Missing Out. All of these
+    are even harder if you're a person of color. But is that 'Yes' worth your peace
+    of mind? This talk is about how knowing when to say no and how to do so.
+  video_id: q9Eoo5i6hmk
+
+- title: 'Lightning Talks'
+  raw_title: 'RubyConf 2022: Lightning Talks'
+  speakers:
+    - Olya Boiaryntseva
+    - Jose Miguel Tomita Rodriguez
+    - Tom Brown
+    - Adam Cuppy
+    - Richard Schneeman
+    - Bryce Simons
+    - Jacob Daddario
+    - Mike Eduard
+    - Landon Gray
+    - Jenner La Fave
+    - Alexander Momchilov
+    - StackOverflow Embedded
+    - Casey Watts
+    - Keith Bennett
+    - Craig Buchek
+    - James Reid-Smith
+    - Adam E. Hampton
+    - Yasu Flores
+    - Anas Alkhatib
+    - Amanda Lundberg
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: ''
+  video_id: "-FM__GyT57Y"
+
+- title: 'Ruby Central Panel'
+  raw_title: 'RubyConf 2022: Ruby Central Panel'
+  speakers:
+    - Allison McMillan
+    - Chelsea Kaufman
+    - Neil McGovern
+    - Marty Haught
+    - Valerie Woolard
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: ''
+  video_id: 0ItWcBK7pTk
+
+- title: 'Exit(ing) Through the YJIT'
+  raw_title: 'RubyConf 2022: Exit(ing) Through the YJIT by Eileen M Uchitelle'
+  speakers:
+    - Eileen M Uchitelle
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: When optimizing code for the YJIT compiler it can be difficult to figure
+    out what code is exiting and why. While working on tracing exits in a Ruby codebase,
+    I found myself wishing we had a tool to reveal the exact line that was causing
+    exits to occur. We set to work on building that functionality into Ruby and now
+    we are able to see every side-exit and why. In this talk we’ll learn about side-exits
+    and how we built a tracer for them. We’ll explore the original implementation,
+    how we rewrote it in Rust, and lastly why it’s so important to always ask "can
+    I make what I built even better?"
+  video_id: EZEEl61bWSw
+
+- title: "Crocheting & Coding: they're more similar than you think!"
+  raw_title: 'RubyConf 2022: Crocheting & Coding: they''re more similar than you think! by Tori Machen'
+  speakers:
+    - Tori Machen
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Many of us have hobbies that we enjoy outside of our careers in tech.
+    For me, that is amigurumi, the art of crocheting stuffed creatures. What if I
+    told you that amigurumi is extremely similar to software development? Join me
+    in exploring the intersection between crocheting amigurumi and developing software.
+    We’ll look at the key similarities between these two crafts, and I’ll share how
+    crocheting has helped me become a better software developer. You’ll walk away
+    inspired to connect your own hobbies to your role in tech or find a new creative
+    hobby (like crochet)!
+  video_id: GOnW_586TiU
+
+- title: 'Keynote: The Case Of The Vanished Variable - A Ruby Mystery Story'
+  raw_title: 'RubyConf 2022: Keynote: The Case Of The Vanished Variable - A Ruby Mystery Story by Nadia Odunayo'
+  speakers:
+    - Nadia Odunayo
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: After a stressful couple of days at work, Deirdre Bug is looking forward
+    to a quiet evening in. But her plans are thwarted when the phone rings. “I know
+    I’m the last person you want to hear from…but...I need your help!” Follow Deirdre
+    as she embarks on an adventure that features a looming Demo Day with serious prize
+    money up for grabs, a trip inside the walls of one of the Ruby community’s most
+    revered institutions, and some broken code that appears to be much more simple
+    than meets the eye.
+  video_id: HSgY9o4gIPE
+
+- title: 'Eclectics Unite: Leverage Your Diverse Background'
+  raw_title: 'RubyConf 2022: Eclectics Unite: Leverage Your Diverse Background by Sijia Wu'
+  speakers:
+    - Sijia Wu
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: In addition to writing Ruby for work, I am also an academic translator,
+    a snowboard instructor, and a drummer in a rock band. I am consistently amazed
+    and inspired by the similarities and connections between software development
+    and my seemingly unrelated experiences. What does translating science articles
+    teach me about effectively using coding resources? How is playing drums in a rehearsal
+    similar to test-driven development? How do I apply snowboard teaching principles
+    to pair programming? Join me as I share my own story and explore ways you can
+    leverage your diverse background.
+  video_id: NGQzBjDWo-A
+
+- title: 'Keynote: Lost in the Wilderness'
+  raw_title: 'RubyConf 2022: Keynote by Suzan Bond'
+  speakers:
+    - Suzan Bond
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Suzan Bond is a former COO of Travis CI, leadership consultant and
+    executive coach. Her specialty is leaders at scaling startups. She's spent more
+    than 15 years in technology. Her education background includes psychology, organization
+    development, leadership and community organizing. Suzan facilitates workshops
+    and is host of LeadDev's Bookmarked series. She's spoken at numerous events, is
+    a contributor to Fast Company's Work Life section and writes the Suzan's Fieldnotes
+    newsletter.
+  video_id: OqpBxSp-4FI
+
+- title: 'How music works, using Ruby'
+  raw_title: 'RubyConf 2022: How music works, using Ruby Thijs Cadier'
+  speakers:
+    - Thijs Cadier
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'That strange phenomenon where air molecules bounce against each other
+    in a way that somehow comforts you, makes you cry, or makes you dance all night:
+    music. Since the advent of recorded audio, a musician doesn''t even need to be
+    present anymore for this to happen (which makes putting "I will always love you"
+    on repeat a little less awkward). Musicians and sound engineers have found many
+    ways of creating music, and making it sound good. Some of their methods have become
+    industry staples used on every recording released today. Let''s look at what they
+    do and reproduce some of their methods in Ruby!'
+  video_id: RAtDPFsk3hc
+
+- title: 'The Magnitude 9.1 Meltdown at Fukushima'
+  raw_title: 'RubyConf 2022: The Magnitude 9.1 Meltdown at Fukushima by Nickolas Means'
+  speakers:
+    - Nickolas Means
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: It was mid-afternoon on Friday, March 11, 2011 when the ground in Tōhoku
+    began to shake. At Fukushima Daiichi nuclear power plant, it seemed like the shaking
+    would never stop. Once it did, the reactors had automatically shut down, backup
+    power had come online, and the operators were well on their way to having everything
+    under control. And then the tsunami struck. They found themselves facing something
+    beyond any worse-case scenario they imagined, and their response is a study in
+    contrasts. We can learn a lot from the extremes they experienced about finding
+    happiness and satisfaction at work.
+  video_id: RGS0jBMniag
+
+- title: "Don't @ me! Faster Instance Variables with Object Shapes"
+  raw_title: 'RubyConf 2022: Don''t @ me! Faster Instance Variables with Object Shapes by Aaron Patterson'
+  speakers:
+    - Aaron Patterson
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Instance variables are a popular feature of the Ruby programming language,
+    and many people enjoy using them. They are so popular that the Ruby core team
+    has done lots of work to speed them up. But we can do even better to speed them
+    up by using a technique called "Object Shapes". In this presentation we'll learn
+    about what object shapes are, how they are implemented, how how they can be used
+    to speed up getting and setting instance variables. We'll make sure to square
+    up Ruby instance variable implementation details so that you can become a more
+    well rounded developer!
+  video_id: ZaHd5MDJRBw
+
+- title: 'scip-ruby - A Ruby indexer built with Sorbet'
+  raw_title: 'RubyConf 2022: scip-ruby - A Ruby indexer built with Sorbet by Varun Gandhi'
+  speakers:
+    - Varun Gandhi
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: scip-ruby is an open source indexer that lets you browse Ruby code
+    online, with IDE functionality like “Go to definition” and “Find usages”. We originally
+    built scip-ruby to improve Ruby support in Sourcegraph, a code intelligence platform.
+    In this talk, you will learn how we built scip-ruby on top of Sorbet, a Ruby typechecker,
+    and how scip-ruby compares to IDEs and other online code navigation tools. Along
+    the way, we will discuss how quintessential ideas like layering code into a functional
+    core and an imperative shell apply to developer tools, and enable easier testing.
+  video_id: cfceVH_1H3Q
+
+- title: 'Building an education savings platform, with Ruby!'
+  raw_title: 'RubyConf 2022: Building an education savings platform, with Ruby! by Tyler Ackerman'
+  speakers:
+    - Tyler Ackerman
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'Wealthsimple Foundation is a Canadian charity working to enable a
+    brighter future for everyone in Canada through access to post-secondary education.
+    The Foundation is supported by Wealthsimple, which builds a variety of digital
+    financial tools trusted by over 2.5 million Canadians. In this talk we''ll go
+    over: - How an organization supporting for-profit and non-profit activities is
+    structured (and the ethical considerations that can arise from that) - Responsibilities
+    of engineers working in a non-profit space - Opportunities and challenges of digital
+    products addressing systematic inequalities'
+  video_id: cmZKu-kyyio
+
+- title: 'Static typing with RBS in Ruby'
+  raw_title: 'RubyConf 2022: Static typing with RBS in Ruby by Gaurav Kumar Singh'
+  speakers:
+    - Gaurav Kumar Singh
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: In this talk, we'll generally explore the static type eco system in
+    Ruby. Ruby has two main type checkers Sorbet and RBS. Sorbet was created by the
+    Stripe and RBS is supported by ruby. Sorbet is an annotation base type checking
+    system while RBS is a definition file-based type system. We'll add type annotation
+    for a popular gem using sorbet and RBS and then compare the differences between
+    the two systems. There is lot of interoperability announced between Sorbet and
+    RBS and we'll explore if it's practically possible to convert a sorbet annotated
+    project to RBS.
+  video_id: iKJeKxf3Nck
+
+- title: 'Helping Redistrict California with Ruby'
+  raw_title: 'RubyConf 2022: Helping Redistrict California with Ruby by Jeremy Evans'
+  speakers:
+    - Jeremy Evans
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Every 10 years, after the federal census, California and most other
+    states redraw the lines of various electoral districts to attempt to ensure the
+    districts are fair and have roughly equal population. California uses a system
+    written in Ruby for citizens to apply to become redistricting commissioners, and
+    for review of the submitted applications. Come learn about redistricting and the
+    unique design of the California redistricting commissioner application system,
+    with 12 separate web server process types, isolated networks, 3-factor authentication,
+    and other security features.
+  video_id: q5nke59IuAs
+
+- title: 'Solidarity not Charity and Collective Liberation'
+  raw_title: 'RubyConf 2022: Solidarity not Charity and Collective Liberation by Mae Beale'
+  speakers:
+    - Mae Beale
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Wondering how to get involved in supporting your communities? Hear
+    from someone who has spun up (and down) multiple volunteer and service projects.
+    May it spark your imagination -- and your heart -- to join or start helping out
+    both this wild world and yourself. New mutual aid groups formed around the world
+    in 2020. The tools were not ideal and the volume overwhelmed volunteers. A handful
+    of of tech folx built a fit-to-suit app to manage immediate needs and maximize
+    impact of partner mutual aid groups. Wins were achieved. Lessons were learned.
+    And the interconnectedness of all things was felt.
+  video_id: saPZ0Jh3UU0
+
+- title: 'What does "high priority" mean? The secret to happy queues'
+  raw_title: 'RubyConf 2022: What does "high priority" mean? The secret to happy queues by Daniel Magliola'
+  speakers:
+    - Daniel Magliola
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'Like most web applications, you run important jobs in the background.
+    And today, some of your urgent jobs are running late. Again. No matter how many
+    changes you make to how you enqueue and run your jobs, the problem keeps happening.
+    The good news is you''re not alone. Most teams struggle with this problem, try
+    more or less the same solutions, and have roughly the same result. In the end,
+    it all boils down to one thing: keeping latency low. In this talk I will present
+    a latency-focused approach to managing your queues reliably, keeping your jobs
+    flowing and your users happy.'
+  video_id: w0Bl-5TDCC4
+
+- title: 'RSpec: The Bad Parts'
+  raw_title: 'RubyConf 2022: RSpec: The Bad Parts by Caleb Hearth'
+  speakers:
+    - Caleb Hearth
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: 'RSpec is good, but it’s even better with less of it. Looking at a
+    realistic example spec, we’ll learn why parts of RSpec like let, subject, shared_examples,
+    behaves like, and before can make your tests hard to read, difficult to navigate,
+    and more complex. We''ll discuss when DRY is not worth the price and how we can
+    avoid repetition without using RSpec''s built-in DSL methods. In the end, we''ll
+    look at what''s left. RSpec: The Good Parts.'
+  video_id: _UFE0t2Sgaw
+
+- title: 'Data indexing with RGB (Ruby, Graphs and Bitmaps)'
+  raw_title: 'RubyConf 2022: Data indexing with RGB (Ruby, Graphs and Bitmaps) by Benjamin Lewis'
+  speakers:
+    - Benjamin Lewis
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: In this talk, we will go on a journey through Zappi’s data history
+    and how we are using Ruby, a graph database, and a bitmap store to build a unique
+    data engine. A journey that starts with the problem of a disconnected data set
+    and serialised data frames, and ends with the solution of an in-memory index.
+    We will explore how we used RedisGraph to model the relationships in our data,
+    connecting semantically equal nodes. Then delve into how a query layer was used
+    to index a bitmap store and, in turn, led to us being able to interrogate our
+    entire dataset orders of magnitude faster than before.
+  video_id: FwBRoxrHaBU
+
+- title: 'Bending Time with Crystal: 6 hours to 15 minutes'
+  raw_title: 'RubyConf 2022: Bending Time with Crystal: 6 hours to 15 minutes by Paul Hoffer'
+  speakers:
+    - Paul Hoffer
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: In software, we often encounter problems that we accept as "just how
+    things are." But sometimes, that creates opportunities to identify creative, out
+    of the box solutions. One idea can be combining the power of Crystal with our
+    existing Ruby knowledge, to create effective tools with minimal learning curve
+    and cognitive overhead. I'll demonstrate how easily Ruby code can be ported to
+    Crystal, how it can benefit us, and how to identify these opportunities.
+  video_id: 6MpXSrgBVww
+
+- title: 'Splitting: the Crucial Optimization for Ruby Blocks'
+  raw_title: 'RubyConf 2022: Splitting: the Crucial Optimization for Ruby Blocks by Benoit Daloze'
+  speakers:
+    - Benoit Daloze
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Blocks are one of the most expressive parts of the Ruby syntax. Many
+    Ruby methods take a block. When a method is given different blocks, there is a
+    crucial optimization necessary to unlock the best performance. This optimization
+    dates back to the early days of research on dynamic languages, yet it seems only
+    a single Ruby implementation currently uses it. This optimization is called splitting
+    and what it does is using different copies of a method and specialize them to
+    the block given at different call sites. This enables compiling the method and
+    the block together for the best performance.
+  video_id: PjUpcR5UPHI
+
+- title: 'Building Stream Processing Applications with Ruby & Meroxa'
+  raw_title: 'RubyConf 2022: Building Stream Processing Applications with Ruby & Meroxa by Ali Hamidi'
+  speakers:
+    - Ali Hamidi
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: As the world moves towards real-time there’s a growing demand for building
+    sophisticated stream processing applications. Traditionally building these apps
+    has involved spinning up separate task-specific tooling, learning new and unfamiliar
+    paradigms, as well as deploying and operating a constellation of complex services.
+    In this talk, we’ll take a look at how to use the Turbine framework (turbine.rb)
+    to build and deploy real-time stream processing applications using Ruby.
+  video_id: 6bHZQy0Ti_c
+
+- title: 'Boot the backlog: Optimizing your workflow for dev happiness'
+  raw_title: 'RubyConf 2022: Boot the backlog: Optimizing your workflow for dev happiness by Stacey McKnight'
+  speakers:
+    - Stacey McKnight
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: What would happen if your team dropped that standing Monday morning
+    refinement meeting? Chaos? We often follow work processes because they’re “the
+    way things are done”, but clunky, unexamined processes slow down even talented
+    teams. Never ending backlogs make it hard to feel like you’re making progress.
+    Frequent meetings break up focus. If something about the way we work doesn’t help
+    us move more quickly or effectively, it’s time to rethink it. Seeking a better
+    way to coordinate work across 3 continents, the Workforce.com dev team adopted
+    the Shape Up approach to project management. This talk explores the core elements
+    of that approach and ways to optimize developer happiness while delivering more
+    value for users.
+  video_id: BB_GjUIA06c
+
+- title: 'Business in the Front, Party in the Back (Office)'
+  raw_title: 'RubyConf 2022: Business in the Front, Party in the Back (Office) by Kevin Whinnery'
+  speakers:
+    - Kevin Whinnery
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: If you have ever built a web application, chances are that you have
+    also had to deal with "the back office" - the chores and one-off tasks required
+    to operate your software in production. Workflows that aren't user-facing, like
+    creating promo codes, moderating content, or running reports, are often a janky
+    combination of admin scripts and spreadsheets. Retool helps developers quickly
+    and easily solve these problems with software instead. In this session, we'll
+    show how to build a back office interface for a Ruby on Rails application using
+    Postgres and several common API services, so you can keep your focus on the business
+    in the front, and let Retool help throw the party in the back (office).
+  video_id: GSBhVVWycvU
+
+- title: 'Analyzing an analyzer - A dive into how RuboCop works'
+  raw_title: "RubyConf 2022: Analyzing an analyzer - A dive into how RuboCop works by Kyle d'Oliveira"
+  speakers:
+    - Kyle d'Oliveira
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: To help us with aspects like linting, security or style, many of us
+    have Rubocop analyzing our code. It's a very useful tool that is widely used,
+    easy to set up and configure. Rubocop can even automatically auto-correct your
+    source code as needed. How is this even possible? It turns out that Ruby is really
+    good at taking Ruby code as input and doing various things based on that input.
+    In this talk, I will go through some of the internals of Rubocop to show how it
+    analyzes and makes changes to your source code.
+  video_id: pSCMgcttW4c
+
+- title: 'Ruby Archaeology: Forgotten web frameworks'
+  raw_title: 'RubyConf 2022: Ruby Archaeology: Forgotten web frameworks by Nick Schwaderer'
+  speakers:
+    - Nick Schwaderer
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: "In the 2000's everyone was writing a Ruby web framework **Today, it
+    seems, we are all too content to focus our energy on a small number of large Ruby
+    web projects**. What happened to our creative spirit? In this talk we focus on
+    Ruby web frameworks that have long gone by the wayside. I won't spoil them here,
+    but I can tell you what we won't be covering: \n* Sinatra \n* Hanami \n* roda
+    \n* merb \n\nWe will answer questions like: \n* Why are fewer people experimenting
+    with their own frameworks today? \n* What features, idioms and ideas are worth
+    exploring? \n* Are any of these frameworks worth reviving or copying?"
+  video_id: oXHgNh6DcSI
+
+- title: "Ruby's Core Gem"
+  raw_title: 'RubyConf 2022: Ruby’s Core Gem by Chris Seaton'
+  speakers:
+    - Chris Seaton
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Ruby has a core library that is part of the interpreter and always
+    available. It’s classes like String and Time. But what would it be like if we
+    re-implemented the core library, writing it in Ruby itself, and made it available
+    as a gem? Would it be faster or slower? Would it be easier to understand and debug?
+    What other benefits could there be? It was originally Rubinius that implemented
+    Ruby’s core in Ruby, and it has been taken up and maintained by the TruffleRuby
+    team.
+  video_id: 8mqDIHer1G4
+
+- title: "I'm in love with Mermaid"
+  raw_title: 'RubyConf 2022: I''m in love with Mermaid by Carolyn Cole'
+  speakers:
+    - Carolyn Cole
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Everyone says that a picture is worth a thousand words... The issue
+    in the past is that those pictures have been hard to create let alone maintain.
+    Welcome Mermaid (https://mermaid-js.github.io/mermaid/#/)! Mermaid is a mark down
+    compatible graphing tool that allows you to add diagrams directly to your markdown
+    in github. I have been using it for a a year and just love it. I believe that
+    you will love it too once you join my session.
+  video_id: iFXomx3QLM4
+
+- title: 'Discover Machine Learning in Ruby'
+  raw_title: 'RubyConf 2022: Discover Machine Learning in Ruby by Justin Bowen'
+  speakers:
+    - Justin Bowen
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: We can use Ruby to do anything we as a community want. Today we’ll
+    explore the work of a hidden gem of a contributor in our community, Andrew Kane,
+    and their Ruby gems for Machine Learning. We will see how contemporary computer
+    vision neural networks can run with Ruby. Ruby is all about developer happiness.
+    Computer Vision is something that brings me great joy as it delivers satisfying
+    visual feedback and connects our code with the real world through images and videos
+    in a way that wasn’t accessible until the last decade or so.
+  video_id: HPbizNgcyFk
+
+- title: 'Staff Engineer: “Here be dragons”'
+  raw_title: 'RubyConf 2022: Staff Engineer: “Here be dragons” by Alexandre Terrasa'
+  speakers:
+    - Alexandre Terrasa
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: "“Here be dragons”: this is how uncharted areas of maps were marked
+    in medieval times. Today, while the journey to become a Senior Engineer is known
+    territory, being a Staff Engineer appears full of dragons. Together, let’s demystify
+    what leading beyond the management track really means."
+  video_id: _7DOSoXICMo
+
+- title: 'Working Together: Pairing as Senior and Junior Developers'
+  raw_title: 'RubyConf 2022: Working Together: Pairing as Senior and Junior Developers by Kelly Ryan'
+  speakers:
+    - Kelly Ryan
+  event_name: RubyConf 2022
+  published_at: '2023-03-06'
+  description: Pairing with a senior developer is a daily necessity for a programmer
+    just starting out. But how should you as a junior developer approach pairing to
+    get the most out of the interaction? How can you not only find a solution to a
+    current problem, but also build relationships and learn skills for future problems?
+    In this talk, you will learn best practices for getting the most out of time with
+    a mentor. I will recommend practical tips and positive habits, as well as ways
+    of thinking that can improve your experience pairing and help you become a better
+    developer.
+  video_id: pvl1HPFqRdk

--- a/data/rubyconf/rubyconf-2023/videos.yml
+++ b/data/rubyconf/rubyconf-2023/videos.yml
@@ -1,8 +1,8 @@
-- title: Keynote - Matz shares insights into Ruby and answers questions submitted by the Ruby community
+- title: "Keynote: Lessons from the Past"
   raw_title: 'RubyConf 2023 - Keynote by Yukihiro "Matz" Matsumoto'
   speakers:
     - Yukihiro "Matz" Matsumoto
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: In this pre-recorded presentation, Matz shares insights into Ruby and answers questions submitted by the Ruby community.
   video_id: Dxy9UBoZjTQ
@@ -11,7 +11,7 @@
   raw_title: "RubyConf 2023 - Which Time Is It? by Joël Quenneville"
   speakers:
     - Joël Quenneville
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: |-
     Can you add two time values together? Yes. No. Not so fast!
@@ -23,7 +23,7 @@
   raw_title: "RubyConf 2023 - Finding a needle in the haystack - Debugging performance issues by Puneet Khushwani"
   speakers:
     - Puneet Khushwani
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: |-
     What should a developer do if suddenly one day they get assigned to debug a Sev1 performance issue?
@@ -37,7 +37,7 @@
   raw_title: "RubyConf 2023 - Popping Into CRuby by Jemma Issroff"
   speakers:
     - Jemma Issroff
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: Ever wondered why a line of Ruby code with no side effects has no performance impact? This talk will explain the concept of "popped" instruction sequences, demystifying how CRuby works behind the scenes to avoid running unnecessary code. We'll delve into parsing, compiling, abstract syntax trees, and instruction sequence. You’ll leave this talk with a deeper understanding of Ruby's inner workings and why they matter.
   video_id: 8R78YHyQ9ko
@@ -46,7 +46,7 @@
   raw_title: "RubyConf 2023 - Get your Data prod ready, Fast, with Ruby Polars! by Paul Reece"
   speakers:
     - Paul Reece
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: Imagine you receive a CSV of data that has over 500,000 rows and 100 columns. Data is randomly missing in some places, some of the column names are wrong, and you have mixed Data types in some of the columns.  Correcting and cleaning that data by hand could take hours. Fear not! There is a better and faster way.  We will look into using Ruby Polars, a gem written in Rust with a Ruby API, to wrangle and clean tabular data to get it prod ready. By learning some basic operations used in Polars you can greatly expedite the import process of CSV files and API Data. Whether your goal is to use the Data in an existing application or use it in a Ruby AI/Machine learning project(since cleaning Data is a vital first step in this process), this talk will get you well on your way!
   video_id: QjTLx7po1jY
@@ -55,7 +55,7 @@
   raw_title: "RubyConf 2023 - State of the RubyGems by Samuel Giddins"
   speakers:
     - Samuel Giddins
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: Part history, part state of the union, and part roadmap for community feedback, this talk will cover how Ruby Central came to have an open source team, what we have been doing for the last 8.5 years, highlights from our work in 2023, and a deep dive into the ideas that we would like to get onto our road map. If you want to know more about Ruby Central, RubyGems, or project planning in long-running open source projects, this is the talk for you.
   video_id: wV9JpikPM9g
@@ -64,7 +64,10 @@
   raw_title: "RubyConf 2023 - Rooftop Ruby podcast by Collin Donnell"
   speakers:
     - Collin Donnell
-  event_name: RubyConf 2023 (San Diego)
+    - Joel Drapper
+    - Roman Turner
+    - Catherine Ricafort McCreary
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: Live - Rooftop Ruby podcast
   video_id: _RSLyjYeNTU
@@ -73,7 +76,7 @@
   raw_title: "RubyConf 2023 - Re-interpreting Data by Murray Steele"
   speakers:
     - Murray Steele
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: |-
     A talk about turning data into other data. Not particularly useful data, but imagine if you could listen to a jpeg, or see what an executable file looked like, or turn a zip file into an orchestral score?
@@ -85,7 +88,7 @@
   raw_title: "RubyConf 2023 - The Future of Understanding Ruby Code by Kevin Newton"
   speakers:
     - Kevin Newton
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: For decades, the Ruby community has been fractured in the way that it parses and understands Ruby code. After countless tools have been developed and person-hours have been invested, we still don't have a common language for understanding Ruby code. No longer! Starting in Ruby 3.3, we will have a single API for parsing and understanding Ruby code. This talk will cover the history of how we got here, what is getting built today, and what you can expect from this exciting future.
   video_id: F9X5uJO9PV8
@@ -94,7 +97,7 @@
   raw_title: "RubyConf 2023 - Demystifying the Ruby package ecosystem by Jenny Shen"
   speakers:
     - Jenny Shen
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: "A Ruby application is built on a foundation of its gems. But how does a gem get from the package repository to running in your project? RubyGems and Bundler does an excellent job in removing the complexities of gem resolution and installation so developers can focus on building great software. Let’s do a deep dive on how these tools seamlessly manage the dependencies you need to get your project off the ground!\n\nIn this talk, we’ll be taking a look at the inner workings of the Ruby package ecosystem. This includes:\n- The processes involved in installing gems from a Gemfile \n- Insights into debugging gems within a Rails application\n- Ensuring you're selecting the right gems to avoid security risks"
   video_id: fkfCXFxJW08
@@ -103,7 +106,7 @@
   raw_title: "RubyConf 2023 - The Unbreakable Code Whose Breaking Won WWII by Aji Slater"
   speakers:
     - Aji Slater
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-19"
   description: |-
     After the last carrier pigeon but before digital encryption algorithms, there was the Enigma machine. An ingenious piece of pre-atomic age technology encoded German military secrets during World War II, baffling code-breakers with mere physical rotors, and switches, without elliptic curves or private keys.
@@ -115,7 +118,7 @@
   raw_title: "RubyConf 2023 - Livin’ La Vida Hanami by Tim Riley"
   speakers:
     - Tim Riley
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: |-
     Upside, inside out, Hanami 2.0 is out!
@@ -127,20 +130,20 @@
     Once you’ve had a taste of it you’ll never be the same!
   video_id: L35MPfmtJZM
 
-- title: Keynote by Sharon Steed
+- title: "Keynote: Making Empathy Actionable"
   raw_title: "RubyConf 2023 - Keynote by Sharon Steed"
   speakers:
     - Sharon Steed
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: Sharon Steed is the founder of Communilogue, an empathy consultancy that teaches audiences how to make empathy actionable so individuals can better connect with their coworkers; companies can better understand their consumers; and everyone can bring more humanity into the office.
   video_id: wkOh5yCLX60
 
-- title: Keynote by Saron Yitbarek
+- title: "Keynote: Our superpower"
   raw_title: "RubyConf 2023 - Keynote by Saron Yitbarek"
   speakers:
     - Saron Yitbarek
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: Saron Yitbarek shares stories and lessons she's learned from years of helping new developers transition into tech careers and building developer communities.
   video_id: 07gTTE4NPZk
@@ -149,7 +152,7 @@
   raw_title: "RubyConf 2023 - Ruby on Rack: The Magic Between Request and Response by Meagan Waller"
   speakers:
     - Meagan Waller
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: Are you ready to embark on an expedition into the core of Ruby web applications? Well, get ready, because it's time to delve into  web development with Rack—the powerhouse that fuels popular Ruby web frameworks like Rails and Sinatra. In this captivating talk, we'll plunge deep into the inner workings of Rack, the unsung hero of web development. We'll uncover its secrets, bask in its versatility, and summon the magic of custom Rack middleware—where session management, authentication, and caching reside. For developers at all levels, this talk offers practical insights and fresh perspectives. Equip yourself with the prowess to wield Rack's middleware magic, making your development journey more efficient and enjoyable.
   video_id: cJ7V9Mg1vzc
@@ -158,7 +161,7 @@
   raw_title: "RubyConf 2023 - The Second Oldest Bug by Jeremy Evans"
   speakers:
     - Jeremy Evans
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: Historically, calling a method with a very large number of arguments resulted in a core dump. In Ruby 1.9, this was improved to instead raise SystemStackError.  In Ruby 2.2, the issue was fixed for methods defined in Ruby.  However, in Ruby 3.2, this is still an issue for methods defined in C.  This issue was reported as a bug over 12 years ago, and was the second oldest open bug in Ruby's bug tracker.  Come learn about stacks, heaps, argument handling during method dispatch, and how we fixed this bug in Ruby 3.3.
   video_id: cIKYxSLCyX0
@@ -167,7 +170,7 @@
   raw_title: "RubyConf 2023 - Wrapping Rust in Ruby by Garen Torikian"
   speakers:
     - Garen Torikian
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: "Ruby is slow. Despite improvements over the years, the language will never be as fast as a compiled language. To compensate for this, whenever Ruby developers need to run performance critical code, it's not uncommon for them to interoperate with a library written in C. Dozens of well known gems, such as Nokogiri and Bcrypt, already do this. But with C comes other problems: how can we ensure that our low-level code is safe from memory leaks and other security vulnerabilities? In this talk, I'll introduce the oxidize-rb project, which is a suite of open source tools which makes it possible to call Rust libraries from within Ruby. I'll also demonstrate how simple it is to incorporate Rust code (including Cargo dependencies) into a Ruby gem."
   video_id: l7TPj7dRHso
@@ -176,18 +179,19 @@
   raw_title: "RubyConf 2023 - The Secret Ingredient: How To Understand and Resolve Just... by Alan Ridlehoover"
   speakers:
     - Alan Ridlehoover
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: |-
     The Secret Ingredient: How To Understand and Resolve Just About Any Flaky Test by Alan Ridlehoover
 
     Flaky tests are an inscrutable bane. Hard to understand. Annoying. And, so frustrating! My personal nemesis is Daylight Saving Time. I can’t tell you how many times I’ve tripped over it. Let’s just say I was well into the “shame on me” part of that relationship, until I discovered the secret ingredient that nearly all flaky tests have in common. Turns out they only seem inscrutable. It really is possible to understand and resolve just about any flaky test.
   video_id: De3-v54jrQo
+
 - title: "How Programs Learn, and What Happens After They're Built"
   raw_title: "RubyConf 2023 - How Programs Learn, and What Happens After They're Built by Phil Crissman"
   speakers:
     - Phil Crissman
-  event_name: RubyConf 2023 (San Diego)
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: |-
     In 1994, Stewart Brand published a book called "How Buildings Learn, and What Happens After They're Built". As well as a fascinating account of architecture and the history of various buildings and building styles, some ideas from this book were inspirational to the famous "Big Ball of Mud" paper, by Brian Foote and Joseph Yoder.
@@ -198,7 +202,31 @@
 - title: Lightning Talks
   raw_title: "RubyConf 2023 - Lightning Talks"
   speakers:
-  event_name: RubyConf 2023 (San Diego)
+    - Anna Lopukhina
+    - Salomón Charabati
+    - Jade Stewart
+    - Amanda Vikdal
+    - Jarrod Reyes
+    - Eli Barreto
+    - Seong-Heon Jung
+    - Joshua Maurer
+    - Eric Halverson
+    - Fito von Zastrow
+    - Somebody from Readyset
+    - Gary Tou
+    - Sergey Sergyenko
+    - Mike Toppa
+    - Heather Roulston
+    - Ryan Erickson
+    - Nicolas Barone
+    - Victoria Guido
+    - Daniel Azuma
+    - Xiujiao Gao
+    - Wayne E. Seguin
+    - Rachael Wright-Munn
+    - Guyren Howe
+    - Brandon Weaver
+  event_name: RubyConf 2023
   published_at: "2023-12-20"
   description: Lightning talks are short presentation (up to 5 mins) delivered by different people in a single session. Conference attendees are welcome to sign up near Check In during the conference.
   video_id: JreuXFz8MpE

--- a/data/rubyconf/rubyconf-2023/videos.yml
+++ b/data/rubyconf/rubyconf-2023/videos.yml
@@ -212,7 +212,7 @@
     - Joshua Maurer
     - Eric Halverson
     - Fito von Zastrow
-    - Somebody from Readyset
+    - Paul Lemus 
     - Gary Tou
     - Sergey Sergyenko
     - Mike Toppa


### PR DESCRIPTION
* Add missing talks for RubyConf Mini 2022
* Add talks from RubyConf 2022
* Added missing speakers
* Fix Speaker names
* Fix wrong/missing/incomplete talk titles
* Formatting