### PR TITLE
add approver to suggestion

### DIFF
--- a/app/models/concerns/suggestable.rb
+++ b/app/models/concerns/suggestable.rb
@@ -7,7 +7,7 @@ module Suggestable
 
   def create_suggestion_from(params:, user: Current.user)
     suggestions.create(content: select_differences_for(params)).tap do |suggestion|
-      suggestion.approved! if managed_by?(user)
+      suggestion.approved!(approver: user) if managed_by?(user)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  name            :string
+#  github_handle   :string
 #
 # rubocop:enable Layout/LineLength
 class User < ApplicationRecord

--- a/db/migrate/20240918050951_add_approved_by_to_suggestion.rb
+++ b/db/migrate/20240918050951_add_approved_by_to_suggestion.rb
@@ -1,0 +1,11 @@
+class AddApprovedByToSuggestion < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :suggestions, :approved_by, foreign_key: {to_table: :users}
+
+    initial_approver = User.find_by(email: "adrienpoly@gmail.com") || User.where(admin: true).order(:created_at).first
+
+    if initial_approver
+      Suggestion.update_all(approved_by_id: initial_approver.id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_14_162252) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_18_050951) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -152,6 +152,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_14_162252) do
     t.integer "suggestable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "approved_by_id"
+    t.index ["approved_by_id"], name: "index_suggestions_on_approved_by_id"
     t.index ["status"], name: "index_suggestions_on_status"
     t.index ["suggestable_type", "suggestable_id"], name: "index_suggestions_on_suggestable"
   end
@@ -246,6 +248,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_14_162252) do
   add_foreign_key "password_reset_tokens", "users"
   add_foreign_key "sessions", "users"
   add_foreign_key "speakers", "speakers", column: "canonical_id"
+  add_foreign_key "suggestions", "users", column: "approved_by_id"
   add_foreign_key "talk_topics", "talks"
   add_foreign_key "talk_topics", "topics"
   add_foreign_key "talks", "events"

--- a/test/fixtures/suggestions.yml
+++ b/test/fixtures/suggestions.yml
@@ -10,6 +10,7 @@
 #  suggestable_id   :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  approved_by_id   :integer
 #
 # rubocop:enable Layout/LineLength
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,6 +11,7 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  name            :string
+#  github_handle   :string
 #
 # rubocop:enable Layout/LineLength
 

--- a/test/models/suggestion_test.rb
+++ b/test/models/suggestion_test.rb
@@ -10,6 +10,7 @@
 #  suggestable_id   :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  approved_by_id   :integer
 #
 # rubocop:enable Layout/LineLength
 require "test_helper"
@@ -31,7 +32,7 @@ class SuggestionTest < ActiveSupport::TestCase
 
     assert suggestion.pending?
 
-    suggestion.approved!
+    suggestion.approved!(approver: users(:one))
 
     assert suggestion.approved?
     assert_equal "Hello World", @talk.reload.title


### PR DESCRIPTION
Add the ability to track who approved the suggestion 
mostly to know if a connected speaker updated his own metadata if so in the future we should try to freeze those metadata from the Github script that fetch the content from the github profile