### PR TITLE
Cleanup and unify Speaker data

### DIFF
--- a/data/ancient-city-ruby/ancient-city-ruby-2013/videos.yml
+++ b/data/ancient-city-ruby/ancient-city-ruby-2013/videos.yml
@@ -88,7 +88,7 @@
 - title: 'This is Your Brain on Software'
   raw_title: Paolo Perrotta - This is Your Brain on Software - Ancient City Ruby 2013
   speakers:
-    - Paolo Perrotta
+    - Paolo "Nusco" Perrotta
   event_name: Ancient City Ruby 2013
   published_at: '2013-06-27'
   description: |-

--- a/data/ancient-city-ruby/ancient-city-ruby-2016/videos.yml
+++ b/data/ancient-city-ruby/ancient-city-ruby-2016/videos.yml
@@ -38,7 +38,7 @@
 - title: 'Unconventional Computing'
   raw_title: Paolo Perrotta - Unconventional Computing - Ancient City Ruby 2016
   speakers:
-    - Paolo Perrotta
+    - Paolo "Nusco" Perrotta
   event_name: Ancient City Ruby 2016
   published_at: '2016-04-21'
   description: |-

--- a/data/balkanruby/balkanruby-2019/videos.yml
+++ b/data/balkanruby/balkanruby-2019/videos.yml
@@ -38,7 +38,7 @@
 - title: 'The Past, Present and Future of Rails at GitHub'
   raw_title: Balkan Ruby 2019 – Eileen Uchitelle – The Past, Present and Future of Rails at GitHub
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: Balkan Ruby 2019
   published_at: '2019-08-05'
   description: ''

--- a/data/euruko/euruko-2018/videos.yml
+++ b/data/euruko/euruko-2018/videos.yml
@@ -3,7 +3,7 @@
   raw_title: EuRuKo 2018 Introduction
   speakers:
     - Pilar Andrea Huidobro Peltier
-    - Ramón Huidobro
+    - Carmen Huidobro
   event_name: Euruko 2018
   published_at: "2021-06-01"
   description:

--- a/data/paris-rb/paris-rb-conf-2018/videos.yml
+++ b/data/paris-rb/paris-rb-conf-2018/videos.yml
@@ -21,7 +21,7 @@
 - title: Living on Rails Edge
   raw_title: '"Living on Rails edge" by Rafael França'
   speakers:
-    - Rafael França
+    - Rafael Mendonça França
   event_name: Paris.rb Conf 2018
   published_at: '2018-07-20'
   description: Recorded in June 2018 during https://2018.rubyparis.org in Paris. More talks at https://goo.gl/8egyWi

--- a/data/rails-world/rails-world-2023/videos.yml
+++ b/data/rails-world/rails-world-2023/videos.yml
@@ -113,7 +113,7 @@
     - Jeremy Daer
     - John Hawthorn
     - Matthew Draper
-    - Rafael França
+    - Rafael Mendonça França
     - Xavier Noria
   event_name: Rails World 2023
   published_at: "2023-10-16"
@@ -123,7 +123,7 @@
     on which features to add? How should Rails evolve in the future? What does it
     take to join the Core team? \n\nRails Core members present were: Aaron Patterson,
     Carlos Antonio Da Silva, David Heinemeier Hansson, Eileen M. Uchitelle, Jean Boussier,
-    Jeremy Daer, John Hawthorn, Matthew Draper, Rafael França, and Xavier Noria.\n\nHosted
+    Jeremy Daer, John Hawthorn, Matthew Draper, Rafael Mendonça França, and Xavier Noria.\n\nHosted
     by @Planetargon founder and CEO @RobbyRussell. \n\nLinks:\nhttps://rubyonrails.org/community\nhttps://rubyonrails.org/\nhttps://github.com/rails\nhttps://www.planetargon.com/\n\n#RubyonRails
     #Rails #RailsCore #AMA #RailsWorld #opensource"
   video_id: 9GzYoUFIkwE

--- a/data/rails-world/rails-world-2023/videos.yml
+++ b/data/rails-world/rails-world-2023/videos.yml
@@ -108,7 +108,7 @@
     - Aaron Patterson
     - Carlos Antonio Da Silva
     - David Heinemeier Hansson
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
     - Jean Boussier
     - Jeremy Daer
     - John Hawthorn
@@ -122,7 +122,7 @@
     submitted by the Rails World audience in Amsterdam, such as: How do they decide
     on which features to add? How should Rails evolve in the future? What does it
     take to join the Core team? \n\nRails Core members present were: Aaron Patterson,
