### PR TITLE
Remove duplicated talk in RailsConf 2014

### DIFF
--- a/data/railsconf/railsconf-2014/videos.yml
+++ b/data/railsconf/railsconf-2014/videos.yml
@@ -1826,25 +1826,6 @@
     http://amara.org/v/FGZk/
   video_id: g3pM6bVPZsQ
 
-- title: WebRTC Change Communcations Forever
-  raw_title: RailsConf 2014 - WebRTC Change Communcations Forever by Greg Baugues
-  speakers:
-    - Greg Baugues
-  event_name: RailsConf 2014
-  thumbnail_xs: https://i.ytimg.com/vi/AviVwTUP38w/default.jpg
-  thumbnail_sm: https://i.ytimg.com/vi/AviVwTUP38w/mqdefault.jpg
-  thumbnail_md: https://i.ytimg.com/vi/AviVwTUP38w/hqdefault.jpg
-  thumbnail_lg: https://i.ytimg.com/vi/AviVwTUP38w/sddefault.jpg
-  thumbnail_xl: https://i.ytimg.com/vi/AviVwTUP38w/maxresdefault.jpg
-  published_at: "2014-05-22"
-  description: |-
-    WebRTC (Real Time Communications) is revolutionizing the way we handle voice, video and data communication by providing native peer-to-peer communication inside the browser. In this talk we'll discuss: - History: How has WebRTC evolved since it's birth just three years ago? - Applications: How are developers using WebRTC beyond video conferencing? (Such as a peer distributed CDN and "bittorrent in the browser"). - Getting Started: What is the WebRTC Hello World?
-
-    Help us caption & translate this video!
-
-    http://amara.org/v/FGZl/
-  video_id: AviVwTUP38w
-
 - title: "Workshop: Teamwork Ain't Always Easy"
   raw_title: RailsConf 2014 - Workshop - Teamwork Ain't Always Easy by Michael Norton
   speakers:


### PR DESCRIPTION
This talk exists twice on YouTube, which is why we imported it twice. I removed the one which has less views and doesn't have the typo in the talk title.

https://www.youtube.com/watch?v=ImCJxCb3RFg
https://www.rubyvideo.dev/talks/webrtc-change-communications-forever

https://www.youtube.com/watch?v=AviVwTUP38w
https://www.rubyvideo.dev/talks/webrtc-change-communcations-forever