### PR TITLE
Fix sign out links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: yarn
+          cache: "yarn"
+          cache-dependency-path: "/dev/null"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "yarn"
-          cache-dependency-path: "/dev/null"
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/app/views/shared/_user_dropdown.html.erb
+++ b/app/views/shared/_user_dropdown.html.erb
@@ -9,7 +9,7 @@
     <% c.with_menu_item_link_to "Analytics", analytics_dashboards_path %>
     <% if Current.user %>
       <% c.with_menu_item_divider %>
-      <% c.with_menu_item_button_to t("sign_out"), Current.session, method: :delete, id: :sign_out %>
+      <% c.with_menu_item_button_to t("sign_out"), Current.session, method: :delete, "data-turbo-method": :delete, id: :sign_out %>
       <% if Current.user&.admin? %>
         <% c.with_menu_item_link_to "Suggestions", admin_suggestions_path %>
         <% c.with_menu_item_link_to t("admin"), avo_path %>

--- a/app/views/shared/_user_dropdown.html.erb
+++ b/app/views/shared/_user_dropdown.html.erb
@@ -9,7 +9,7 @@
     <% c.with_menu_item_link_to "Analytics", analytics_dashboards_path %>
     <% if Current.user %>
       <% c.with_menu_item_divider %>
-      <% c.with_menu_item_button_to t("sign_out"), Current.session, method: :delete, "data-turbo-method": :delete, id: :sign_out %>
+      <% c.with_menu_item_link_to t("sign_out"), Current.session, method: :delete, "data-turbo-method": :delete, id: :sign_out %>
       <% if Current.user&.admin? %>
         <% c.with_menu_item_link_to "Suggestions", admin_suggestions_path %>
         <% c.with_menu_item_link_to t("admin"), avo_path %>

--- a/app/views/shared/_user_mobile_dropdown.html.erb
+++ b/app/views/shared/_user_mobile_dropdown.html.erb
@@ -29,7 +29,7 @@
 
     <% signed_in do %>
       <% c.with_menu_item_divider %>
-      <% c.with_menu_item_button_to t("sign_out"), Current.session, method: :delete, "data-turbo-method": :delete, id: :sign_out %>
+      <% c.with_menu_item_link_to t("sign_out"), Current.session, method: :delete, "data-turbo-method": :delete, id: :sign_out %>
       <% if Current.user&.admin? %>
         <% c.with_menu_item_link_to "Suggestions", admin_suggestions_path %>
         <% c.with_menu_item_link_to t("admin"), avo_path %>

--- a/app/views/shared/_user_mobile_dropdown.html.erb
+++ b/app/views/shared/_user_mobile_dropdown.html.erb
@@ -29,7 +29,7 @@
 
     <% signed_in do %>
       <% c.with_menu_item_divider %>
-      <% c.with_menu_item_button_to t("sign_out"), Current.session, method: :delete, id: :sign_out %>
+      <% c.with_menu_item_button_to t("sign_out"), Current.session, method: :delete, "data-turbo-method": :delete, id: :sign_out %>
       <% if Current.user&.admin? %>
         <% c.with_menu_item_link_to "Suggestions", admin_suggestions_path %>
         <% c.with_menu_item_link_to t("admin"), avo_path %>


### PR DESCRIPTION
**Before**
`button_to` creates a form which causing an issue that the user can only logout if they click directly on the text. 

https://github.com/user-attachments/assets/4629bd20-444c-4b10-9c64-592e306914e1



**After**
Using `link_to` with `data-turbo-method: :delete` fixes this issue.


https://github.com/user-attachments/assets/e5b01f91-e2cd-4a3b-999d-4d69e8a7eb75



