### PR TITLE
default to en when language is nil or invalid

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -60,7 +60,7 @@ class Talk < ApplicationRecord
 
   # normalization
   normalizes :language, apply_to_nil: true, with: ->(language) do
-    Language.find(language)&.alpha2 || Language::DEFAULT
+    language.present? ? Language.find(language)&.alpha2 : Language::DEFAULT
   end
 
   # TODO convert to performs

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -58,13 +58,10 @@ class Talk < ApplicationRecord
   # jobs
   performs :update_from_yml_metadata!, queue_as: :low
 
-  # attributes
-  attribute :language, default: Language::DEFAULT
-
   # normalization
-  normalizes :language, with: ->(language) {
-    language.present? ? Language.find(language)&.alpha2 : Language::DEFAULT
-  }
+  normalizes :language, apply_to_nil: true, with: ->(language) do
+    Language.find(language)&.alpha2 || Language::DEFAULT
+  end
 
   # TODO convert to performs
   def analyze_talk_topics!

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -129,8 +129,8 @@ class TalkTest < ActiveSupport::TestCase
     assert_equal "ja", Talk.new(language: "japanese").language
     assert_equal "ja", Talk.new(language: "ja").language
 
-    assert_equal "en", Talk.new(language: "doesntexist").language
-    assert_equal "en", Talk.new(language: "random").language
+    assert_nil Talk.new(language: "doesntexist").language
+    assert_nil Talk.new(language: "random").language
   end
 
   test "invalid language defaults to english" do
@@ -138,8 +138,9 @@ class TalkTest < ActiveSupport::TestCase
     talk.language = "random"
     talk.valid?
 
-    assert_equal 0, talk.errors.size
-    assert_equal "en", talk.language
+    assert_equal 2, talk.errors.size
+    assert_equal ["Language can't be blank", "Language  is not a valid IS0-639 alpha2 code"],
+      talk.errors.map(&:full_message)
   end
 
   test "create a new talk with a nil language" do

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -120,7 +120,7 @@ class TalkTest < ActiveSupport::TestCase
     assert_equal "en", Talk.new.language
   end
 
-  test "language is normalized to alpha2 code or defautl to english" do
+  test "language is normalized to alpha2 code" do
     assert_equal "en", Talk.new(language: "English").language
     assert_equal "en", Talk.new(language: "english").language
     assert_equal "en", Talk.new(language: "en").language
@@ -133,7 +133,7 @@ class TalkTest < ActiveSupport::TestCase
     assert_nil Talk.new(language: "random").language
   end
 
-  test "invalid language defaults to english" do
+  test "language must be valid and present" do
     talk = talks(:one)
     talk.language = "random"
     talk.valid?

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -120,7 +120,7 @@ class TalkTest < ActiveSupport::TestCase
     assert_equal "en", Talk.new.language
   end
 
-  test "language is normalized to alpha2 code" do
+  test "language is normalized to alpha2 code or defautl to english" do
     assert_equal "en", Talk.new(language: "English").language
     assert_equal "en", Talk.new(language: "english").language
     assert_equal "en", Talk.new(language: "en").language
@@ -129,17 +129,22 @@ class TalkTest < ActiveSupport::TestCase
     assert_equal "ja", Talk.new(language: "japanese").language
     assert_equal "ja", Talk.new(language: "ja").language
 
-    assert_nil Talk.new(language: "doesntexist").language
-    assert_nil Talk.new(language: "random").language
+    assert_equal "en", Talk.new(language: "doesntexist").language
+    assert_equal "en", Talk.new(language: "random").language
   end
 
-  test "language must be valid and present" do
+  test "invalid language defaults to english" do
     talk = talks(:one)
     talk.language = "random"
     talk.valid?
 
-    assert_equal 2, talk.errors.size
-    assert_equal ["Language can't be blank", "Language  is not a valid IS0-639 alpha2 code"],
-      talk.errors.map(&:full_message)
+    assert_equal 0, talk.errors.size
+    assert_equal "en", talk.language
+  end
+
+  test "create a new talk with a nil language" do
+    talk = Talk.create!(title: "New title", language: nil)
+    assert_equal "en", talk.language
+    assert talk.valid?
   end
 end


### PR DESCRIPTION
@marcoroth I think there where some kind conflict between the validation and normalize. Also added the `apply_to_nil: true` setting for the normalize function. as a result if the language is nil or unknow it always defaults to `en` 