### PR TITLE
Don't reset already approved Topic when creating new topics

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -19,10 +19,8 @@ class Topic < ApplicationRecord
   enum :status, %w[pending approved rejected].index_by(&:itself)
 
   def self.create_from_list(topics, status: :pending)
-    topics.map do |topic|
-      Topic.find_or_create_by(name: topic).tap do |topic|
-        topic.update(status: status)
-      end
-    end.uniq
+    topics.map { |topic|
+      Topic.find_by(name: topic) || Topic.find_or_create_by(name: topic, status: status)
+    }.uniq
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -278,6 +278,7 @@ topics = [
   "Reporting",
   "REST API",
   "REST",
+  "Rich Text Editor",
   "RJIT",
   "Robot",
   "RPC",

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -2,13 +2,24 @@ require "test_helper"
 
 class TopicTest < ActiveSupport::TestCase
   test "create_from_list" do
-    topics = ["Rails", "Ruby", "Rails on Rails"]
+    topics = ["Rails", "Ruby", "Ruby on Rails"]
     statuses = ["pending", "approved", "rejected"]
 
     statuses.each do |status|
-      Topic.create_from_list(topics, status: status)
-      assert_equal status, Topic.last.status
+      created_topics = Topic.create_from_list(topics, status: status)
+      assert_equal [status], created_topics.pluck(:status).uniq
+      Topic.where(name: topics).destroy_all
     end
+  end
+
+  test "create_from_list shoudln't update status of exiting topic" do
+    topic = Topic.create(name: "Ruby on Rails", status: :approved)
+    assert_equal "approved", topic.status
+
+    created_topics = Topic.create_from_list([topic.name], status: :pending)
+
+    assert_equal 1, created_topics.length
+    assert_equal "approved", created_topics.first.status
   end
 
   test "create_from_list with duplicated topics" do


### PR DESCRIPTION
It seems like that the `create_from_list()` method in `Topic` was resetting already approved Topics when new ones get created from the `AnalyzeTalkTopicsJob`. This pull request splits the two cases, one for just looking up an existing topic and the other one for creating the topic with the given status.