### PR TITLE
Add talks card cache

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,5 +11,6 @@
 @import "components/transition.css";
 @import "components/typography.css";
 @import "components/video.css";
+@import "components/visibility.css";
 
 @import "vlitejs/vlite.css";

--- a/app/assets/stylesheets/components/visibility.css
+++ b/app/assets/stylesheets/components/visibility.css
@@ -1,0 +1,17 @@
+@layer components {
+  body.signed-in .for-signed-out-users {
+    display: none;
+  }
+
+  body:not(.signed-in) .for-signed-out-users {
+    display: block;
+  }
+
+  body.signed-in .for-signed-in-users {
+    display: block;
+  }
+
+  body:not(.signed-in) .for-signed-in-users {
+    display: none;
+  }
+}

--- a/app/controllers/bookmark_talks_controller.rb
+++ b/app/controllers/bookmark_talks_controller.rb
@@ -1,4 +1,4 @@
-class WatchListTalksController < ApplicationController
+class BookmarkTalksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_watch_list
 
@@ -17,6 +17,6 @@ class WatchListTalksController < ApplicationController
   private
 
   def set_watch_list
-    @watch_list = Current.user.watch_lists.find(params[:watch_list_id])
+    @watch_list = Current.user.default_watch_list
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,8 +50,6 @@ class EventsController < ApplicationController
   end
 
   def set_user_favorites
-    return unless Current.user
-
-    @user_favorite_talks_ids = Current.user.default_watch_list.talks.ids
+    @user_favorite_talks_ids = Current.user ? Current.user.default_watch_list.talks.ids : []
   end
 end

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -68,8 +68,6 @@ class SpeakersController < ApplicationController
   end
 
   def set_user_favorites
-    return unless Current.user
-
-    @user_favorite_talks_ids = Current.user.default_watch_list.talks.ids
+    @user_favorite_talks_ids = Current.user ? Current.user.default_watch_list.talks.ids : []
   end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -17,7 +17,7 @@ class TalksController < ApplicationController
   # GET /talks/1
   def show
     set_meta_tags(@talk)
-    @related_talks = @talk.event.talks
+    @related_talks = @talk.event.talks.with_essential_card_data
     fresh_when(@talk)
   end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -17,6 +17,7 @@ class TalksController < ApplicationController
   # GET /talks/1
   def show
     set_meta_tags(@talk)
+    @related_talks = @talk.event.talks
     fresh_when(@talk)
   end
 
@@ -50,8 +51,6 @@ class TalksController < ApplicationController
   end
 
   def set_user_favorites
-    return unless Current.user
-
-    @user_favorite_talks_ids = Current.user.default_watch_list.talks.ids
+    @user_favorite_talks_ids = Current.user ? Current.user.default_watch_list.talks.ids : []
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -18,8 +18,6 @@ class TopicsController < ApplicationController
   end
 
   def set_user_favorites
-    return unless Current.user
-
-    @user_favorite_talks_ids = Current.user.default_watch_list.talks.ids
+    @user_favorite_talks_ids = Current.user ? Current.user.default_watch_list.talks.ids : []
   end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -109,7 +109,7 @@ class Talk < ApplicationRecord
   scope :with_topics, -> { joins(:talk_topics) }
 
   scope :with_essential_card_data, -> do
-    select(:id, :slug, :title, :date, :thumbnail_sm, :thumbnail_lg, :video_id, :event_id)
+    select(:id, :slug, :title, :date, :thumbnail_sm, :thumbnail_lg, :video_id, :event_id, :updated_at)
       .includes(:speakers, :event)
   end
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -8,15 +8,16 @@
     </div>
     <div class="w-full">
       <div id="talks" class="min-w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 h-full sm:p-4">
-        <%= render partial: "talks/card",
-              collection: @talks,
-              locals: {
-                favoritable: true,
-                user_favorite_talks_ids: @user_favorite_talks_ids,
-                back_to: request.fullpath,
-                back_to_title: @event.name
-              },
-              as: :talk %>
+        <% @talks.each do |talk| %>
+          <%= render partial: "talks/card",
+                locals: {
+                  talk: talk,
+                  bookmarkable: true,
+                  user_favorite_talks_ids: @user_favorite_talks_ids,
+                  back_to: request.fullpath,
+                  back_to_title: @event.name
+                } %>
+        <% end %>
       </div>
       <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
     <%= yield :head %>
   </head>
 