-    Carlos Antonio Da Silva, David Heinemeier Hansson, Eileen Uchitelle, Jean Boussier,
+    Carlos Antonio Da Silva, David Heinemeier Hansson, Eileen M. Uchitelle, Jean Boussier,
     Jeremy Daer, John Hawthorn, Matthew Draper, Rafael França, and Xavier Noria.\n\nHosted
     by @Planetargon founder and CEO @RobbyRussell. \n\nLinks:\nhttps://rubyonrails.org/community\nhttps://rubyonrails.org/\nhttps://github.com/rails\nhttps://www.planetargon.com/\n\n#RubyonRails
     #Rails #RailsCore #AMA #RailsWorld #opensource"
@@ -204,7 +204,7 @@
 - title: 'Keynote: The Magic of Rails'
   raw_title: Eileen Uchitelle - The Magic of Rails - Rails World 2023
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: Rails World 2023
   published_at: "2023-10-16"
   description:

--- a/data/railsconf/railsconf-2012/videos.yml
+++ b/data/railsconf/railsconf-2012/videos.yml
@@ -749,7 +749,7 @@
 - title: Mobile Rage - What causes it & how to fix it.
   raw_title: Mobile Rage - What causes it & how to fix it. by Lori Olson
   speakers:
-    - Lori Olson
+    - Lori M Olson
   event_name: RailsConf 2012
   published_at: "2012-08-22"
   description: |-

--- a/data/railsconf/railsconf-2017/videos.yml
+++ b/data/railsconf/railsconf-2017/videos.yml
@@ -1001,7 +1001,7 @@
 - title: "Practical Debugging"
   raw_title: 'RailsConf 2017: Practical Debugging by Kevin Deisz'
   speakers:
-    - Kevin Deisz
+    - Kevin Newton
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/oi4h30chCz8/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/oi4h30chCz8/mqdefault.jpg
@@ -1010,7 +1010,7 @@
   thumbnail_xl: https://i.ytimg.com/vi/oi4h30chCz8/maxresdefault.jpg
   published_at: '2017-05-18'
   description: |-
-    RailsConf 2017: Practical Debugging by Kevin Deisz
+    RailsConf 2017: Practical Debugging by Kevin Newton
 
     People give ruby a bad reputation for speed, efficiency, weak typing, etc. But one of the biggest benefits of an interpreted language is the ability to debug and introspect quickly without compilation. Oftentimes developers reach for heavy-handed libraries to debug their application when they could just as easily get the information they need by using tools they already have.
 

--- a/data/railsconf/railsconf-2017/videos.yml
+++ b/data/railsconf/railsconf-2017/videos.yml
@@ -50,7 +50,7 @@
 - title: "Building Rails ActionDispatch::SystemTestCase Framework"
   raw_title: 'RailsConf 2017: Building Rails ActionDispatch::SystemTestCase Framework by Eileen Uchitelle'
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/sSn4B8orX70/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/sSn4B8orX70/mqdefault.jpg
@@ -59,7 +59,7 @@
   thumbnail_xl: https://i.ytimg.com/vi/sSn4B8orX70/maxresdefault.jpg
   published_at: '2017-05-05'
   description: |-
-    RailsConf 2017: Building Rails ActionDispatch::SystemTestCase Framework by Eileen Uchitelle
+    RailsConf 2017: Building Rails ActionDispatch::SystemTestCase Framework by Eileen M. Uchitelle
 
     At the 2014 RailsConf DHH declared system testing would be added to Rails. Three years later, Rails 5.1 makes good on that promise by introducing a new testing framework: ActionDispatch::SystemTestCase. The feature brings system testing to Rails with zero application configuration by adding Capybara integration. After a demonstration of the new framework, we'll walk through what's uniquely involved with building OSS features & how the architecture follows the Rails Doctrine. We'll take a rare look at what it takes to build a major feature for Rails, including goals, design decisions, & roadblocks.
   video_id: sSn4B8orX70
@@ -596,7 +596,7 @@
   speakers:
     - Sam Saffron
     - Richard Schneeman
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
     - Nate Berkopec
     - Rafael França
   event_name: RailsConf 2017
@@ -607,7 +607,7 @@
   thumbnail_xl: https://i.ytimg.com/vi/SMxlblLe_Io/maxresdefault.jpg
   published_at: '2017-05-15'
   description: |-
-    RailsConf 2017: Panel: Performance... performance with Sam Saffron, Richard Schneeman, Eileen Uchitelle, Nate Berkopec & Rafael França
+    RailsConf 2017: Panel: Performance... performance with Sam Saffron, Richard Schneeman, Eileen M. Uchitelle, Nate Berkopec & Rafael França
 
     Is your application running too slow? How can you make it run leaner and faster? Is Ruby 2.4 going to make anything faster or better? Should you be upgrading to the latest version of Rails? Is your Rails application being weighed down by a large swarm of dependencies?
 

