### PR TITLE
Limit Talks to even number per page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,9 +15,9 @@ class EventsController < ApplicationController
     event_talks = @event.talks
     if params[:q].present?
       talks = event_talks.pagy_search(params[:q])
-      @pagy, @talks = pagy_meilisearch(talks, items: 9)
+      @pagy, @talks = pagy_meilisearch(talks, limit: 21)
     else
-      @pagy, @talks = pagy(event_talks.with_essential_card_data.order(date: :desc), items: 9)
+      @pagy, @talks = pagy(event_talks.with_essential_card_data.order(date: :desc), limit: 21)
     end
   end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -8,9 +8,9 @@ class TalksController < ApplicationController
   def index
     if params[:q].present?
       talks = Talk.with_essential_card_data.pagy_search(params[:q])
-      @pagy, @talks = pagy_meilisearch(talks, limit: 21, page: params[:page]&.to_i || 1)
+      @pagy, @talks = pagy_meilisearch(talks, limit: 20, page: params[:page]&.to_i || 1)
     else
-      @pagy, @talks = pagy(Talk.all.with_essential_card_data.order(date: :desc), limit: 21, page: params[:page]&.to_i || 1)
+      @pagy, @talks = pagy(Talk.all.with_essential_card_data.order(date: :desc), limit: 20, page: params[:page]&.to_i || 1)
     end
   end
 


### PR DESCRIPTION
The talks on the events#show page should be dividable by 3 (since we were using `items` this argument was unused and defaulted to 20 making it uneven)

The talks on the talks#index page should be dividable by 4, which is why I changed it to 20 so we it's actually dividable by 4 to make it even.