### PR TITLE
Remove `year` column from `Talk` model

### DIFF
--- a/app/avo/resources/talk.rb
+++ b/app/avo/resources/talk.rb
@@ -36,7 +36,6 @@ class Avo::Resources::Talk < Avo::BaseResource
     field :thumbnail_sm, as: :text, hide_on: :index
     field :thumbnail_md, as: :text, hide_on: :index
     field :thumbnail_lg, as: :text, hide_on: :index
-    field :year, as: :number
     field :thumbnail_xs, as: :text, hide_on: :index
     field :thumbnail_xl, as: :text, hide_on: :index
     field :date, as: :date, hide_on: :index

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -47,6 +47,6 @@ class TalksController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def talk_params
-    params.require(:talk).permit(:title, :description, :slug, :year)
+    params.require(:talk).permit(:title, :description, :slug, :date)
   end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -12,7 +12,6 @@
 #  thumbnail_sm        :string           default(""), not null
 #  thumbnail_md        :string           default(""), not null
 #  thumbnail_lg        :string           default(""), not null
-#  year                :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  event_id            :integer

--- a/app/views/talks/_form.html.erb
+++ b/app/views/talks/_form.html.erb
@@ -22,8 +22,8 @@
   </div>
 
   <div class="my-5">
-    <%= form.label :year %>
-    <%= form.number_field :year, class: "input input-bordered w-full" %>
+    <%= form.label :date %>
+    <%= form.text_field :date, class: "input input-bordered w-full" %>
   </div>
 
   <div class="inline">

--- a/db/migrate/20240819134138_drop_year_from_talk.rb
+++ b/db/migrate/20240819134138_drop_year_from_talk.rb
@@ -1,0 +1,5 @@
+class DropYearFromTalk < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :talks, :year
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_18_212042) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_19_134138) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -156,7 +156,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_18_212042) do
     t.string "thumbnail_sm", default: "", null: false
     t.string "thumbnail_md", default: "", null: false
     t.string "thumbnail_lg", default: "", null: false
-    t.integer "year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "event_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,16 +44,17 @@ MeiliSearch::Rails.deactivate! do
 
         talk = Talk.find_or_create_by!(title: talk_data["title"], event: event) do |tlk|
           tlk.description = talk_data["description"]
-          tlk.year = talk_data["year"].presence || event_data["year"]
           tlk.video_id = talk_data["video_id"]
           tlk.video_provider = :youtube
-          tlk.date = talk_data["published_at"]
           tlk.language = talk_data["language"]
           tlk.thumbnail_xs = talk_data["thumbnail_xs"] || ""
           tlk.thumbnail_sm = talk_data["thumbnail_sm"] || ""
           tlk.thumbnail_md = talk_data["thumbnail_md"] || ""
           tlk.thumbnail_lg = talk_data["thumbnail_lg"] || ""
           tlk.thumbnail_xl = talk_data["thumbnail_xl"] || ""
+
+          year = talk_data["year"].presence || event_data["year"]
+          tlk.date = talk_data["date"] || talk_data["published_at"] || Date.parse("#{year}-01-01")
 
           slug = talk_data["title"].parameterize
 

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -26,7 +26,7 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update talk" do
-    patch talk_url(@talk), params: {talk: {description: @talk.description, slug: @talk.slug, title: @talk.title, year: @talk.year}}
+    patch talk_url(@talk), params: {talk: {description: @talk.description, slug: @talk.slug, title: @talk.title, date: @talk.date}}
     assert_redirected_to talk_url(@talk)
   end
 

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -12,7 +12,6 @@
 #  thumbnail_sm        :string           default(""), not null
 #  thumbnail_md        :string           default(""), not null
 #  thumbnail_lg        :string           default(""), not null
-#  year                :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  event_id            :integer
@@ -40,11 +39,9 @@ one:
     - Bad practices
   slug: yaroslav-shmarov-hotwire-cookbook-common-uses-essential-patterns-best-practices-rails-world
   video_id: F75k4Oc6g9Q
-  year: 2023
   raw_transcript: '[{"start_time": "00:00:15.280", "end_time": "00:00:21.320", "text": "so nice to be here with you thank you all for coming so uh my name is uh"}, {"start_time": "00:00:21.320", "end_time": "00:00:27.800", "text": "yaroslav I m from Ukraine you might know me from my blog or from my super Al"}, {"start_time": "00:00:27.800", "end_time": "00:00:34.399", "text": "YouTube channel where I post a lot of stuff about trby and especially about hot fire so I originate from Ukraine"}, {"start_time": "00:00:34.399", "end_time": "00:00:40.239", "text": "from the north of Ukraine so right now it is liberated so that is Kev Chernobyl"}, {"start_time": "00:00:40.239", "end_time": "00:00:45.920", "text": "and chern so I used to live 80 kmers away from Chernobyl great"}, {"start_time": "00:00:45.920", "end_time": "00:00:52.680", "text": "place yeah and uh that is my family s home so it got boned in one of the first"}, {"start_time": "00:00:52.680", "end_time": "00:01:00.000", "text": "days of war that is my godfather he went to defend Ukraine and uh I mean we are"}, {"start_time": "00:01:00.000", "end_time": "00:01:05.799", "text": "he has such a beautiful venue but there is the war going on and like just today"}, {"start_time": "00:01:05.799", "end_time": "00:01:13.159", "text": "the city of har was randomly boned by the Russians and there are many Ruby"}, {"start_time": "00:01:13.159", "end_time": "00:01:19.520", "text": "rails people from Ukraine some of them are actually fighting this is verok he contributed to Ruby and he is actually"}, {"start_time": "00:01:19.520", "end_time": "00:01:27.960", "text": "defending Ukraine right now but on a positive note I just recently became a father"}, {"start_time": "00:01:27.960", "end_time": "00:01:35.000", "text": "so yeah um it is uh just 2 and a half months ago in uh France and uh today we"}, {"start_time": "00:01:35.000", "end_time": "00:01:35.000", "text": "are going to talk about hot fire"}]'
 
 two:
   title: talk title 2
   description: talk descritpion 2
   slug: talk-title-2
-  year: 2022

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -12,7 +12,6 @@
 #  thumbnail_sm        :string           default(""), not null
 #  thumbnail_md        :string           default(""), not null
 #  thumbnail_lg        :string           default(""), not null
-#  year                :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  event_id            :integer

--- a/test/system/talks_test.rb
+++ b/test/system/talks_test.rb
@@ -16,7 +16,6 @@ class TalksTest < ApplicationSystemTestCase
 
     fill_in "Description", with: @talk.description
     fill_in "Title", with: @talk.title
-    fill_in "Year", with: @talk.year
     click_on "Suggest modifications"
 
     assert_text "Your suggestion was successfully created and will be reviewed soon."

--- a/test/tasks/db_seed_test.rb
+++ b/test/tasks/db_seed_test.rb
@@ -14,8 +14,8 @@ class DbSeedTest < ActiveSupport::TestCase
       Rake::Task["db:seed"].invoke
     end
 
-    # ensure that all talks have a year
-    assert_equal Talk.where(year: nil).count, 0
+    # ensure that all talks have a date
+    assert_equal Talk.where(date: nil).count, 0
 
     # Ensuring idempotency
     assert_no_difference "Talk.maximum(:created_at)" do


### PR DESCRIPTION
I don't think we need the `year` column on the `Talk` model, since we have a `date` column.

This pull request therefore removes the `year` column. For the seeds, it adds the `year` field as a fallback if both `date` and `published_at` aren't present.