--- a/data/railsconf/railsconf-2017/videos.yml
+++ b/data/railsconf/railsconf-2017/videos.yml
@@ -172,7 +172,7 @@
 - title: "Upgrading a big application to Rails 5"
   raw_title: 'RailsConf 2017: Upgrading a big application to Rails 5 by Rafael França'
   speakers:
-    - Rafael França
+    - Rafael Mendonça França
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/I-2Xy3RS1ns/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/I-2Xy3RS1ns/mqdefault.jpg
@@ -181,7 +181,7 @@
   thumbnail_xl: https://i.ytimg.com/vi/I-2Xy3RS1ns/maxresdefault.jpg
   published_at: '2017-05-09'
   description: |-
-    RailsConf 2017: Upgrading a big application to Rails 5 by Rafael França
+    RailsConf 2017: Upgrading a big application to Rails 5 by Rafael Mendonça França
 
     In this talk we would take a look in different strategies to upgrade Rails application to the newest version taking as example a huge monolithic Rails application. We will learn what were the biggest challenges and how they could be avoided. We will also learn why the changes were made in Rails and how they work.
   video_id: I-2Xy3RS1ns
@@ -598,7 +598,7 @@
     - Richard Schneeman
     - Eileen M. Uchitelle
     - Nate Berkopec
-    - Rafael França
+    - Rafael Mendonça França
   event_name: RailsConf 2017
   thumbnail_xs: https://i.ytimg.com/vi/SMxlblLe_Io/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/SMxlblLe_Io/mqdefault.jpg
@@ -607,7 +607,7 @@
   thumbnail_xl: https://i.ytimg.com/vi/SMxlblLe_Io/maxresdefault.jpg
   published_at: '2017-05-15'
   description: |-
-    RailsConf 2017: Panel: Performance... performance with Sam Saffron, Richard Schneeman, Eileen M. Uchitelle, Nate Berkopec & Rafael França
+    RailsConf 2017: Panel: Performance... performance with Sam Saffron, Richard Schneeman, Eileen M. Uchitelle, Nate Berkopec & Rafael Mendonça França
 
     Is your application running too slow? How can you make it run leaner and faster? Is Ruby 2.4 going to make anything faster or better? Should you be upgrading to the latest version of Rails? Is your Rails application being weighed down by a large swarm of dependencies?
 

--- a/data/railsconf/railsconf-2018/videos.yml
+++ b/data/railsconf/railsconf-2018/videos.yml
@@ -873,7 +873,7 @@
 - title: 'Keynote: The Future of Rails 6: Scalable by Default'
   raw_title: 'RailsConf 2018: Keynote: The Future of Rails 6: Scalable by Default by Eileen Uchitelle'
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: RailsConf 2018
   thumbnail_xs: https://i.ytimg.com/vi/8evXWvM4oXM/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/8evXWvM4oXM/mqdefault.jpg
@@ -882,7 +882,7 @@
   thumbnail_xl: https://i.ytimg.com/vi/8evXWvM4oXM/maxresdefault.jpg
   published_at: '2018-05-17'
   description: 'RailsConf 2018: Keynote: The Future of Rails 6: Scalable by Default
-    by Eileen Uchitelle'
+    by Eileen M. Uchitelle'
   video_id: 8evXWvM4oXM
 
 - title: "Running a Business, Demystified"

--- a/data/railsconf/railsconf-2019/videos.yml
+++ b/data/railsconf/railsconf-2019/videos.yml
@@ -1938,7 +1938,7 @@
 - title: The Past, Present, and Future of Rails at GitHub
   raw_title: RailsConf 2019 - The Past, Present, and Future of Rails at GitHub by Eileen M  Uchitelle
   speakers:
-    - Eileen M Uchitelle
+    - Eileen M. Uchitelle
   event_name: RailsConf 2019
   thumbnail_xs: https://i.ytimg.com/vi/vIScxVu00bs/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/vIScxVu00bs/mqdefault.jpg

--- a/data/railsconf/railsconf-2019/videos.yml
+++ b/data/railsconf/railsconf-2019/videos.yml
@@ -1022,7 +1022,7 @@
 - title: Pre-evaluation in Ruby
   raw_title: RailsConf 2019 - Pre-evaluation in Ruby by Kevin Deisz
   speakers:
-    - Kevin Deisz
+    - Kevin Newton
   event_name: RailsConf 2019
   thumbnail_xs: https://i.ytimg.com/vi/7GqhHmfjemY/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/7GqhHmfjemY/mqdefault.jpg

