### PR TITLE
owner can update speaker and talk data

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -45,7 +45,7 @@ class TalksController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def talk_params
-    params.require(:talk).permit(:title, :description, :slug, :date)
+    params.require(:talk).permit(:title, :description, :summary, :date)
   end
 
   def set_user_favorites

--- a/app/models/concerns/suggestable.rb
+++ b/app/models/concerns/suggestable.rb
@@ -7,11 +7,16 @@ module Suggestable
 
   def create_suggestion_from(params:, user: Current.user)
     suggestions.create(content: select_differences_for(params)).tap do |suggestion|
-      suggestion.approved! if user&.admin?
+      suggestion.approved! if managed_by?(user)
     end
   end
 
   private
+
+  def managed_by?(visiting_user)
+    # this should be overitten in the model where the concern is included
+    raise NotImplementedError, "This method should be implemented in the model where the concern is included"
+  end
 
   def select_differences_for(params)
     params.reject do |key, value|

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -49,6 +49,10 @@ class Event < ApplicationRecord
     end
   end
 
+  def managed_by?(user)
+    Current.user&.admin?
+  end
+
   def suggestion_summary
     <<~HEREDOC
       Event: #{name}

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -47,6 +47,13 @@ class Speaker < ApplicationRecord
     name
   end
 
+  def managed_by?(visiting_user)
+    return false unless visiting_user.present?
+    return true if visiting_user.admin?
+
+    user == visiting_user
+  end
+
   def github_avatar_url(size: 200)
     return "" unless github.present?
 

--- a/app/models/suggestion.rb
+++ b/app/models/suggestion.rb
@@ -31,7 +31,7 @@ class Suggestion < ApplicationRecord
 
   def notice
     if approved?
-      "Suggestion approved!"
+      "Modification approved!"
     elsif rejected?
       "Suggestion rejected!"
     else

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -104,6 +104,13 @@ class Talk < ApplicationRecord
   scope :without_topics, -> { where.missing(:talk_topics) }
   scope :with_topics, -> { joins(:talk_topics) }
 
