### PR TITLE
Add basic empty state for events index page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ doc/*
 
 service_account.json
 /.cache
+
+# asdf
+.tool-versions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -535,6 +535,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin
   x86_64-linux
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -11,10 +11,14 @@
       <% end %>
   </div>
 
-  <% @events.group_by(&:organisation).each do |organisation, events| %>
-    <h2><%= organisation.name %></h2>
-    <div id="<%= dom_id(organisation, "events") %>" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-8 lg:gap-x-12 gap-y-2 min-w-full pt-4 pb-8">
-      <%= render events %>
-    </div>
+  <% if @events.any? %>
+    <% @events.group_by(&:organisation).each do |organisation, events| %>
+      <h2><%= organisation.name %></h2>
+      <div id="<%= dom_id(organisation, "events") %>" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-8 lg:gap-x-12 gap-y-2 min-w-full pt-4 pb-8">
+        <%= render events %>
+      </div>
+    <% end %>
+  <% else %>
+    <p>No events found</p>
   <% end %>
 </div>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -80,4 +80,13 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "FR", @event.reload.country_code
     assert_redirected_to event_url(@event)
   end
+
+  test "should display an empty state message when no events are found" do
+    Event.delete_all
+
+    get events_url
+
+    assert_response :success
+    assert_select "p", text: "No events found"
+  end
 end


### PR DESCRIPTION
# Description
    
This PR adds an empty state to the events index page, so that when there are no events, instead of displaying a blank page, we display a message to the user.

For now, I'm just adding a basic `<p>` tag, and using no punctuation at the end. However, let me know if you have something else in mind.

## Why

I was clicking around the webpage to test performance ([like you guys asked](https://x.com/adrienpoly/status/1838235678859022747)), and when I saw the blank page I thought I had indeed broken something up. Turns out, there's just no events for some letters.

In order to not confuse users as to whether the page is still loading, an empty state message would help.


# Media

https://github.com/user-attachments/assets/8d03fd28-2406-47c5-8787-5e2045f337f8