--- a/data/railsconf/railsconf-2020/videos.yml
+++ b/data/railsconf/railsconf-2020/videos.yml
@@ -27,7 +27,7 @@
 - title: "Keynote: Technically, a Talk"
   raw_title: "RailsConf 2020 CE - Keynote: Technically, a Talk by Eileen Uchitelle"
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: RailsConf 2020 CE
   thumbnail_xs: https://i.ytimg.com/vi/vebtTRXAznU/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/vebtTRXAznU/mqdefault.jpg
@@ -36,13 +36,13 @@
   thumbnail_xl: https://i.ytimg.com/vi/vebtTRXAznU/maxresdefault.jpg
   published_at: "2020-04-24"
   description: |-
-    Keynote: Technically, a Talk by Eileen Uchitelle
+    Keynote: Technically, a Talk by Eileen M. Uchitelle
 
     "Peer deep into Rails’ database handling and you may find the code overly complex, hard to follow, and full of technical debt. On the surface you’re right - it is complex, but that complexity represents the strong foundation that keeps your applications simple and focused on your product code. In this talk we’ll look at how to use multiple databases, the beauty (and horror) of Rails connection management, and why we built this feature for you.
     "
     __________
 
-    Eileen Uchitelle is a Staff Software Engineer on the Ruby Architecture Team at GitHub and a member of the Rails Core team. She's an avid contributor to open source focusing on the Ruby on Rails framework and its dependencies. Eileen is passionate about scalability, performance, and making open source communities more sustainable and welcoming.
+    Eileen M. Uchitelle is a Staff Software Engineer on the Ruby Architecture Team at GitHub and a member of the Rails Core team. She's an avid contributor to open source focusing on the Ruby on Rails framework and its dependencies. Eileen is passionate about scalability, performance, and making open source communities more sustainable and welcoming.
   video_id: vebtTRXAznU
 
 - title: "Aaron Patterson's Variety Show"

--- a/data/railsconf/railsconf-2021/videos.yml
+++ b/data/railsconf/railsconf-2021/videos.yml
@@ -1027,7 +1027,7 @@
 - title: "New dev, old codebase: A series of mentorship stories"
   raw_title: "RailsConf 2021: New dev, old codebase: A series of mentorship stories - Ramón Huidobro"
   speakers:
-    - Ramón Huidobro
+    - Carmen Huidobro
   event_name: RailsConf 2021
   thumbnail_xs: https://i.ytimg.com/vi/NcQqEurV4vo/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/NcQqEurV4vo/mqdefault.jpg

--- a/data/railsconf/railsconf-2021/videos.yml
+++ b/data/railsconf/railsconf-2021/videos.yml
@@ -2,7 +2,7 @@
 - title: "Keynote: All the Things I Thought I Couldn't Do"
   raw_title: "RailsConf 2021: Keynote: Eileen Uchitelle - All the Things I Thought I Couldn't Do"
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: RailsConf 2021
   thumbnail_xs: https://i.ytimg.com/vi/5bWE6GpN938/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/5bWE6GpN938/mqdefault.jpg

--- a/data/railsconf/railsconf-2022/videos.yml
+++ b/data/railsconf/railsconf-2022/videos.yml
@@ -1045,7 +1045,7 @@
 - title: "Keynote: The Success of Ruby on Rails"
   raw_title: "RailsConf 2022 - Keynote: The Success of Ruby on Rails by Eileen Uchitelle"
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: RailsConf 2022
   thumbnail_xs: https://i.ytimg.com/vi/p17xn05zc9c/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/p17xn05zc9c/mqdefault.jpg
@@ -1055,7 +1055,7 @@
   published_at: "2022-05-17"
   start_date: "2022-05-17"
   ends_at: "2022-05-19"
-  description: "Keynote: The Success of Ruby on Rails by Eileen Uchitelle"
+  description: "Keynote: The Success of Ruby on Rails by Eileen M. Uchitelle"
   video_id: p17xn05zc9c
 
 - title: "A Rails Performance Guidebook: from 0 to 1B requests/day"

--- a/data/railsconf/railsconf-2023/videos.yml
+++ b/data/railsconf/railsconf-2023/videos.yml
@@ -1059,8 +1059,8 @@
 - title: "Keynote: The Magic of Rails"
   raw_title: RailsConf 2023 - Keynote by Eileen Uchitelle
   speakers:
-    - Eileen Uchitelle
-  description: Keynote by Eileen Uchitelle
+    - Eileen M. Uchitelle
+  description: Keynote by Eileen M. Uchitelle
   thumbnail_xs: https://i.ytimg.com/vi/TKulocPqV38/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/TKulocPqV38/mqdefault.jpg
   thumbnail_md: https://i.ytimg.com/vi/TKulocPqV38/hqdefault.jpg