-  <body>
+  <body class="<%= class_names("signed-in": signed_in?) %>">
     <%= render "shared/navbar" %>
     <%= render "shared/flashes" %>
 

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -28,7 +28,7 @@
               collection: @talks,
               as: :talk,
               locals: {
-                favoritable: true,
+                bookmarkable: true,
                 user_favorite_talks_ids: @user_favorite_talks_ids,
                 back_to: request.fullpath,
                 back_to_title: @speaker.name

--- a/app/views/talks/_bookmark.html.erb
+++ b/app/views/talks/_bookmark.html.erb
@@ -1,0 +1,20 @@
+<%# locals: (talk:, bookmarked: false, bookmarkable: false) %>
+<% if bookmarkable %>
+  <div class="for-signed-in-users">
+    <% if bookmarked %>
+      <%= button_to bookmark_talk_path(talk.id), method: :delete, id: dom_id(talk, :remove_bookmark) do %>
+        <%= heroicon :bookmark, class: "text-primary shrink-0 cursor-pointer mt-1", variant: :solid, size: :sm %>
+      <% end %>
+    <% else %>
+      <%= button_to bookmark_talks_path(talk_id: talk.id), method: :post, id: dom_id(talk, :bookmark) do %>
+        <%= heroicon :bookmark, class: "shrink-0 cursor-pointer mt-1", variant: :outline, size: :sm %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="for-signed-out-users">
+    <%= link_to sign_in_path(redirect_to: request.fullpath), data: {turbo_frame: "modal"} do %>
+      <%= heroicon :bookmark, class: "shrink-0 cursor-pointer mt-1", variant: :outline, size: :sm %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -43,8 +43,8 @@
           </div>
           <div class="self-end">
             <%= render "talks/bookmark", talk: talk,
-                    bookmarkable: bookmarkable,
-                    bookmarked: bookmarkable && user_favorite_talks_ids.include?(talk.id) %>
+                  bookmarkable: bookmarkable,
+                  bookmarked: bookmarkable && user_favorite_talks_ids.include?(talk.id) %>
           </div>
         </div>
       </div>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -1,53 +1,51 @@
 
 <%# locals: (talk:, user_favorite_talks_ids: [], bookmarkable: false, back_to: nil, back_to_title: nil) -%>
-<% cache [talk, user_favorite_talks_ids, bookmarkable, back_to, back_to_title] do %>
-  <div class="card card-compact bg-white shadow-xl w-full" id="<%= dom_id talk %>" style="<%= "view-transition-name: #{dom_id(talk, :talk_card)}" %>">
-    <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden" do %>
-        <%= image_tag talk.thumbnail_sm,
-              srcset: ["#{talk.thumbnail_lg} 2x"],
-              id: dom_id(talk),
-              height: 174,
-              width: 310,
-              alt: "talk by #{talk.speakers.map(&:name).join(", ")}: #{talk.title}",
-              style: "view-transition-name: #{dom_id(talk, :image)}",
-              class: "w-full object-cover rounded-t-xl" %>
-    <% end %>
-    <div class="card-body flex flex-row justify-between items-start gap-2">
-      <div class="flex flex-col items-start h-full justify-between gap-2 w-full">
-        <div class="flex items-start justify-between gap-2 w-full">
-          <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title) do %>
-            <%= content_tag :h2, talk.title, class: "text-sm font-sans font-medium" %>
+<div class="card card-compact bg-white shadow-xl w-full" id="<%= dom_id talk %>" style="<%= "view-transition-name: #{dom_id(talk, :talk_card)}" %>">
+  <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden" do %>
+      <%= image_tag talk.thumbnail_sm,
+            srcset: ["#{talk.thumbnail_lg} 2x"],
+            id: dom_id(talk),
+            height: 174,
+            width: 310,
+            alt: "talk by #{talk.speakers.map(&:name).join(", ")}: #{talk.title}",
+            style: "view-transition-name: #{dom_id(talk, :image)}",
+            class: "w-full object-cover rounded-t-xl" %>
+  <% end %>
+  <div class="card-body flex flex-row justify-between items-start gap-2">
+    <div class="flex flex-col items-start h-full justify-between gap-2 w-full">
+      <div class="flex items-start justify-between gap-2 w-full">
+        <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title) do %>
+          <%= content_tag :h2, talk.title, class: "text-sm font-sans font-medium" %>
+        <% end %>
+      </div>
+      <div class="flex gap-2 items-end justify-between w-full">
+        <div class="flex flex-col text-sm w-full flex-grow">
+          <div class="flex items-start gap-2 font-light">
+            <% speakers_count = talk.speakers.size %>
+            <% if speakers_count > 1 %>
+              <%= heroicon :users, size: :sm, class: "shrink-0 grow-0 my-1" %>
+            <% elsif speakers_count == 1 %>
+              <%= heroicon :user, size: :sm, class: "shrink-0 grow-0 my-1" %>
+            <% end %>
+
+            <div class="line-clamp-1">
+              <% speaker_names = talk.speakers.map { |speaker| link_to speaker.name, speaker_path(speaker), class: "link link-ghost" } %>
+              <%= sanitize speaker_names.join(", ") %>
+            </div>
+          </div>
+          <% if talk.event %>
+            <div class="flex items-center gap-2 font-light">
+              <%= heroicon :map_pin, size: :sm, class: "shrink-0 grow-0" %>
+              <%= link_to talk.event.name, talk.event, class: "link link-ghost line-clamp-1" %>
+            </div>
           <% end %>
         </div>
