### PR TITLE
Fix Talk#Show speakers n+1

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -21,7 +21,7 @@ class SpeakersController < ApplicationController
 
   # GET /speakers/1
   def show
-    @talks = @speaker.talks.order(date: :desc)
+    @talks = @speaker.talks.includes(:speakers, :event).order(date: :desc)
     @back_path = speakers_path
     set_meta_tags(@speaker)
     # fresh_when(@speaker)


### PR DESCRIPTION
There is an n+1 query triggered by rendering the speakers of each talk because it's not eager loaded in the controller when rendering Speakers#show

| **Before** | **After** |
|------------|-----------|
| ![Before](https://github.com/user-attachments/assets/3ed9027b-e358-49bb-9b5f-d8848446903b) | ![After](https://github.com/user-attachments/assets/287d803f-aa1d-463d-860d-a99689bd9069) |