--- a/data/ruby-on-ice/ruby-on-ice-2019/videos.yml
+++ b/data/ruby-on-ice/ruby-on-ice-2019/videos.yml
@@ -2,15 +2,15 @@
 - title: 'Keynote: The Past, Present, and Future of Rails at GitHub'
   raw_title: 'Ruby on Ice 2019 Keynote: The Past, Present, and Future of Rails at GitHub by Eileen Uchitelle'
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: Ruby on Ice 2019
   published_at: '2019-04-01'
   description: |-
     On August 15, 2018 GitHub accomplished a great feat: upgrading our application from Rails 3.2 to 5.2. While this upgrade took a difficult year and a half your upgrade doesn't need to be this hard. In this talk we'll look at ways in which our upgrade was uniquely hard, how we accomplished this monumental task, and what we're doing to prevent hard upgrades in the future. We'll take a deep dive into why we upgraded Rails and our plans for upstreaming features from the GitHub application into the Rails framework.
 
-    By Eileen Uchitelle https://twitter.com/@eileencodes
+    By Eileen M. Uchitelle https://twitter.com/@eileencodes
 
-    Eileen Uchitelle is an Senior Systems Engineer on the Platform Systems Team at GitHub and a member of the Rails Core team. She's an avid contributor to open source focusing on the Ruby on Rails framework and its dependencies. Eileen is passionate about security, performance, and making open source communities more sustainable and welcoming.
+    Eileen M. Uchitelle is an Senior Systems Engineer on the Platform Systems Team at GitHub and a member of the Rails Core team. She's an avid contributor to open source focusing on the Ruby on Rails framework and its dependencies. Eileen is passionate about security, performance, and making open source communities more sustainable and welcoming.
 
     https://rubyonice.com/speakers/eileen_uchitelle
   video_id: jxBAkhaRtNg

--- a/data/ruby-on-ice/ruby-on-ice-2019/videos.yml
+++ b/data/ruby-on-ice/ruby-on-ice-2019/videos.yml
@@ -34,7 +34,7 @@
 - title: Hardware Hacking with Your Rails App
   raw_title: 'Ruby on Ice 2019: Hardware Hacking with Your Rails App by Ramón Huidobro'
   speakers:
-    - Ramón Huidobro
+    - Carmen Huidobro
   event_name: Ruby on Ice 2019
   published_at: '2019-04-01'
   description: |-
@@ -42,9 +42,9 @@
 
     In this talk, I’ll go over my experiences and lessons learned from working on dedicated hardware for industrial catering services.
 
-    By Ramón Huidobro https://twitter.com/@senorhuidobro
+    By Carmen Huidobro https://twitter.com/@hola_soy_milk
 
-    Ramón Huidobro is a chilean kids’ coding instructor and freelance software dev. He likes to introduce people to coding more than he enjoys coding itself. If you want pointless Nintendo trivia, look no further than Ramón! You’ll probably find him at a lot of conferences and has been told he has a distinctive laugh, so he’s easy to spot, especially when wearing a onesie.
+    Carmen Huidobro is a chilean kids’ coding instructor and freelance software dev. He likes to introduce people to coding more than he enjoys coding itself. If you want pointless Nintendo trivia, look no further than Carmen! You’ll probably find him at a lot of conferences and has been told he has a distinctive laugh, so he’s easy to spot, especially when wearing a onesie.
 
     https://rubyonice.com/speakers/ramon_huidobro
   video_id: WoUL1pO99N8

--- a/data/rubyconf/rubyconf-2021/videos.yml
+++ b/data/rubyconf/rubyconf-2021/videos.yml
@@ -539,7 +539,7 @@
 - title: "YJIT - Building a new JIT Compiler inside CRuby"
   raw_title: RubyConf 2021 - YJIT - Building a new JIT Compiler inside CRuby by Maxime Chevalier Boisvert
   speakers:
-    - Maxime Chevalier Boisvert
+    - Maxime Chevalier-Boisvert
   event_name: RubyConf 2021
   published_at: "2022-08-09"
   description: |-

--- a/data/rubyconf/rubyconf-2021/videos.yml
+++ b/data/rubyconf/rubyconf-2021/videos.yml
@@ -564,7 +564,7 @@
 - title: "Improving CVAR performance in Ruby 3.1"
   raw_title: RubyConf 2021 - Improving CVAR performance in Ruby 3.1 by Eileen Uchitelle
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: RubyConf 2021
   published_at: "2022-08-09"
   description: |-

--- a/data/rubyconf/rubyconf-2022/videos.yml
+++ b/data/rubyconf/rubyconf-2022/videos.yml
@@ -307,7 +307,7 @@
 - title: 'Exit(ing) Through the YJIT'
   raw_title: 'RubyConf 2022: Exit(ing) Through the YJIT by Eileen M Uchitelle'
   speakers:
-    - Eileen M Uchitelle
+    - Eileen M. Uchitelle
   event_name: RubyConf 2022
   published_at: '2023-03-06'
   description: When optimizing code for the YJIT compiler it can be difficult to figure

--- a/data/rubyconfth/rubyconfth-2019/videos.yml
+++ b/data/rubyconfth/rubyconfth-2019/videos.yml
@@ -13,7 +13,7 @@
 - title: Beyond REST in Rails
   raw_title: RubyConf TH 2019 - Beyond REST in Rails by Vipul Am
   speakers:
-    - Vipul Am
+    - Vipul A M
   event_name: RubyConf TH 2019
   published_at: "2019-09-06"
   description: |-

--- a/data/rubyconfth/rubyconfth-2022/videos.yml
+++ b/data/rubyconfth/rubyconfth-2022/videos.yml
@@ -48,7 +48,7 @@
 - title: Roasting the Duck - A Talk About Ruby and Types
   raw_title: RubyConfTH 2022 - Roasting the Duck - A talk about Ruby and types by Paolo Perrotta
   speakers:
-    - Paolo Perrotta
+    - Paolo "Nusco" Perrotta
   event_name: RubyConf TH 2022
   published_at: '2022-12-09'
   description: "A talk from RubyConfTH, held in Bangkok, Thailand on December 9-10,

--- a/data/rubyday/rubyday-2015/videos.yml
+++ b/data/rubyday/rubyday-2015/videos.yml
@@ -56,10 +56,10 @@
 - title: "How teaching kids to code made me a better developer"
   raw_title: RubyDay 2015 - R. Huidobro - How teaching kids to code made me a better developer
   speakers:
-    - Ramón Huidobro
+    - Carmen Huidobro
   event_name: rubyday 2015
   published_at: "2015-11-13"
-  description: Ramon Huidobro's talk from RubyDay 2015 in Turin.
+  description: Carmen Huidobro's talk from RubyDay 2015 in Turin.
   video_id: CPXb0W_VdSk
 
 - title: "Making hybrid apps that don't suck"

--- a/data/rubyday/rubyday-2016/videos.yml
+++ b/data/rubyday/rubyday-2016/videos.yml
@@ -56,7 +56,7 @@
 - title: "Refinements - The Worst Feature You Ever Loved"
   raw_title: RubyDay2016 - Paolo Perrotta - Refinements - The Worst Feature You Ever Loved
   speakers:
-    - Paolo Perrotta
+    - Paolo "Nusco" Perrotta
   event_name: rubyday 2016
   published_at: "2016-11-25"
   description: ""

--- a/data/rubyday/rubyday-2016/videos.yml
+++ b/data/rubyday/rubyday-2016/videos.yml
@@ -47,7 +47,7 @@
 - title: "How Sprockets Works"
   raw_title: RubyDay2016 - Rafael Franca - How Sprockets Works
   speakers:
-    - Rafael França
+    - Rafael Mendonça França
   event_name: rubyday 2016
   published_at: "2016-11-25"
   description: ""

--- a/data/rubyday/rubyday-2020/videos.yml
+++ b/data/rubyday/rubyday-2020/videos.yml
@@ -89,7 +89,7 @@
 - title: "Technically, a Talk"
   raw_title: Technically, a Talk - Eileen Uchitelle - Rubyday 2020
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: rubyday 2020
   published_at: "2020-09-16"
   description: |-

--- a/data/rubyday/rubyday-2023/videos.yml
+++ b/data/rubyday/rubyday-2023/videos.yml
@@ -24,7 +24,7 @@
 - title: "How ChatGPT Works"
   raw_title: How ChatGPT Works | Paolo Perrotta | rubyday 2023
   speakers:
-    - Paolo Perrotta
+    - Paolo "Nusco" Perrotta
   event_name: rubyday 2023
   published_at: "2023-06-16"
   description: |-

--- a/data/rubykaigi/rubykaigi-2015/videos.yml
+++ b/data/rubykaigi/rubykaigi-2015/videos.yml
@@ -234,7 +234,7 @@
     - Lin Yu Hsiang
     - Tomohiro Hashidate
     - Tadashi Saito
-    - Pilar Huidobro
+    - Pilar Andrea Huidobro Peltier
   event_name: RubyKaigi 2015
   published_at: "2015-12-11"
   video_id: Yf7l4Yp461I

--- a/data/rubykaigi/rubykaigi-2015/videos.yml
+++ b/data/rubykaigi/rubykaigi-2015/videos.yml
@@ -384,7 +384,7 @@
 - title: Refinements - the Worst Feature You Ever Loved
   raw_title: Refinements - the Worst Feature You Ever Loved - RubyKaigi 2015
   speakers:
-    - Paolo Perrotta
+    - Paolo "Nusco" Perrotta
   event_name: RubyKaigi 2015
   published_at: "2015-12-11"
   video_id: _gLgE3c5jTU

--- a/data/rubykaigi/rubykaigi-2017/videos.yml
+++ b/data/rubykaigi/rubykaigi-2017/videos.yml
@@ -162,7 +162,7 @@
 - title: Compiling Ruby
   raw_title: "[EN] Compiling Ruby / Kevin Deisz @kddeisz"
   speakers:
-    - Kevin Deisz
+    - Kevin Newton
   event_name: RubyKaigi 2017
   published_at: "2017-09-18"
   video_id: B3Uf-aHZwmw

--- a/data/rubykaigi/rubykaigi-2019/videos.yml
+++ b/data/rubykaigi/rubykaigi-2019/videos.yml
@@ -630,7 +630,7 @@
 - title: Pre-evaluation in Ruby
   raw_title: "[EN] Pre-evaluation in Ruby / Kevin Deisz @kddeisz"
   speakers:
-    - Kevin Deisz
+    - Kevin Newton
   event_name: RubyKaigi 2019
   published_at: "2019-04-18"
   video_id: q3i5pYpxP-s

--- a/data/rubykaigi/rubykaigi-2019/videos.yml
+++ b/data/rubykaigi/rubykaigi-2019/videos.yml
@@ -818,7 +818,7 @@
 - title: A Deep Learning Adventure
   raw_title: "[EN] A Deep Learning Adventure / Paolo Perrotta @nusco"
   speakers:
-    - Paolo Perrotta
+    - Paolo "Nusco" Perrotta
   event_name: RubyKaigi 2019
   published_at: "2019-04-18"
   video_id: Uj-7X-9lkIg

--- a/data/rubykaigi/rubykaigi-2020/videos.yml
+++ b/data/rubykaigi/rubykaigi-2020/videos.yml
@@ -379,7 +379,7 @@
 - title: Prettier Ruby
   raw_title: "[EN] Prettier Ruby / Kevin Deisz @kddeisz"
   speakers:
-    - Kevin Deisz
+    - Kevin Newton
   event_name: RubyKaigi Takeout 2020
   published_at: "2020-09-04"
   video_id: 3945FmGGHhw

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -5598,12 +5598,12 @@
   bio: ""
   website: ""
   slug: raia
-- name: Ramón Huidobro
+- name: Carmen Huidobro
   twitter: ""
   github: ""
   bio: ""
   website: ""
-  slug: ramon-huidobro
+  slug: carmen-huidobro
 - name: Ratnadeep Deshmane
   twitter: rtdp
   github: rtdp

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -4239,7 +4239,7 @@
   bio: ""
   website: http://lorencrawford.herokuapp.com/
   slug: loren-crawford
-- name: Lori Olson
+- name: Lori M Olson
   twitter: ""
   github: wndxlori
   bio: ""

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -4714,7 +4714,7 @@
     teacher focused on developing software engineers
   website: maxveld.ink
   slug: max-veldink
-- name: Maxime Chevalier Boisvert
+- name: Maxime Chevalier-Boisvert
   twitter: Love2Code
   github: maximecb
   bio:

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -1905,18 +1905,12 @@
   bio: ""
   website: ""
   slug: eeva-jonna-panula
-- name: Eileen M Uchitelle
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: eileen-m-uchitelle
-- name: Eileen Uchitelle
+- name: Eileen M. Uchitelle
   twitter: eileencodes
   github: eileencodes
   bio: "@Rails Core Team | \r\nRuby & Rails Infrastructure Team @shopify"
-  website: http://eileencodes.com
-  slug: eileen-uchitelle
+  website: https://eileencodes.com
+  slug: eileen-m-uchitelle
 - name: Elain Marina
   twitter: ""
   github: ""

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -3223,7 +3223,7 @@
   bio: ""
   website: joemastey.com
   slug: joe-mastey
-- name: Joe moore
+- name: Joe Moore
   twitter: ""
   github: joemoore
   bio: ""

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -3847,12 +3847,6 @@
   bio: ""
   website: ""
   slug: kerstin-puschke
-- name: Kevin Deisz
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: kevin-deisz
 - name: Kevin Gilpin
   twitter: ""
   github: kgilpin

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -5346,12 +5346,12 @@
   bio: ""
   website: http://ilconnettivo.wordpress.com/
   slug: paolo-montrasio
-- name: Paolo Perrotta
+- name: Paolo "Nusco" Perrotta
   twitter: ""
   github: nusco
   bio: ""
   website: http://ducktypo.blogspot.com
