### PR TITLE
Status enum for topics

### DIFF
--- a/app/avo/actions/approve_topic.rb
+++ b/app/avo/actions/approve_topic.rb
@@ -1,4 +1,4 @@
-class Avo::Actions::PublishTopic < Avo::BaseAction
+class Avo::Actions::ApproveTopic < Avo::BaseAction
   self.name = "Publish Topic"
 
   def handle(query:, fields:, current_user:, resource:, **args)

--- a/app/avo/actions/publish_topic.rb
+++ b/app/avo/actions/publish_topic.rb
@@ -3,7 +3,7 @@ class Avo::Actions::PublishTopic < Avo::BaseAction
 
   def handle(query:, fields:, current_user:, resource:, **args)
     query.each do |record|
-      record.update(published: true)
+      record.approved!
     end
   end
 end

--- a/app/avo/actions/reject_topic.rb
+++ b/app/avo/actions/reject_topic.rb
@@ -1,0 +1,16 @@
+class Avo::Actions::RejectTopic < Avo::BaseAction
+  self.name = "Reject Topic"
+  # self.visible = -> do
+  #   true
+  # end
+
+  # def fields
+  #   # Add Action fields here
+  # end
+
+  def handle(query:, fields:, current_user:, resource:, **args)
+    query.each do |record|
+      record.rejected!
+    end
+  end
+end

--- a/app/avo/filters/published.rb
+++ b/app/avo/filters/published.rb
@@ -1,21 +1,21 @@
 class Avo::Filters::Published < Avo::Filters::BooleanFilter
-  self.name = "Published"
+  self.name = "Approved Status"
 
   def apply(request, query, values)
-    return query if values["published"] == values["unpublished"]
+    selected_statuses = values.select { |k, v| v }.keys
 
-    if values["published"]
-      query = query.where(published: true)
-    elsif values["unpublished"]
-      query = query.where(published: false)
+    if selected_statuses.any?
+      query = query.where(status: selected_statuses)
     end
+
     query
   end
 
   def options
     {
-      published: "Published",
-      unpublished: "Unpublished"
+      pending: "Pending",
+      approved: "Approved",
+      rejected: "Rejected"
     }
   end
 end

--- a/app/avo/resources/topic.rb
+++ b/app/avo/resources/topic.rb
@@ -23,7 +23,8 @@ class Avo::Resources::Topic < Avo::BaseResource
   end
 
   def actions
-    action Avo::Actions::PublishTopic
+    action Avo::Actions::ApproveTopic
+    action Avo::Actions::RejectTopic
   end
 
   def filters

--- a/app/avo/resources/topic.rb
+++ b/app/avo/resources/topic.rb
@@ -11,12 +11,14 @@ class Avo::Resources::Topic < Avo::BaseResource
       query.find_by(slug: id)
     end
   }
+  self.keep_filters_panel_open = true
 
   def fields
     field :id, as: :id
     field :name, as: :text
     field :description, as: :markdown, hide_on: :index
-    field :published, as: :boolean
+    field :status, as: :status, loading_when: "pending", success_when: "approved", failed_when: "rejected", hide_on: :forms
+    field :status, as: :select, enum: ::Topic.statuses, only_on: :forms
     field :talks, as: :has_many
   end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -40,7 +40,7 @@ class TalksController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_talk
-    @talk = Talk.includes(:speakers, :event).find_by(slug: params[:slug])
+    @talk = Talk.includes(:speakers, :event, :approved_topics).find_by(slug: params[:slug])
 
     redirect_to talks_path, status: :moved_permanently if @talk.blank?
   end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -2,7 +2,7 @@ class TopicsController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @topics = Topic.published.with_talks.order(name: :asc)
