### PR TITLE
Workaround for language filter

### DIFF
--- a/app/avo/filters/language.rb
+++ b/app/avo/filters/language.rb
@@ -7,7 +7,7 @@ class Avo::Filters::Language < Avo::Filters::SelectFilter
 
   def apply(request, query, language)
     if language
-      query.where(language: language)
+      query.where("language is ?", language)
     else
       query
     end


### PR DESCRIPTION
Avo can't handle the [Rails 7.1 `normalizes`](https://github.com/rails/rails/pull/43945) feature for the Filter query, this pull request implements the workaround discussed in this comment: https://github.com/avo-hq/avo/issues/3151#issuecomment-2298725355. This way it doesn't try to serialize the `Proc` for the `normalizes` in the filter query.