-  slug: paolo-perrotta
+  slug: paolo-nusco-perrotta
 - name: Pat Allan
   twitter: pat
   github: pat

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -5586,12 +5586,6 @@
     Writing newsletter at https://tips.rstankov.com"
   website: http://rstankov.com
   slug: radoslav-stankov
-- name: Rafael França
-  twitter: rafaelfranca
-  github: rafaelfranca
-  bio: ""
-  website: ""
-  slug: rafael-franca
 - name: Rafael Mendonça França
   twitter: rafaelfranca
   github: rafaelfranca

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -5482,14 +5482,6 @@
     night.\r\n@RustFestEU @GDGVienna \r\nHave you heard? I also crochet\U0001F9F6\r\n\r\n"
   website: www.pilar.codes
   slug: pilar-andrea-huidobro-peltier
-- name: Pilar Huidobro
-  twitter: tamacodechi
-  github: tamacodechi
-  bio:
-    "Engineering Manager by day, community organizer and videogame enthusiast by
-    night.\r\n@RustFestEU @GDGVienna \r\nHave you heard? I also crochet\U0001F9F6\r\n\r\n"
-  website: www.pilar.codes
-  slug: pilar-huidobro
 - name: Piotr Murach
   twitter: piotr_murach
   github: piotrmurach

--- a/data/tropicalrb/tropicalrb-2024/videos.yml
+++ b/data/tropicalrb/tropicalrb-2024/videos.yml
@@ -244,13 +244,13 @@
 - title: 'Keynote: The Magic of Rails'
   raw_title: Eileen Uchitelle - Tropical.rb Keynote
   speakers:
-    - Eileen Uchitelle
+    - Eileen M. Uchitelle
   event_name: Tropical.rb 2024
   published_at: '2024-04-05'
   video_id: ow56D90FYpg
   language: english
   description: |-
-    Keynote | Eileen Uchitelle
+    Keynote | Eileen M. Uchitelle
 
     Tropical.rb - The Latin America Rails Conference
     https://www.tropicalrb.com/

--- a/data/wroclove-rb/wroclove-rb-2018/videos.yml
+++ b/data/wroclove-rb/wroclove-rb-2018/videos.yml
@@ -154,7 +154,7 @@
 - title: Lightning Talks Day 2
   raw_title: Lightning talks Saturday - wroc_love.rb 2018
   speakers:
-    - Bartosz Bonistawski # Serverless Ruby
+    - Bartosz Bonisławski # Serverless Ruby
     - Sergey Silnov # Ruby on $4 computer - mruby on esp32
     - Adam Skołuda # How wroc_love.rb impacts developers and companies
     - Vladimir Dementyev # To Refine Or Not To Refine # slides: https://speakerdeck.com/palkan/wroc-love-dot-rb-2018-lightning-talk-to-refine-or-not-to-refine

--- a/load_testing/search_payload.csv
+++ b/load_testing/search_payload.csv
@@ -39,7 +39,7 @@ Matt Sanders
 James Edward Gray II
 Nathen Harvey
 John Bender
-Lori Olson
+Lori M Olson
 Daniel Azuma
 Aaron Patterson
 Rich Hickey

--- a/load_testing/search_payload.csv
+++ b/load_testing/search_payload.csv
@@ -107,7 +107,7 @@ Jenn Scheer
 Jessica Eldredge
 Cameron Daigle
 Charles Lowell
-Joe moore
+Joe Moore
 Brandon Hays
 Justin Searls
 Eric Saxby

--- a/test/models/youtube/video_metadata_test.rb
+++ b/test/models/youtube/video_metadata_test.rb
@@ -19,11 +19,11 @@ require "test_helper"
 class Youtube::VideoMetadataTest < ActiveSupport::TestCase
   test "remove the event name from the title and preserve the keynote mention" do
     metadata = OpenStruct.new({
-      title: "RailsConf 2021: Keynote: Eileen Uchitelle - All the Things I Thought I Couldn't Do",
+      title: "RailsConf 2021: Keynote: Eileen M. Uchitelle - All the Things I Thought I Couldn't Do",
       description: "RailsConf 2021 lorem ipsum"
     })
     results = Youtube::VideoMetadata.new(metadata: metadata, event_name: "RailsConf 2021")
-    assert_equal "Keynote: Eileen Uchitelle - All the Things I Thought I Couldn't Do", results.cleaned.title
+    assert_equal "Keynote: Eileen M. Uchitelle - All the Things I Thought I Couldn't Do", results.cleaned.title
     assert results.keynote?
   end
 


### PR DESCRIPTION
While browsing the /speakers list I found some speakers that had duplicate records. I tried to unify them here in this commit. I already set the right canonical speaker in Avo on production, so the redirects already work for all of them.