+    @topics = Topic.approved.with_talks.order(name: :asc)
     @topics = @topics.where("lower(name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
   end
 

--- a/app/jobs/analyze_talk_topics_job.rb
+++ b/app/jobs/analyze_talk_topics_job.rb
@@ -19,11 +19,7 @@ class AnalyzeTalkTopicsJob < ApplicationJob
       []
     end
 
-    topics.map! do |topic|
-      Topic.find_or_create_by(name: topic)
-    end
-
-    talk.topics = topics.uniq
+    talk.topics = Topic.create_from_list(topics)
     talk.save!
 
     talk

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -46,6 +46,7 @@ class Talk < ApplicationRecord
 
   has_many :talk_topics
   has_many :topics, through: :talk_topics
+  has_many :approved_topics, through: :talk_topics, source: :topic, inverse_of: :talks
 
   # validations
   validates :title, presence: true

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -12,6 +12,17 @@ class Topic < ApplicationRecord
   # normalize attributes
   normalizes :name, with: ->(name) { name.squish }
 
-  scope :published, -> { where(published: true) }
+  # scopes
   scope :with_talks, -> { joins(:talks).distinct }
+
+  # enums
+  enum :status, %w[pending approved rejected].index_by(&:itself)
+
+  def self.create_from_list(topics, status: :pending)
+    topics.map do |topic|
+      Topic.find_or_create_by(name: topic).tap do |topic|
+        topic.update(status: status)
+      end
+    end.uniq
+  end
 end

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -22,7 +22,7 @@
     <h1><%= talk.title %></h1>
 
     <div class="flex gap-2">
-      <% talk.topics.published.each do |topic| %>
+      <% talk.approved_topics.each do |topic| %>
         <%= link_to topic do %>
           <div class="badge badge-secondary">#<%= topic.name.parameterize %></div>
         <% end %>

--- a/db/migrate/20240816074626_add_status_to_topic.rb
+++ b/db/migrate/20240816074626_add_status_to_topic.rb
@@ -1,0 +1,8 @@
+class AddStatusToTopic < ActiveRecord::Migration[7.2]
+  def change
+    add_column :topics, :status, :string, null: false, default: "pending"
+    add_index :topics, :status
+
+    Topic.published.update_all(status: "approved")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_15_155647) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_16_074626) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -181,7 +181,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_15_155647) do
     t.string "slug", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "pending", null: false
     t.index ["name"], name: "index_topics_on_name", unique: true
+    t.index ["status"], name: "index_topics_on_status"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -355,6 +355,4 @@ topics = [
 ]
 
 # create topics
-topics.each do |topic|
-  Topic.find_or_create_by(name: topic).update(published: true)
-end
+Topic.create_from_list(topics, status: :approved)

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class TopicsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @topic1 = Topic.create(name: "Topic 1", published: true)
-    @topic2 = Topic.create(name: "Topic 2", published: false)
+    @topic1 = Topic.create(name: "Topic 1", status: :approved)
+    @topic2 = Topic.create(name: "Topic 2", status: :pending)
 
     @talk = talks(:one)
     @topic1.talks << @talk
@@ -16,7 +16,7 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_select "##{dom_id(@topic1)} > span", "1"
     assert_select "##{dom_id(@topic2)}", 0
 
-    @topic2.update(published: true)
+    @topic2.approved!
     get topics_url
     assert_response :success
     assert_select "##{dom_id(@topic2)}", 0

--- a/test/fixtures/topics.yml
+++ b/test/fixtures/topics.yml
@@ -3,9 +3,9 @@
 activerecord:
   name: ActiveRecord
   slug: activerecord
-  published: true
+  status: approved
 
 activesupport:
   name: ActiveSupport
   slug: activesupport
-  published: true
+  status: approved

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -1,7 +1,21 @@
 require "test_helper"
 
 class TopicTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "create_from_list" do
+    topics = ["Rails", "Ruby", "Rails on Rails"]
+    statuses = ["pending", "approved", "rejected"]
+
+    statuses.each do |status|
+      Topic.create_from_list(topics, status: status)
+      assert_equal status, Topic.last.status
+    end
+  end
+
+  test "create_from_list with duplicated topics" do
+    topics = ["Rails", "Rails", "Ruby", "Rails on Rails"]
+
+    assert_changes "Topic.count", 3 do
+      Topic.create_from_list(topics)
+    end
+  end
 end


### PR DESCRIPTION
@marcoroth I am replacing the publish boolean by an enum so that we can reject topics once for all 

I ll see if it make sens to feed the list of rejected topics to the prompt