### PR TITLE
set canonical speaker

### DIFF
--- a/app/avo/actions/assign_canonical_speaker.rb
+++ b/app/avo/actions/assign_canonical_speaker.rb
@@ -1,0 +1,23 @@
+class Avo::Actions::AssignCanonicalSpeaker < Avo::BaseAction
+  self.name = "Assign Canonical Speaker"
+  # self.visible = -> do
+  #   true
+  # end
+
+  def fields
+    field :speaker_id, as: :select, name: "Canonical speaker",
+      help: "The name of the speaker to be set as canonical",
+      options: -> { Speaker.order(:name).pluck(:name, :id) }
+  end
+
+  def handle(query:, fields:, current_user:, resource:, **args)
+    canonical_speaker = Speaker.find(fields[:speaker_id])
+
+    query.each do |record|
+      record.assign_canonical_speaker!(canonical_speaker: canonical_speaker)
+    end
+
+    succeed "Assigning canonical speaker #{canonical_speaker.name} to #{query.count} speakers"
+    redirect_to avo.resources_speaker_path(canonical_speaker)
+  end
+end

--- a/app/avo/actions/assign_canonical_speaker.rb
+++ b/app/avo/actions/assign_canonical_speaker.rb
@@ -18,6 +18,6 @@ class Avo::Actions::AssignCanonicalSpeaker < Avo::BaseAction
     end
 
     succeed "Assigning canonical speaker #{canonical_speaker.name} to #{query.count} speakers"
-    redirect_to avo.resources_speaker_path(canonical_speaker)
+    redirect_to avo.resources_speaker_path(canonical_speaker), status: :permanent_redirect
   end
 end

--- a/app/avo/resources/speaker.rb
+++ b/app/avo/resources/speaker.rb
@@ -33,6 +33,6 @@ class Avo::Resources::Speaker < Avo::BaseResource
 
   def actions
     action Avo::Actions::SpeakerGithub
-    action Avo::Actions::MergeSpeakerInto
+    action Avo::Actions::AssignCanonicalSpeaker
   end
 end

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -43,6 +43,7 @@ class SpeakersController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_speaker
     @speaker = Speaker.includes(:talks).find_by!(slug: params[:slug])
+    redirect_to speaker_path(@speaker.canonical) if @speaker.canonical.present?
   end
 
   # Only allow a list of trusted parameters through.

--- a/db/migrate/20240901163900_add_canonical_reference_to_speaker.rb
+++ b/db/migrate/20240901163900_add_canonical_reference_to_speaker.rb
@@ -1,0 +1,5 @@
+class AddCanonicalReferenceToSpeaker < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :speakers, :canonical, foreign_key: {to_table: :speakers}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_21_191208) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_01_163900) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -123,6 +123,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_21_191208) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "talks_count", default: 0, null: false
+    t.integer "canonical_id"
+    t.index ["canonical_id"], name: "index_speakers_on_canonical_id"
     t.index ["name"], name: "index_speakers_on_name"
     t.index ["slug"], name: "index_speakers_on_slug", unique: true
   end
@@ -205,6 +207,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_21_191208) do
   add_foreign_key "events", "organisations"
   add_foreign_key "password_reset_tokens", "users"
   add_foreign_key "sessions", "users"
+  add_foreign_key "speakers", "speakers", column: "canonical_id"
   add_foreign_key "talk_topics", "talks"
   add_foreign_key "talk_topics", "topics"
   add_foreign_key "talks", "events"

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -21,6 +21,18 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should redirect to canonical speaker" do
+    talk = @speaker_with_talk.talks.first
+    @speaker_with_talk.assign_canonical_speaker!(canonical_speaker: @speaker)
+    @speaker_with_talk.reload
+    assert_equal @speaker, @speaker_with_talk.canonical
+    assert @speaker.talks.ids.include?(talk.id)
+    assert @speaker_with_talk.talks.empty?
+
+    get speaker_url(@speaker_with_talk)
+    assert_redirected_to speaker_url(@speaker)
+  end
+
   test "should get edit" do
     get edit_speaker_url(@speaker)
     assert_response :success


### PR DESCRIPTION
in order to update speakers and duplicates this PR update the `merge to` action with an assign canonical. the main objective is to avoid creating broken backlinks and to avoid deleting existing pages. Rather than deleting we set a canonical speaker with permanent redirection