-        <div class="flex gap-2 items-end justify-between w-full">
-          <div class="flex flex-col text-sm w-full flex-grow">
-            <div class="flex items-center gap-2 font-light">
-              <% speakers_count = talk.speakers.size %>
-              <% if speakers_count > 1 %>
-                <%= heroicon :users, size: :sm, class: "shrink-0 grow-0 my-1" %>
-              <% elsif speakers_count == 1 %>
-                <%= heroicon :user, size: :sm, class: "shrink-0 grow-0 my-1" %>
-              <% end %>
-
-              <div class="line-clamp-1">
-                <% speaker_names = talk.speakers.map { |speaker| link_to speaker.name, speaker_path(speaker), class: "link link-ghost" } %>
-                <%= sanitize speaker_names.join(", ") %>
-              </div>
-            </div>
-            <% if talk.event %>
-              <div class="flex items-center gap-2 font-light">
-                <%= heroicon :map_pin, size: :sm, class: "shrink-0 grow-0" %>
-                <%= link_to talk.event.name, talk.event, class: "link link-ghost line-clamp-1" %>
-              </div>
-            <% end %>
-          </div>
-          <div class="self-end">
-            <%= render "talks/bookmark", talk: talk,
-                  bookmarkable: bookmarkable,
-                  bookmarked: bookmarkable && user_favorite_talks_ids.include?(talk.id) %>
-          </div>
+        <div class="self-end">
+          <%= render "talks/bookmark", talk: talk,
+                bookmarkable: bookmarkable,
+                bookmarked: bookmarkable && user_favorite_talks_ids.include?(talk.id) %>
         </div>
       </div>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -1,66 +1,53 @@
 
