### PR TITLE
Only show speakers with talks on speakers index

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -7,11 +7,11 @@ class SpeakersController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        @speakers = Speaker.all.order(:name).select(:id, :name, :slug, :talks_count, :github)
+        @speakers = Speaker.with_talks.order(:name).select(:id, :name, :slug, :talks_count, :github)
         @speakers = @speakers.where("lower(name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
       end
       format.json do
-        @pagy, @speakers = pagy(Speaker.all.order(:name), limit: params[:per_page])
+        @pagy, @speakers = pagy(Speaker.with_talks.order(:name), limit: params[:per_page])
       end
     end
   end

--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -11,6 +11,6 @@
       <% end %>
   </div>
   <div id="speakers" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-8 lg:gap-x-12 gap-y-2 min-w-full">
-      <%= render @speakers %>
+    <%= render @speakers %>
   </div>
 </div>

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -3,11 +3,17 @@ require "test_helper"
 class SpeakersControllerTest < ActionDispatch::IntegrationTest
   setup do
     @speaker = speakers(:one)
+    @speaker_with_talk = speakers(:two)
+
+    @speaker_with_talk.talks << talks(:one)
   end
 
   test "should get index" do
     get speakers_url
     assert_response :success
+
+    assert_select "##{dom_id(@speaker)}", 0
+    assert_select "##{dom_id(@speaker_with_talk)}", 1
   end
 
   test "should show speaker" do
@@ -30,6 +36,9 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     json_response = JSON.parse(response.body)
-    assert_includes json_response["speakers"].map { |speaker_data| speaker_data["name"] }, @speaker.name
+    speakers = json_response["speakers"].map { |speaker_data| speaker_data["name"] }
+
+    assert_includes speakers, @speaker_with_talk.name
+    assert_equal 1, speakers.length
   end
 end


### PR DESCRIPTION
Showing speakers without talks seems weird, let's only show speakers that have talks assigned.

![CleanShot 2024-08-15 at 20 03 19](https://github.com/user-attachments/assets/f9ea2b66-dcad-410b-b303-53c9d2552bc5)
