### PR TITLE
Fix topic.talks slow query

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -17,7 +17,7 @@ class EventsController < ApplicationController
       talks = event_talks.pagy_search(params[:q])
       @pagy, @talks = pagy_meilisearch(talks, items: 9)
     else
-      @pagy, @talks = pagy(event_talks.order(date: :desc).includes(:speakers), items: 9)
+      @pagy, @talks = pagy(event_talks.with_essential_card_data.order(date: :desc), items: 9)
     end
   end
 

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -21,7 +21,7 @@ class SpeakersController < ApplicationController
 
   # GET /speakers/1
   def show
-    @talks = @speaker.talks.includes(:speakers, :event).order(date: :desc)
+    @talks = @speaker.talks.with_essential_card_data.order(date: :desc)
     @back_path = speakers_path
     set_meta_tags(@speaker)
     # fresh_when(@speaker)

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -7,10 +7,10 @@ class TalksController < ApplicationController
   # GET /talks
   def index
     if params[:q].present?
-      talks = Talk.includes(:speakers, :event).pagy_search(params[:q])
+      talks = Talk.with_essential_card_data.pagy_search(params[:q])
       @pagy, @talks = pagy_meilisearch(talks, limit: 21, page: params[:page]&.to_i || 1)
     else
-      @pagy, @talks = pagy(Talk.all.order(date: :desc).includes(:speakers, :event), limit: 21, page: params[:page]&.to_i || 1)
+      @pagy, @talks = pagy(Talk.all.with_essential_card_data.order(date: :desc), limit: 21, page: params[:page]&.to_i || 1)
     end
   end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -10,7 +10,11 @@ class TopicsController < ApplicationController
 
   def show
     @topic = Topic.find_by!(slug: params[:slug])
-    @pagy, @talks = pagy(@topic.talks.order(date: :desc).select(:id, :slug, :title, :date, :thumbnail_sm, :thumbnail_lg, :video_id, :event_id).includes(:speakers, :event), limit: 12, page: params[:page]&.to_i || 1)
+    @pagy, @talks = pagy(
+      @topic.talks.with_essential_card_data.order(date: :desc),
+      limit: 12,
+      page: params[:page]&.to_i || 1
+    )
   end
 
   def set_user_favorites

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -10,7 +10,7 @@ class TopicsController < ApplicationController
 
   def show
     @topic = Topic.find_by!(slug: params[:slug])
-    @pagy, @talks = pagy(@topic.talks.order(date: :desc).includes(:speakers, :event), limit: 12, page: params[:page]&.to_i || 1)
+    @pagy, @talks = pagy(@topic.talks.order(date: :desc).select(:id, :slug, :title, :date, :thumbnail_sm, :thumbnail_lg, :video_id, :event_id).includes(:speakers, :event), limit: 12, page: params[:page]&.to_i || 1)
   end
 
   def set_user_favorites

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -108,6 +108,11 @@ class Talk < ApplicationRecord
   scope :without_topics, -> { where.missing(:talk_topics) }
   scope :with_topics, -> { joins(:talk_topics) }
 
+  scope :with_essential_card_data, -> do
+    select(:id, :slug, :title, :date, :thumbnail_sm, :thumbnail_lg, :video_id, :event_id)
+      .includes(:speakers, :event)
+  end
+
   def managed_by?(visiting_user)
     return false unless visiting_user.present?
     return true if visiting_user.admin?


### PR DESCRIPTION
It seems that the root cause for slow queries for `topic.talks` is the large amount of extra columns on the `Talk` model I suppose mostly the transcription and summary that are large text columns.

I ran a little test in prod by selecting only the required columns for the cards and the results are day and night

![CleanShot 2024-10-17 at 06 34 16@2x](https://github.com/user-attachments/assets/522608a7-cb03-4956-bf37-0d3c7d8955e7)

What remains strange is that this was the only route where queries were slow. 

speaker.talks or event.talks wasn't that slow ???? not sure what is the difference with `Topic`

anyhow this PR should close #222 by introducing a new scope for talks `with_essential_card_data` that has been applied to all views rendering a collection of talks