### PR TITLE
Feature/speaker name is misaligned in talk card

### DIFF
--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -1,9 +1,7 @@
-
 <%# locals: (talk:, user_favorite_talks_ids: [], favoritable: false, back_to: nil, back_to_title: nil) -%>
-
 <div class="card card-compact bg-white shadow-xl w-full" id="<%= dom_id talk %>" style="<%= "view-transition-name: #{dom_id(talk, :talk_card)}" %>">
   <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden" do %>
-      <%= image_tag talk.thumbnail_sm,
+    <%= image_tag talk.thumbnail_sm,
             srcset: ["#{talk.thumbnail_lg} 2x"],
             id: dom_id(talk),
             height: 174,
@@ -21,14 +19,13 @@
       </div>
       <div class="flex gap-2 items-end justify-between w-full">
         <div class="flex flex-col text-sm w-full flex-grow">
-          <div class="flex items-start gap-2 font-light">
+          <div class="flex items-center gap-2 font-light">
             <% speakers_count = talk.speakers.size %>
             <% if speakers_count > 1 %>
               <%= heroicon :users, size: :sm, class: "shrink-0 grow-0 my-1" %>
             <% elsif speakers_count == 1 %>
               <%= heroicon :user, size: :sm, class: "shrink-0 grow-0 my-1" %>
             <% end %>
-
             <div class="line-clamp-1">
               <% speaker_names = talk.speakers.map { |speaker| link_to speaker.name, speaker_path(speaker), class: "link link-ghost" } %>
               <%= sanitize speaker_names.join(", ") %>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -1,7 +1,9 @@
+
 <%# locals: (talk:, user_favorite_talks_ids: [], favoritable: false, back_to: nil, back_to_title: nil) -%>
+
 <div class="card card-compact bg-white shadow-xl w-full" id="<%= dom_id talk %>" style="<%= "view-transition-name: #{dom_id(talk, :talk_card)}" %>">
   <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden" do %>
-    <%= image_tag talk.thumbnail_sm,
+      <%= image_tag talk.thumbnail_sm,
             srcset: ["#{talk.thumbnail_lg} 2x"],
             id: dom_id(talk),
             height: 174,
@@ -26,6 +28,7 @@
             <% elsif speakers_count == 1 %>
               <%= heroicon :user, size: :sm, class: "shrink-0 grow-0 my-1" %>
             <% end %>
+
             <div class="line-clamp-1">
               <% speaker_names = talk.speakers.map { |speaker| link_to speaker.name, speaker_path(speaker), class: "link link-ghost" } %>
               <%= sanitize speaker_names.join(", ") %>


### PR DESCRIPTION
fixes #230 
**Before**
<img width="696" alt="image" src="https://github.com/user-attachments/assets/9fd17b68-4f40-4d97-b5ac-5aae3e41126d">
**After**
<img width="786" alt="image" src="https://github.com/user-attachments/assets/41b24317-cc10-4edd-9701-1e2898831332">