-<%# locals: (talk:, user_favorite_talks_ids: [], favoritable: false, back_to: nil, back_to_title: nil) -%>
-
-<div class="card card-compact bg-white shadow-xl w-full" id="<%= dom_id talk %>" style="<%= "view-transition-name: #{dom_id(talk, :talk_card)}" %>">
-  <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden" do %>
-      <%= image_tag talk.thumbnail_sm,
-            srcset: ["#{talk.thumbnail_lg} 2x"],
-            id: dom_id(talk),
-            height: 174,
-            width: 310,
-            alt: "talk by #{talk.speakers.map(&:name).join(", ")}: #{talk.title}",
-            style: "view-transition-name: #{dom_id(talk, :image)}",
-            class: "w-full object-cover rounded-t-xl" %>
-  <% end %>
-  <div class="card-body flex flex-row justify-between items-start gap-2">
-    <div class="flex flex-col items-start h-full justify-between gap-2 w-full">
-      <div class="flex items-start justify-between gap-2 w-full">
-        <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title) do %>
-          <%= content_tag :h2, talk.title, class: "text-sm font-sans font-medium" %>
-        <% end %>
-      </div>
-      <div class="flex gap-2 items-end justify-between w-full">
-        <div class="flex flex-col text-sm w-full flex-grow">
-          <div class="flex items-center gap-2 font-light">
-            <% speakers_count = talk.speakers.size %>
-            <% if speakers_count > 1 %>
-              <%= heroicon :users, size: :sm, class: "shrink-0 grow-0 my-1" %>
-            <% elsif speakers_count == 1 %>
-              <%= heroicon :user, size: :sm, class: "shrink-0 grow-0 my-1" %>
-            <% end %>
-
-            <div class="line-clamp-1">
-              <% speaker_names = talk.speakers.map { |speaker| link_to speaker.name, speaker_path(speaker), class: "link link-ghost" } %>
-              <%= sanitize speaker_names.join(", ") %>
-            </div>
-          </div>
-          <% if talk.event %>
-            <div class="flex items-center gap-2 font-light">
-              <%= heroicon :map_pin, size: :sm, class: "shrink-0 grow-0" %>
-              <%= link_to talk.event.name, talk.event, class: "link link-ghost line-clamp-1" %>
-            </div>
+<%# locals: (talk:, user_favorite_talks_ids: [], bookmarkable: false, back_to: nil, back_to_title: nil) -%>
+<% cache [talk, user_favorite_talks_ids, bookmarkable, back_to, back_to_title] do %>
+  <div class="card card-compact bg-white shadow-xl w-full" id="<%= dom_id talk %>" style="<%= "view-transition-name: #{dom_id(talk, :talk_card)}" %>">
+    <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden" do %>
+        <%= image_tag talk.thumbnail_sm,
+              srcset: ["#{talk.thumbnail_lg} 2x"],
+              id: dom_id(talk),
+              height: 174,
+              width: 310,
+              alt: "talk by #{talk.speakers.map(&:name).join(", ")}: #{talk.title}",
+              style: "view-transition-name: #{dom_id(talk, :image)}",
+              class: "w-full object-cover rounded-t-xl" %>
+    <% end %>
+    <div class="card-body flex flex-row justify-between items-start gap-2">
+      <div class="flex flex-col items-start h-full justify-between gap-2 w-full">
+        <div class="flex items-start justify-between gap-2 w-full">
+          <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title) do %>
+            <%= content_tag :h2, talk.title, class: "text-sm font-sans font-medium" %>
           <% end %>
         </div>
-        <% if favoritable %>
-          <div class="self-end">
-            <% if default_watch_list %>
-              <% if user_favorite_talks_ids.include?(talk.id) %>
-                <%= button_to watch_list_talk_path(default_watch_list, talk.id), method: :delete do %>
-                  <%= heroicon :bookmark, class: "text-primary shrink-0 cursor-pointer mt-1", variant: :solid, size: :sm %>
-                <% end %>
-              <% else %>
-                <%= button_to watch_list_talks_path(default_watch_list, talk_id: talk.id), method: :post do %>
-                  <%= heroicon :bookmark, class: "shrink-0 cursor-pointer mt-1", variant: :outline, size: :sm %>
-                <% end %>
+        <div class="flex gap-2 items-end justify-between w-full">
+          <div class="flex flex-col text-sm w-full flex-grow">
+            <div class="flex items-center gap-2 font-light">
+              <% speakers_count = talk.speakers.size %>
+              <% if speakers_count > 1 %>
+                <%= heroicon :users, size: :sm, class: "shrink-0 grow-0 my-1" %>
+              <% elsif speakers_count == 1 %>
+                <%= heroicon :user, size: :sm, class: "shrink-0 grow-0 my-1" %>
               <% end %>