+  def managed_by?(visiting_user)
+    return false unless visiting_user.present?
+    return true if visiting_user.admin?
+
+    speakers.exists?(user: visiting_user)
+  end
+
   def to_meta_tags
     {
       title: title,

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -52,8 +52,32 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should update event" do
-    patch event_url(@event), params: {event: {city: "Paris", country_code: "FR"}}
+  test "should create a pending suggestion for anonymous users" do
+    assert_difference "Suggestion.pending.count", 1 do
+      patch event_url(@event), params: {event: {city: "Paris", country_code: "FR"}}
+    end
+
+    assert_redirected_to event_url(@event)
+  end
+
+  test "should create a pending suggestion for signed in users" do
+    sign_in_as @user
+
+    assert_difference "Suggestion.pending.count", 1 do
+      patch event_url(@event), params: {event: {city: "Paris", country_code: "FR"}}
+    end
+
+    assert_redirected_to event_url(@event)
+  end
+
+  test "should update directly the content for admins" do
+    sign_in_as users(:admin)
+    assert_difference "Suggestion.approved.count", 1 do
+      patch event_url(@event), params: {event: {city: "Paris", country_code: "FR"}}
+    end
+
+    assert_equal "Paris", @event.reload.city
+    assert_equal "FR", @event.reload.country_code
     assert_redirected_to event_url(@event)
   end
 end

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -38,9 +38,43 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should update speaker" do
-    patch speaker_url(@speaker), params: {speaker: {bio: @speaker.bio, github: @speaker.github, name: @speaker.name, slug: @speaker.slug, twitter: @speaker.twitter, website: @speaker.website}}
+  test "should create a suggestion for speaker" do
+    patch speaker_url(@speaker), params: {speaker: {bio: "new bio", github: "new-github", name: "new-name", slug: "new-slug", twitter: "new-twitter", website: "new-website"}}
+
     assert_redirected_to speaker_url(@speaker)
+    assert_not_equal @speaker.reload.bio, "new bio"
+    assert_equal 1, @speaker.suggestions.pending.count
+  end
+
+  test "admin can update directly the speaker" do
+    sign_in_as users(:admin)
+    patch speaker_url(@speaker), params: {speaker: {bio: "new bio", github: "new-github", name: "new-name", slug: "new-slug", twitter: "new-twitter", website: "new-website"}}
+
+    assert_redirected_to speaker_url(@speaker)
+    assert_equal "new bio", @speaker.reload.bio
+    assert_equal 0, @speaker.suggestions.pending.count
+  end
+
+  test "owner can update directly the speaker" do
+    user = User.create!(email: "test@example.com", password: "Secret1*3*5*", github_handle: @speaker.github, verified: true)
+    assert user.persisted?
+    assert_equal user, @speaker.user
+
+    sign_in_as user
+
+    assert_no_changes -> { @speaker.suggestions.pending.count } do
+      patch speaker_url(@speaker), params: {speaker: {bio: "new bio", github: "new-github", name: "new-name", slug: "new-slug", twitter: "new-twitter", website: "new-website"}}
+    end
+
+    assert_redirected_to speaker_url(@speaker)
+    assert_equal "new bio", @speaker.reload.bio
+    assert_equal @speaker.name, "new-name"
+    assert_equal @speaker.twitter, "new-twitter"
+    assert_equal @speaker.website, "new-website"
+
+    # those attributes can't be changed by the owner
+    assert_not_equal @speaker.github, "new-github"
+    assert_not_equal @speaker.slug, "new-slug"
   end
 
   test "should get index as JSON" do

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -25,9 +25,51 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should update talk" do
-    patch talk_url(@talk), params: {talk: {description: @talk.description, slug: @talk.slug, title: @talk.title, date: @talk.date}}
+  test "anonymous user can suggest a modification" do
+    patch talk_url(@talk), params: {talk: {description: "new description", slug: "new-slug", title: "new title", date: "2024-01-01"}}
     assert_redirected_to talk_url(@talk)
+    assert_equal "Your suggestion was successfully created and will be reviewed soon.", flash[:notice]
+    assert_equal 1, @talk.suggestions.pending.count
+    assert_not_equal "new description", @talk.reload.description
+    assert_not_equal "new title", @talk.title
+    assert_not_equal "2024-01-01", @talk.date.to_s
+  end
+
+  test "admin user can update talk" do
+    @user = users(:admin)
+    sign_in_as @user
+
+    patch talk_url(@talk), params: {talk: {summary: "new summary", description: "new description", slug: "new-slug", title: "new title", date: "2024-01-01"}}
+    assert_redirected_to talk_url(@talk)
+    assert_equal "Modification approved!", flash[:notice]
+    assert_equal 1, @talk.suggestions.approved.count
+    assert_equal "new description", @talk.reload.description
+    assert_equal "new summary", @talk.summary
+    assert_equal "new title", @talk.title
+    assert_equal "2024-01-01", @talk.date.to_s
+
+    # some attributes cannot be changed
+    assert_not_equal "new slug", @talk.slug
+  end
+
+  test "owner can update directly the talk" do
+    user = User.create!(email: "test@example.com", password: "Secret1*3*5*", github_handle: @talk.speakers.first.github, verified: true)
+    assert user.persisted?
+    assert_equal user, @talk.speakers.first.user
+
+    sign_in_as user
+
+    patch talk_url(@talk), params: {talk: {summary: "new summary", description: "new description", slug: "new-slug", title: "new title", date: "2024-01-01"}}
+    assert_redirected_to talk_url(@talk)
+    assert_equal "Modification approved!", flash[:notice]
+    assert_equal 1, @talk.suggestions.approved.count
+    assert_equal "new description", @talk.reload.description
+    assert_equal "new summary", @talk.summary
+    assert_equal "new title", @talk.title
+    assert_equal "2024-01-01", @talk.date.to_s
+
+    # some attributes cannot be changed
+    assert_not_equal "new slug", @talk.slug
   end
 
   test "should show topics" do

--- a/test/fixtures/speaker_talks.yml
+++ b/test/fixtures/speaker_talks.yml
@@ -1,0 +1,16 @@
+# rubocop:disable Layout/LineLength
+# == Schema Information
+#
+# Table name: speaker_talks
+#
+#  speaker_id :integer          not null
+#  talk_id    :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  id         :integer          not null, primary key
+#
+# rubocop:enable Layout/LineLength
+
+one:
+  speaker: one
+  talk: one


### PR DESCRIPTION
close #199

A speaker authenticated with the same Github handle can update the metadata of his speaker page and talks 
Other users can suggest changes


