### PR TITLE
Data cleanup of talk titles, event names, and published dates

### DIFF
--- a/data/blue-ridge-ruby/blue-ridge-ruby-2023/videos.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2023/videos.yml
@@ -81,7 +81,7 @@
     more exciting developments in the language, especially when it comes to performance.
   video_id: s0NMy_PBxkk
 
-- title: "What's you type? Generating type signatures with Sorbet and Tapioca"
+- title: "What's your type? Generating type signatures with Sorbet and Tapioca"
   raw_title: "BlueRidgeRuby2023: What's you type? Generating type signatures with Sorbet and Tapioca - Emily Samp"
   speakers:
     - Emily Samp

--- a/data/helsinki-ruby-brigade/helsinki-ruby-brigade/videos.yml
+++ b/data/helsinki-ruby-brigade/helsinki-ruby-brigade/videos.yml
@@ -1,64 +1,68 @@
 ---
-- title: Oivan’s journey with Ruby on Rails
+- title: Oivan's journey with Ruby on Rails
   raw_title: Oivan’s journey with Ruby on Rails
   speakers:
     - Aki Teliö
-  event_name: Ruby Brigade
-  published_at: "2023-06-20"
+  event_name: Helsinki Ruby Brigade
+  published_at: "2023-05-10"
   description: |-
     Oivan has built and scaling one of the largest applications in the ME region. Among this journey, there have been several learnings including restructuring the team, cultural differences and working with microservices application. Now we are scaling up and building larger teams.
 
     Aki Teliö at the Helsinki Ruby Brigade meet-up on 2023-05-10.
   video_id: 8s-8E0NhM88
+
 - title: Ruby ❤️ Rust
   raw_title: Ruby ❤️ Rust
   speakers:
     - Matias Korhonen
-  event_name: Ruby Brigade
-  published_at: "2023-06-20"
+  event_name: Helsinki Ruby Brigade
+  published_at: "2023-05-10"
   description: |-
     A very quick intro to Rust-based gem extensions and an even quicker introduction to Rust itself.
 
     Matias Korhonen at the Helsinki Ruby Brigade meet-up on 2023-05-10.
   video_id: O5HCGJIcK68
+
 - title: Interact with AI effortlessly
   raw_title: Interact with AI effortlessly
   speakers:
     - Lauri Jutila
-  event_name: Ruby Brigade
-  published_at: "2023-06-20"
+  event_name: Helsinki Ruby Brigade
+  published_at: "2023-05-10"
   description: |-
     AI, and especially LLMs, are all the rage right now. Lauri will show you how interacting with AI models can be easy and effortless.
 
     Lauri Jutila at the Helsinki Ruby Brigade meet-up on 2023-05-10.
   video_id: oftEvWV0us0
+
 - title: "Developers’ role in elevating the quality of design"
   raw_title: Developers’ role in elevating the quality of design
   speakers:
     - Simo Virtanen
-  event_name: Ruby Brigade
-  published_at: "2023-09-09"
+  event_name: Helsinki Ruby Brigade
+  published_at: "2023-09-06"
   description:
     Does designing end when designs are handed over to developers? A talk
     about how developers can help designers be better. By Simo Virtanen at Helsinki
     Ruby Brigade on 2023-09-06.
   video_id: GUKSN6ePoj8
+
 - title: Dependencies – an asset and a curse
   raw_title: Dependencies – an asset and a curse (Joakim Antman)
   speakers:
     - Joakim Antman
-  event_name: Ruby Brigade
-  published_at: "2024-02-26"
+  event_name: Helsinki Ruby Brigade
+  published_at: "2024-02-21"
   description: Helsinki Ruby Brigade, 2024-02-21.
   video_id: gYYBhmSFiCE
+
 - title: How I’m trying to fix localization, and what you can do to help
   raw_title:
-    How I’m trying to fix localization, and what you can do to help (Eemeli
-    Aro)
+    How I’m trying to fix localization, and what you can do to help (Eemeli Aro)
   speakers:
     - Eemeli Aro
-  event_name: Ruby Brigade
-  published_at: "2024-02-26"
+  event_name: Helsinki Ruby Brigade
+  published_at: "2024-02-21"
   description: |-
     Like many other problems in coding, localization (the art of making your stuff usable and nice to people from various countries and cultures) can seem really easy, until it’s not. Really simple solutions often get you most of the way to what you need, but then the final few complexities turn out to be Hard. I’ve spent a decade working on making localization easier; let me share with you a couple of the projects I’m currently engaged in, and how you can help make the world a little bit more international.
 

--- a/data/helsinki-ruby-brigade/playlists.yml
+++ b/data/helsinki-ruby-brigade/playlists.yml
@@ -7,4 +7,4 @@
   year: 2023
   videos_count: 6
   metadata_parser: Youtube::VideoMetadata
-  slug: ruby-brigade
+  slug: helsinki-ruby-brigade

--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -1,5 +1,5 @@
 ---
-- name: Railsconf
+- name: RailsConf
   website: https://railsconf.org/
   twitter: railsconf
   youtube_channel_name: confreaks
@@ -21,7 +21,7 @@
   slug: rails-pacific
   language: english
 
-- name: RailsWorld
+- name: Rails World
   website: https://rubyonrails.org/world
   twitter: rails
   kind: conference

--- a/data/railsconf/playlists.yml
+++ b/data/railsconf/playlists.yml
@@ -8,6 +8,7 @@
   videos_count: 9
   metadata_parser: Youtube::VideoMetadata
   slug: railsconf-2011
+
 - id: PLF16D2F3A8469021E
   title: RailsConf 2012
   description:
@@ -78,6 +79,7 @@
   year: "2019"
   videos_count: 86
   slug: railsconf-2019
+
 - id: PLE7tQUdRKcyZ-TzxlxdLvh6tDUfZHqm76
   title: RailsConf 2020 CE
   description: |-

--- a/data/railsconf/railsconf-2017/videos.yml
+++ b/data/railsconf/railsconf-2017/videos.yml
@@ -33,7 +33,7 @@
     Why are there are so many disagreements in software? Why don’t we all converge on the same beliefs or technologies? It might sound obvious that people shouldn't agree, but I want to convince you it’s weird that we don't. This talk will be a philosophical exploration of how knowledge converges within subcultures, as I explore this question through the worlds of software, online fraud, and poker.
   video_id: x07q6V4VXC8
 
-- title: 'Opening Keynote'
+- title: 'Keynote: The Best Tool For The Job!'
   raw_title: 'RailsConf 2017: Opening Keynote by David Heinemeier Hansson'
   speakers:
     - David Heinemeier Hansson


### PR DESCRIPTION
I collected some miscellaneous fixes/typos over the last few weeks which aren't really group-able otherwise, so here's a pull request that fixes those. 