### PR TITLE
Upgrade `avo` to `3.11.7`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,5 +127,5 @@ gem "json-repair", "~> 0.2.0"
 
 gem "redcarpet", "~> 3.6"
 gem "country_select", "~> 8.0"
-gem "avo", ">= 3.2"
+gem "avo", "~> 3.11"
 gem "frozen_record", "~> 0.27.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       rack
     ast (2.4.2)
     authentication-zero (2.16.36)
-    avo (3.10.10)
+    avo (3.11.7)
       actionview (>= 6.1)
       active_link_to
       activerecord (>= 6.1)
@@ -514,7 +514,7 @@ DEPENDENCIES
   annotate
   appsignal (~> 3.4)
   authentication-zero (~> 2.16)
-  avo (>= 3.2)
+  avo (~> 3.11)
   bcrypt (~> 3.1.7)
   bootsnap
   byebug (~> 11.1)


### PR DESCRIPTION
I upgraded Avo locally for #140, but didn't commit it. Now with https://github.com/avo-hq/avo/issues/3151 I wanted to make sure the Avo on `main` is also running the latest version.