### PR TITLE
Sign in modal

### DIFF
--- a/app/components/ui/modal_component.html.erb
+++ b/app/components/ui/modal_component.html.erb
@@ -1,0 +1,8 @@
+<%= content_tag :dialog, class: classes, **attributes do %>
+  <div class="modal-box" data-modal-target="modalBox">
+    <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" data-action="click->modal#close">
+      <%= helpers.heroicon :x_mark %>
+    </button>
+    <%= content %>
+  </div>
+<% end %>

--- a/app/components/ui/modal_component.rb
+++ b/app/components/ui/modal_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Ui::ModalComponent < ApplicationComponent
+  POSITION_MAPPING = {
+    top: "modal-top",
+    bottom: "modal-bottom",
+    middle: "modal-middle",
+    responsive: "modal-bottom sm:modal-middle"
+  }
+
+  option :open, type: Dry::Types["strict.bool"], default: proc { false }
+  option :position, type: Dry::Types["coercible.symbol"].enum(*POSITION_MAPPING.keys), optional: true, default: proc { :responsive }
+
+  private
+
+  def before_render
+    attributes[:data] = {controller: "modal", modal_open_value: open, action: "keydow->modal#close"}
+  end
+
+  def classes
+    [component_classes, attributes.delete(:class)].compact_blank.join(" ")
+  end
+
+  def component_classes
+    class_names(
+      "modal",
+      POSITION_MAPPING[position]
+    )
+  end
+
+  def content_classes
+    class_names("dropdown-content menu menu-smp-2 mt-4 w-max z-[1] rounded-lg shadow-2xl bg-white text-neutral", attributes.delete(:content_classes))
+  end
+end

--- a/app/controllers/concerns/remote_modal.rb
+++ b/app/controllers/concerns/remote_modal.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#
+# include this module in your controller to respond with a remote modal
+# if the request is a turbo frame request with a turbo_frame_id="modal"
+# then the response will use the modal layout (wraps the content into a self opening modal)
+#
+module RemoteModal
+  extend ActiveSupport::Concern
+  DEFAULT_ALLOWED_ACTIONS = %i[new show edit index].freeze
+
+  included do
+    before_action :allowed_action?
+    layout :define_layout
+  end
+
+  class_methods do
+    #
+    # provide a list of actions that should be allowed to be called remotely
+    #
+    # @param [Array<Symbol>] *actions list of actions that should be allowed to be called remotely
+    #
+    # @return [Array<Symbol>]
+    #
+    def allowed_remote_modal_actions(*actions)
+      @allowed_actions = actions
+    end
+
+    def allowed_actions
+      @allowed_actions || DEFAULT_ALLOWED_ACTIONS
+    end
+  end
+
+  private
+
+  def allowed_action?
+    self.class.allowed_actions.include?(action_name.to_sym)
+  end
+
+  def define_layout
+    return "modal" if turbo_frame_request_id == "modal" && allowed_action?
+
+    "application"
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,7 @@
 class SessionsController < ApplicationController
+  include RemoteModal
+  allowed_remote_modal_actions :new
+
   skip_before_action :authenticate_user!, only: %i[new create]
 
   before_action :set_session, only: :destroy

--- a/app/helpers/view_component_helper.rb
+++ b/app/helpers/view_component_helper.rb
@@ -3,7 +3,8 @@ module ViewComponentHelper
     badge: "Ui::BadgeComponent",
     button: "Ui::ButtonComponent",
     divider: "Ui::DividerComponent",
-    dropdown: "Ui::DropdownComponent"
+    dropdown: "Ui::DropdownComponent",
+    modal: "Ui::ModalComponent"
   }.freeze
 
   UI_HELPERS.each do |name, component|

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,6 +10,9 @@ application.register("auto-submit", AutoSubmitController)
 import DropdownController from "./dropdown_controller"
 application.register("dropdown", DropdownController)
 
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
+
 import PageTransitionMissingController from "./page_transition_missing_controller"
 application.register("page-transition-missing", PageTransitionMissingController)
 

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from '@hotwired/stimulus'
+import { useClickOutside } from 'stimulus-use'
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  static values = {
+    open: Boolean
+  }
+
+  static targets = ['modalBox']
+
+  initialize () {
+    useClickOutside(this, { element: this.modalBoxTarget })
+  }
+
+  connect () {
+    if (this.openValue) {
+      this.open()
+    }
+  }
+
+  disconnect () {
+    this.close()
+  }
+
+  clickOutside (event) {
+    this.close()
+  }
+
+  open () {
+    this.element.showModal()
+  }
+
+  close (e) {
+    e?.preventDefault()
+
+    this.element.close()
+  }
+}

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -14,13 +14,3 @@ import '~/controllers'
 
 // Page transitions
 Turn.start()
-
-document.addEventListener('turbo:before-frame-render', (event) => {
-  if (document.startViewTransition) {
-    event.preventDefault()
-
-    document.startViewTransition(() => {
-      event.detail.resume()
-    })
-  }
-})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,5 +31,6 @@
     </div>
 
     <%= render "shared/footer" %>
+    <%= turbo_frame_tag "modal" %>
   </body>
 </html>

--- a/app/views/layouts/modal.html.erb
+++ b/app/views/layouts/modal.html.erb
@@ -1,0 +1,5 @@
+<%= turbo_frame_tag "modal" do %>
+  <%= ui_modal open: true, position: :responsive do %>
+    <%= yield %>
+  <% end %>
+<% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,11 +1,9 @@
 <% redirect_to_path = params.delete(:redirect_to) || root_path %>
 
-<div class="flex items-center justify-center py-24 px-4 sm:px-6 lg:px-8">
+<div class="flex items-center justify-center sm:py-24 px-4 sm:px-6 lg:px-8">
   <div class="max-w-md w-full space-y-8">
     <div>
-      <h1 class="mt-6 text-center text-3xl font-semibold text-neutral">
-        Sign in to your account
-      </h1>
+      <div class="mt-4 leading-relaxed"><strong>Sign in</strong> to bookmark your favorite talks, create watch lists and more to come.</div>
     </div>
     <div class="mt-8 space-y-6">
       <div>
@@ -22,6 +20,7 @@
           <% end %>
         </div>
       <% end %>
+      <div class="text-base font-light leading-relaxed"> We collect your email address, name and Github handle to create your account. All attributes are encrypted in our database. We do not share your email address with anyone else.</div>
     </div>
   </div>
 </div>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -59,7 +59,9 @@
                 <% end %>
               <% end %>
             <% else %>
-              <!-- here we want to display the watch list button but it will trigger a sign in modal  -->
+              <%= link_to sign_in_path(redirect_to: request.fullpath), data: {turbo_frame: "modal"} do %>
+                <%= heroicon :bookmark, class: "shrink-0 cursor-pointer mt-1", variant: :outline, size: :sm %>
+              <% end %>
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
add remote modal for sign in 

- adds a new modal component
- adds a new remote modal controller Concern

to open a page in a remote modal update the turbo frame target 
``` erb
<%= link_to sign_in_path(redirect_to: request.fullpath), data: {turbo_frame: "modal"} do %>
```

add the concern to the controller
```ruby
class SessionsController < ApplicationController
  include RemoteModal
  allowed_remote_modal_actions :new
  ...
end
```

![CleanShot 2024-09-12 at 18 07 35@2x](https://github.com/user-attachments/assets/968c093d-9dce-41bd-a5ea-60d146a051f3)





