### PR TITLE
Add GitHub handle to user model

### DIFF
--- a/app/controllers/sessions/omniauth_controller.rb
+++ b/app/controllers/sessions/omniauth_controller.rb
@@ -9,6 +9,7 @@ class Sessions::OmniauthController < ApplicationController
       @user = User.find_or_create_by(email: github_email) do |user|
         user.password = SecureRandom.base58
         user.verified = true
+        user.github_handle = omniauth.info&.try(:nickname)
       end
       connected_account.user = @user
       connected_account.access_token = token

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -25,8 +25,10 @@ class Speaker < ApplicationRecord
   # associations
   has_many :speaker_talks, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id
   has_many :talks, through: :speaker_talks, inverse_of: :speakers
-  belongs_to :canonical, class_name: "Speaker", optional: true
   has_many :aliases, class_name: "Speaker", foreign_key: "canonical_id"
+
+  belongs_to :canonical, class_name: "Speaker", optional: true
+  belongs_to :user, primary_key: :github_handle, foreign_key: :github, optional: true
 
   # validations
   validates :canonical, exclusion: {in: ->(speaker) { [speaker] }, message: "can't be itself"}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true, format: {with: URI::MailTo::EMAIL_REGEXP}
   validates :password, allow_nil: true, length: {minimum: 6}
+  validates :github_handle, presence: true, uniqueness: true
 
   encrypts :email, deterministic: true
   encrypts :name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true, format: {with: URI::MailTo::EMAIL_REGEXP}
   validates :password, allow_nil: true, length: {minimum: 6}
-  validates :github_handle, presence: true, uniqueness: true
+  validates :github_handle, presence: true, uniqueness: true, allow_nil: true
 
   encrypts :email, deterministic: true
   encrypts :name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy, inverse_of: :user
   has_many :connected_accounts, dependent: :destroy
   has_many :watch_lists, dependent: :destroy
+  has_one :speaker, primary_key: :github_handle, foreign_key: :github
 
   validates :email, presence: true, uniqueness: true, format: {with: URI::MailTo::EMAIL_REGEXP}
   validates :password, allow_nil: true, length: {minimum: 6}

--- a/db/migrate/20240914162252_add_github_handle_to_user.rb
+++ b/db/migrate/20240914162252_add_github_handle_to_user.rb
@@ -1,0 +1,10 @@
+class AddGithubHandleToUser < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :github_handle, :string
+
+    add_index :users, :github_handle, unique: true
+    ConnectedAccount.all.each do |connected_account|
+      connected_account.user.update(github_handle: connected_account.username)
+    end
+  end
+end

--- a/db/migrate/20240914162252_add_github_handle_to_user.rb
+++ b/db/migrate/20240914162252_add_github_handle_to_user.rb
@@ -2,7 +2,7 @@ class AddGithubHandleToUser < ActiveRecord::Migration[7.2]
   def change
     add_column :users, :github_handle, :string
 
-    add_index :users, :github_handle, unique: true
+    add_index :users, :github_handle, unique: true, where: "github_handle IS NOT NULL"
     ConnectedAccount.all.each do |connected_account|
       connected_account.user.update(github_handle: connected_account.username)
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_12_164120) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_14_162252) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -215,7 +215,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_12_164120) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.string "github_handle"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["github_handle"], name: "index_users_on_github_handle", unique: true
   end
 
   create_table "watch_list_talks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -217,7 +217,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_14_162252) do
     t.string "name"
     t.string "github_handle"
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["github_handle"], name: "index_users_on_github_handle", unique: true
+    t.index ["github_handle"], name: "index_users_on_github_handle", unique: true, where: "github_handle IS NOT NULL"
   end
 
   create_table "watch_list_talks", force: :cascade do |t|

--- a/test/controllers/sessions/omniauth_controller_test.rb
+++ b/test/controllers/sessions/omniauth_controller_test.rb
@@ -31,6 +31,7 @@ class Sessions::OmniauthControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_equal "twitter", User.last.connected_accounts.last.username
+    assert_equal "twitter", User.last.github_handle
   end
 
   test "finds existing user if already exists (developer)" do

--- a/test/models/speaker_test.rb
+++ b/test/models/speaker_test.rb
@@ -38,4 +38,13 @@ class SpeakerTest < ActiveSupport::TestCase
     speaker = Speaker.new(website: "")
     assert_equal "#", speaker.valid_website_url
   end
+
+  test "speaker user association" do
+    speaker = speakers(:one)
+    user = users(:one)
+    user.update(github_handle: speaker.github)
+    assert_equal user.github_handle, speaker.github
+    assert_equal user, speaker.user
+    assert_equal speaker, user.speaker
+  end
 end


### PR DESCRIPTION
currently the GitHub handle is persited in the connected_account model. This does help much if we want to link a user to a speaker or simply display the Github picture profile of the signed in user.

This PR move the stroage of teh handle to the User model and add a link between a User and a speaker when they have the same GitHub handle. This is a first step in the direction to allow user to update their talks summaries or their bio by example 