-            <% else %>
-              <%= link_to sign_in_path(redirect_to: request.fullpath), data: {turbo_frame: "modal"} do %>
-                <%= heroicon :bookmark, class: "shrink-0 cursor-pointer mt-1", variant: :outline, size: :sm %>
-              <% end %>
+
+              <div class="line-clamp-1">
+                <% speaker_names = talk.speakers.map { |speaker| link_to speaker.name, speaker_path(speaker), class: "link link-ghost" } %>
+                <%= sanitize speaker_names.join(", ") %>
+              </div>
+            </div>
+            <% if talk.event %>
+              <div class="flex items-center gap-2 font-light">
+                <%= heroicon :map_pin, size: :sm, class: "shrink-0 grow-0" %>
+                <%= link_to talk.event.name, talk.event, class: "link link-ghost line-clamp-1" %>
+              </div>
             <% end %>
           </div>
-        <% end %>
+          <div class="self-end">
+            <%= render "talks/bookmark", talk: talk,
+                    bookmarkable: bookmarkable,
+                    bookmarked: bookmarkable && user_favorite_talks_ids.include?(talk.id) %>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (talk:, admin: false) -%>
+<%# locals: (talk:) -%>
 
 <%= content_tag :div, id: dom_id(talk),
       data: {

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -14,6 +14,7 @@
         <%= render partial: "talks/card",
               collection: @talks,
               as: :talk,
+              cached: ->(talk) { [talk, @user_favorite_talks_ids, request.fullpath] },
               locals: {
                 bookmarkable: true,
                 user_favorite_talks_ids: @user_favorite_talks_ids,

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -9,16 +9,18 @@
   <% end %>
 
   <%= turbo_frame_tag "talks", target: "_top" do %>
-    <div id="talks" class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gallery">
-      <%= render partial: "talks/card",
-            collection: @talks,
-            as: :talk,
-            locals: {
-              favoritable: true,
-              user_favorite_talks_ids: @user_favorite_talks_ids,
-              back_to: request.fullpath
-            } %>
-    </div>
+    <% cache [@talks, @user_favorite_talks_ids, request.fullpath] do %>
+      <div id="talks" class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gallery">
+        <%= render partial: "talks/card",
+              collection: @talks,
+              as: :talk,
+              locals: {
+                bookmarkable: true,
+                user_favorite_talks_ids: @user_favorite_talks_ids,
+                back_to: request.fullpath
+              } %>
+      </div>
+    <% end %>
     <div class="flex mt-4 w-full">
       <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
     </div>

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -7,10 +7,10 @@
       <div style="view-transition-name: title"><%= back_to_title %></div>
     </div>
   <% end %>
-  <% cache [@talk, @related_talks, Current.user&.admin?] do %>
+  <% cache [@talk, @related_talks] do %>
     <div class="w-full flex">
       <div class="flex-grow">
-        <%= render partial: "talks/talk", locals: {talk: @talk, admin: Current.user&.admin?} %>
+        <%= render partial: "talks/talk", locals: {talk: @talk} %>
       </div>
       <div class="gap-4 w-96 flex-shrink-0 hidden md:flex md:flex-col px-4">
         <%#= turbo_frame_tag "recommended_talks", target: "_top", src: talk_recommendations_path(@talk) %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -10,18 +10,21 @@
   <div class="flex items-center gap-2 title text-primary">
     <h1 class="mb-4" style="view-transition-name: title"><%= @topic.name %></h1>
   </div>
-  <div id="topic-talks" class="grid min-w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 gallery">
-    <%= render partial: "talks/card",
-          collection: @talks,
-          as: :talk,
-          locals: {
-            favoritable: true,
-            user_favorite_talks_ids: @user_favorite_talks_ids,
-            back_to: request.fullpath,
-            back_to_title: @topic.name
-          } %>
-  </div>
-  <div class="flex mt-4 w-full">
-    <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
-  </div>
+  <% cache [@talks, @user_favorite_talks_ids, request.fullpath, @topic.name] do %>
+    <div id="topic-talks" class="grid min-w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 gallery">
+      <%= render partial: "talks/card",
+            collection: @talks,
+            as: :talk,
+            cached: ->(talk) { [talk, @user_favorite_talks_ids, request.fullpath, @topic.name] },
+            locals: {
+              bookmarkable: true,
+              user_favorite_talks_ids: @user_favorite_talks_ids,
+              back_to: request.fullpath,
+              back_to_title: @topic.name
+            } %>
+    </div>
+    <div class="flex mt-4 w-full">
+      <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -22,7 +22,7 @@
               back_to: request.fullpath,
               back_to_title: @topic.name
             } %>
-    <!--</div>-->
+    </div>
   <% end %>
   <div class="flex mt-4 w-full">
     <%== pagy_nav(@pagy) if @pagy.pages > 1 %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -15,16 +15,16 @@
       <%= render partial: "talks/card",
             collection: @talks,
             as: :talk,
-            cached: ->(talk) { [talk, @user_favorite_talks_ids, request.fullpath, @topic.name] },
+            cached: ->(talk) { ["#{talk.id}-#{talk.updated_at.to_i}", @user_favorite_talks_ids, request.fullpath, @topic.name] },
             locals: {
               bookmarkable: true,
               user_favorite_talks_ids: @user_favorite_talks_ids,
               back_to: request.fullpath,
               back_to_title: @topic.name
             } %>
-    </div>
-    <div class="flex mt-4 w-full">
-      <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
-    </div>
+    <!--</div>-->
   <% end %>
+  <div class="flex mt-4 w-full">
+    <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+  </div>
 </div>

--- a/app/views/watch_lists/_watch_list.html.erb
+++ b/app/views/watch_lists/_watch_list.html.erb
@@ -4,7 +4,7 @@
           collection: watch_list.talks,
           as: :talk,
           locals: {
-            favoritable: true,
+            bookmarkable: true,
             user_favorite_talks_ids: watch_list.talks.ids,
             back_to: watch_lists_path,
             back_to_title: watch_list.name

--- a/app/views/watch_lists/_watch_list.html.erb
+++ b/app/views/watch_lists/_watch_list.html.erb
@@ -3,6 +3,7 @@
     <%= render partial: "talks/card",
           collection: watch_list.talks,
           as: :talk,
+          cached: ->(talk) { [talk, @user_favorite_talks_ids, request.fullpath, watch_list.name] },
           locals: {
             bookmarkable: true,
             user_favorite_talks_ids: watch_list.talks.ids,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,9 @@ Rails.application.routes.draw do
     resources :enhance, only: [:update], param: :slug
   end
 
+  resources :watch_lists, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :bookmark_talks, only: [:create, :destroy]
+
   get "leaderboard", to: "leaderboard#index"
 
   # admin
@@ -68,8 +71,4 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "page#home"
-
-  resources :watch_lists, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
-    resources :talks, only: [:create, :destroy], controller: "watch_list_talks"
-  end
 end

--- a/config/solid_cache.yml
+++ b/config/solid_cache.yml
@@ -2,7 +2,7 @@ default: &default
   database: cache
   store_options:
     max_age: <%= 1.month.to_i %>
-    max_size: <%= 512.megabytes %>
+    max_size: <%= 2.gigabytes %>
     namespace: <%= Rails.env %>
 
 development:

--- a/test/controllers/bookmark_talks_controller_test.rb
+++ b/test/controllers/bookmark_talks_controller_test.rb
@@ -1,16 +1,16 @@
 require "test_helper"
 
-class WatchListTalksControllerTest < ActionDispatch::IntegrationTest
+class BookmarkTalksControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:one)
-    @watch_list = watch_lists(:one)
+    @watch_list = @user.default_watch_list
     @talk = talks(:one)
     sign_in_as @user
   end
 
-  test "should add talk to watch_list" do
+  test "should bookmark talk to default watch list" do
     assert_difference("WatchListTalk.count") do
-      post watch_list_talks_url(@watch_list), params: {talk_id: @talk.id}
+      post bookmark_talks_url params: {talk_id: @talk.id}
     end
 
     assert_redirected_to watch_list_url(@watch_list)
@@ -21,7 +21,7 @@ class WatchListTalksControllerTest < ActionDispatch::IntegrationTest
     WatchListTalk.create!(watch_list: @watch_list, talk: @talk)
 
     assert_difference("WatchListTalk.count", -1) do
-      delete watch_list_talk_url(@watch_list, @talk.id)
+      delete bookmark_talk_url(@talk.id)
     end
 
     assert_redirected_to watch_list_url(@watch_list)


### PR DESCRIPTION
Topics#show pages are quite slow to render and in general from the load test we performed the /talks page was the slowest index page.

This PR tries to cache the talks cards


I have deployed for a short time this PR in prod an the results are not what I would have expected and they are hard to understand right now


## Appsignal

This topics#show response time as we can see this PR makes the performance really worst
![66f4a09a2bf67fb0e7aa8fe9](https://github.com/user-attachments/assets/c9930a5c-a91f-4923-aa6b-7239161712f7)


## logs

BUT when I look into the looks I don't see the same response time, response time are typically within the 50ms range for those pages.

![CleanShot 2024-09-26 at 01 47 15@2x](https://github.com/user-attachments/assets/00e3d8b7-93db-4804-9c22-b6ba33d91e71)
<details><summary>Details</summary>
<p>
I, [2024-09-25T23:30:45.693454 #83]  INFO -- : [82779c63-c469-477c-af1b-56009323b77b] Completed 200 OK in 28ms (Views: 17.6ms | ActiveRecord: 1.7ms (10 queries, 3 cached) | GC: 0.0ms)
I, [2024-09-25T23:30:46.121273 #83]  INFO -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] Started GET "/topics/abstract-syntax-tree-ast" for 141.101.95.60 at 2024-09-25 23:30:46 +0000
I, [2024-09-25T23:30:46.122217 #83]  INFO -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] Processing by TopicsController#show as HTML
I, [2024-09-25T23:30:46.122276 #83]  INFO -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Parameters: {"slug"=>"abstract-syntax-tree-ast"}
D, [2024-09-25T23:30:46.123628 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   Session Load (0.1ms)  SELECT "sessions".* FROM "sessions" WHERE "sessions"."id" = ? LIMIT ?  [["id", 32], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.124946 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   User Load (0.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.126304 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   WatchList Load (0.1ms)  SELECT "watch_lists".* FROM "watch_lists" WHERE "watch_lists"."user_id" = ? ORDER BY "watch_lists"."id" ASC LIMIT ?  [["user_id", 1], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.144579 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   Talk Ids (0.3ms)  SELECT "talks"."id" FROM "talks" INNER JOIN "watch_list_talks" ON "talks"."id" = "watch_list_talks"."talk_id" WHERE "watch_list_talks"."watch_list_id" = ?  [["watch_list_id", 1]]
D, [2024-09-25T23:30:46.145654 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   Topic Load (0.1ms)  SELECT "topics".* FROM "topics" WHERE "topics"."slug" = ? LIMIT ?  [["slug", "abstract-syntax-tree-ast"], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.147332 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendering layout layouts/application.html.erb
D, [2024-09-25T23:30:46.147405 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendering topics/show.html.erb within layouts/application
D, [2024-09-25T23:30:46.149912 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]    (0.8ms)  SELECT COUNT(*) AS "size", MAX("talks"."updated_at") AS timestamp FROM "talks" INNER JOIN "talk_topics" ON "talks"."id" = "talk_topics"."talk_id" WHERE "talk_topics"."topic_id" = ?  [["topic_id", 875]]
D, [2024-09-25T23:30:46.158374 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   SolidCache::Entry Load (7.6ms)  SELECT "solid_cache_entries"."key", "solid_cache_entries"."value" FROM "solid_cache_entries" WHERE "solid_cache_entries"."key_hash" IN (?)  [[nil, 7500390716560074863]]
I, [2024-09-25T23:30:46.159038 #83]  INFO -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered topics/show.html.erb within layouts/application (Duration: 11.6ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.162084 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/_top_banner.html.erb (Duration: 0.4ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.162571 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/navbar/_link.html.erb (Duration: 0.3ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.162827 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/navbar/_link.html.erb (Duration: 0.1ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.163040 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/navbar/_link.html.erb (Duration: 0.1ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.163249 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/navbar/_link.html.erb (Duration: 0.1ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.163474 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/navbar/_link.html.erb (Duration: 0.1ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.163693 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/navbar/_link.html.erb (Duration: 0.1ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.164665 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   CACHE WatchList Load (0.0ms)  SELECT "watch_lists".* FROM "watch_lists" WHERE "watch_lists"."user_id" = ? ORDER BY "watch_lists"."id" ASC LIMIT ?  [["user_id", 1], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.165459 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   CACHE WatchList Load (0.0ms)  SELECT "watch_lists".* FROM "watch_lists" WHERE "watch_lists"."user_id" = ? ORDER BY "watch_lists"."id" ASC LIMIT ?  [["user_id", 1], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.168015 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/_user_dropdown.html.erb (Duration: 1.9ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.169156 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   CACHE WatchList Load (0.0ms)  SELECT "watch_lists".* FROM "watch_lists" WHERE "watch_lists"."user_id" = ? ORDER BY "watch_lists"."id" ASC LIMIT ?  [["user_id", 1], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.169811 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   CACHE WatchList Load (0.0ms)  SELECT "watch_lists".* FROM "watch_lists" WHERE "watch_lists"."user_id" = ? ORDER BY "watch_lists"."id" ASC LIMIT ?  [["user_id", 1], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.171676 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/_user_mobile_dropdown.html.erb (Duration: 3.4ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.171800 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/_navbar.html.erb (Duration: 9.6ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.172000 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/_flashes.html.erb (Duration: 0.1ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.173676 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered shared/_footer.html.erb (Duration: 1.5ms | GC: 0.0ms)
I, [2024-09-25T23:30:46.174116 #83]  INFO -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a]   Rendered layout layouts/application.html.erb (Duration: 26.7ms | GC: 0.0ms)
D, [2024-09-25T23:30:46.175166 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   Ahoy::Visit Load (0.1ms)  SELECT "ahoy_visits".* FROM "ahoy_visits" WHERE "ahoy_visits"."visit_token" = ? LIMIT ?  [["visit_token", "[FILTERED]"], ["LIMIT", 1]]
D, [2024-09-25T23:30:46.176138 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   TRANSACTION (0.1ms)  begin transaction
D, [2024-09-25T23:30:46.176476 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   Ahoy::Event Create (0.4ms)  INSERT INTO "ahoy_events" ("visit_id", "user_id", "name", "properties", "time") VALUES (?, ?, ?, ?, ?) RETURNING "id"  [["visit_id", 93941], ["user_id", nil], ["name", "topics#show"], ["properties", "{\"controller\":\"topics\",\"action\":\"show\",\"slug\":\"abstract-syntax-tree-ast\"}"], ["time", "2024-09-25 23:30:46.174767"]]
D, [2024-09-25T23:30:46.176769 #83] DEBUG -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] [primary]   TRANSACTION (0.1ms)  commit transaction
I, [2024-09-25T23:30:46.177018 #83]  INFO -- : [71ce1913-ac0a-48b6-9346-91ec8dbb117a] Completed 200 OK in 55ms (Views: 18.8ms | ActiveRecord: 11.5ms (13 queries, 4 cached) | GC: 0.0ms)
I, [2024-09-25T23:30:46.179585 #87]  INFO -- : [b75fccb5-80f2-4174-84a8-90d5fdf033ba] Started GET "/up" for 127.0.0.1 at 2024-09-25 23:30:46 +0000
I, [2024-09-25T23:30:46.180248 #87]  INFO -- : [b75fccb5-80f2-4174-84a8-90d5fdf033ba] Processing by Rails::HealthController#show as */*
I, [2024-09-25T23:30:46.180861 #87]  INFO -- : [b75fccb5-80f2-4174-84a8-90d5fdf033ba] [ahoy] Visit excluded
</p>
</details> 

## oha

```
 oha -c 1 -z 10s -m GET https://rubyvideo.dev/topics/abstract-syntax-tree-ast
```

Summary:
  Success rate:	100.00%
  Total:	10.1279 secs
  Slowest:	2.3109 secs
  Fastest:	0.3328 secs
  Average:	1.4139 secs
  Requests/sec:	0.7899

running the same test on a branch without cache returns those numbers

```
oha -c 1 -z 10s -m GET https://rubyvideo.dev/topics/abstract-syntax-tree-ast
Summary:
  Success rate:	100.00%
  Total:	10.0025 secs
  Slowest:	2.1678 secs
  Fastest:	0.3932 secs
  Average:	1.2713 secs
  Requests/sec:	0.6998
```

## Conclusion 

Not sure what is happening but it looks like the cache is making things worst. I checked iin teh logs we do see in prod and dev cache read and write.  To investigate....

