### PR TITLE
find by slug rather than name to seed content

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,8 @@ end
 
 MeiliSearch::Rails.deactivate! do
   organisations.each do |organisation|
-    organisation = Organisation.find_or_create_by!(name: organisation["name"]) do |org|
+    organisation = Organisation.find_or_create_by!(slug: organisation["slug"]) do |org|
+      org.name = organisation["name"]
       org.website = organisation["website"]
       # org.twitter = organisation["twitter"]
       org.youtube_channel_name = organisation["youtube_channel_name"]
@@ -28,7 +29,7 @@ MeiliSearch::Rails.deactivate! do
     events = YAML.load_file("#{Rails.root}/data/#{organisation.slug}/playlists.yml")
 
     events.each do |event_data|
-      event = Event.find_by(name: event_data["title"])
+      event = Event.find_by(slug: event_data["slug"])
       next if event
 
       event = Event.create!(name: event_data["title"], date: event_data["published_at"], organisation: organisation)


### PR DESCRIPTION
Relates to 
- https://github.com/adrienpoly/rubyvideo/pull/116
- #111
- #102


this ensure that if we update the organisation or event name it does not create duplicated content when we run the next seed script