### PR TITLE
Fix `AddStatusToTopic` migration

### DIFF
--- a/db/migrate/20240816074626_add_status_to_topic.rb
+++ b/db/migrate/20240816074626_add_status_to_topic.rb
@@ -3,6 +3,6 @@ class AddStatusToTopic < ActiveRecord::Migration[7.2]
     add_column :topics, :status, :string, null: false, default: "pending"
     add_index :topics, :status
 
-    Topic.published.update_all(status: "approved")
+    Topic.where(published: true).update_all(status: "approved")
   end
 end


### PR DESCRIPTION
The new migration added #129 fails when running because that same PR also removed the `published` scope on `Topic.`

```
❯ rails db:migrate
== 20240815155647 AddUniqIndexOnTalkTopic: migrating ==========================
-- add_index(:talk_topics, [:talk_id, :topic_id], {:unique=>true})
   -> 0.0121s
== 20240815155647 AddUniqIndexOnTalkTopic: migrated (0.0122s) =================

== 20240816074626 AddStatusToTopic: migrating =================================
-- add_column(:topics, :status, :string, {:null=>false, :default=>"pending"})
   -> 0.0144s
-- add_index(:topics, :status)
   -> 0.0026s
bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

undefined method `published' for class Topic
/Users/marcoroth/Development/rubyvideo/db/migrate/20240816074626_add_status_to_topic.rb:6:in `change'

Caused by:
NoMethodError: undefined method `published' for class Topic (NoMethodError)
Did you mean?  public_send
/Users/marcoroth/Development/rubyvideo/db/migrate/20240816074626_add_status_to_topic.rb:6:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

Instead, we can use a regular `where` clause instead.