### PR TITLE
Update Meta Tags to Rails 7.2

### DIFF
--- a/app/controllers/concerns/metadata.rb
+++ b/app/controllers/concerns/metadata.rb
@@ -9,7 +9,7 @@ module Metadata
 
   def set_default_meta_tags
     set_meta_tags({
-      description: "A collection of talks of Ruby conferences around the world, built using Rails 7.1, Hotwire and Kamal"
+      description: "A collection of talks of Ruby conferences around the world, built using Rails 7.2, Hotwire and Kamal"
     })
   end
 end


### PR DESCRIPTION
We are now running Rails 7.2 (via #121) 🚀 