### PR TITLE
Upgrade `mission_control-jobs` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem "activerecord-enhancedsqlite3-adapter"
 gem "litestream", "~> 0.10.1"
 gem "solid_cache"
 gem "solid_queue"
-gem "mission_control-jobs"
+gem "mission_control-jobs", "~> 0.3"
 
 gem "inline_svg", "~> 1.9"
 gem "net-http", "~> 0.3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,9 +276,10 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
-    mission_control-jobs (0.2.1)
+    mission_control-jobs (0.3.1)
       importmap-rails
-      rails (~> 7.1)
+      irb (~> 1.13)
+      rails (>= 7.1)
       stimulus-rails
       turbo-rails
     msgpack (1.7.2)
@@ -453,7 +454,7 @@ GEM
       rubocop-performance (~> 1.21.0)
     standardrb (1.0.1)
       standard
-    stimulus-rails (1.3.3)
+    stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
     strscan (3.1.0)
@@ -539,7 +540,7 @@ DEPENDENCIES
   litestream (~> 0.10.1)
   meilisearch-rails
   meta-tags (~> 2.18)
-  mission_control-jobs
+  mission_control-jobs (~> 0.3)
   net-http (~> 0.3.2)
   pagy
   propshaft


### PR DESCRIPTION
Upgrade `mission_control-jobs` gem to avoid deprecation warning. 
```
❯ rails c

DEPRECATION WARNING: Extending Rails console through `Rails::ConsoleMethods` is deprecated and will be removed in Rails 8.0.
Please directly use IRB's extension API to add new commands or helpers to the console.
For more details, please visit: https://github.com/ruby/irb/blob/master/EXTEND_IRB.md
 (called from block in <class:Engine> at /Users/marcoroth/.anyenv/envs/rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/mission_control-jobs-0.2.1/lib/mission_control/jobs/engine.rb:73)
```

This was fixed in https://github.com/rails/mission_control-jobs/pull/117 and released with https://github.com/rails/mission_control-jobs/releases/tag/v0.2.2