### PR TITLE
Resolve RubyConf 2016 TODOs in schedule

### DIFF
--- a/data/rubyconf/rubyconf-2016/videos.yml
+++ b/data/rubyconf/rubyconf-2016/videos.yml
@@ -1,168 +1,27 @@
 ---
 
-# TODO: talk dates
-# TODO: talks running order
-# TODO: schedule website
+# https://web.archive.org/web/20161115224654/http://rubyconf.org/schedule
 
-- title: The Little Server That Could
-  raw_title: RubyConf 2016 - The Little Server That Could by Stella Cotton
-  speakers:
-    - Stella Cotton
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - The Little Server That Could by Stella Cotton
+## Day 1 - 2016-11-10
 
-    Have you ever wondered what dark magic happens when you start up your Ruby server? Let’s explore the mysteries of the web universe by writing a tiny web server in Ruby! Writing a web server lets you dig deeper into the Ruby Standard Library and the Rack interface. You’ll get friendlier with I/O, signal trapping, file handles, and threading. You’ll also explore dangers first hand that can be lurking inside your production code- like blocking web requests and shared state with concurrency.
-  video_id: AFgDPssfZ9k
-
-- title: Q&A with Matz
-  raw_title: RubyConf 2016 - Matz Q&A by Yukihiro 'Matz' Matsumoto
-  speakers:
-    - Yukihiro "Matz" Matsumoto
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Matz Q&A by Yukihiro 'Matz' Matsumoto
-
-    Part of our annual tradition, Matz answers questions from Evan as well as the audience
-  video_id: Ohs2hZBzif8
-
-- title: The Neuroscience and Psychology of Open Source Communities
-  raw_title: RubyConf 2016 - The Neuroscience and Psychology of Open Source Communities by Elizabeth Barron
-  speakers:
-    - Elizabeth Barron
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - The Neuroscience and Psychology of Open Source Communities by Elizabeth Barron
-
-    ***Contains explicit language***
-
-    Because people are complex, diverse creatures, ensuring that your open source community is healthy, vibrant, and welcoming can be challenging. The good news is, science can help you understand human thoughts and behaviors, and the complexities of interacting in a collaborative way online. We'll discuss cognitive biases, the SCARF collaboration model, the online community life cycle, and how these things interact. You'll come away from this talk with a deeper understanding of yourself, your fellow humans, & the knowledge to improve personal interactions and the open source communities you belong to.
-  video_id: VXE42FyFFX4
-
-- title: Metaprogramming? Not good enough!
-  raw_title: RubyConf 2016 - Metaprogramming? Not good enough! by Justin Weiss
-  speakers:
-    - Justin Weiss
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Metaprogramming? Not good enough! by Justin Weiss
-
-    If you know how to metaprogram in Ruby, you can create methods and objects on the fly, build Domain Specific Languages, or just save yourself a lot of typing. But can you change how methods are dispatched? Can you decide that the normal inheritance rules don't apply to some object?
-
-    In order to change those core parts of the language, there can't be much difference between how a language is implemented and how it's used. In this talk, you'll make that difference smaller, building a totally extensible object model on top of Ruby, using less than a dozen new classes and methods.
-  video_id: JOvBmhukWI0
-
-- title: Rhythmic Recursion
-  raw_title: RubyConf 2016 - Rhythmic Recursion by Celeen Rusk
-  speakers:
-    - Celeen Rusk
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Rhythmic Recursion by Celeen Rusk
-
-    One of the best things about multi-disciplinary work is recognizing familiar ideas in a different setting. It’s like running into an old friend while you’re on vacation halfway around the world-- “I had no idea you’d be here! It’s so great to see you!”
-
-    In this talk we’ll run into our old friend recursion in the faraway land of minimalist music, by rewriting a piece of rhythmic music in Ruby.
-  video_id: cSPhgRgjwZs
-
-- title: Opening Keynote by Yukihiro 'Matz' Matsumoto
+- title: 'Opening Keynote: RINSWAN'
   raw_title: RubyConf 2016 - Opening Keynote by Yukihiro 'Matz' Matsumoto
   speakers:
     - Yukihiro "Matz" Matsumoto
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-10'
   description: RubyConf 2016 - Opening Keynote by Yukihiro 'Matz' Matsumoto
   video_id: 1l3U1X3z0CE
 
-- title: That Works?! Quines and Other Delightfully Useless Programs
-  raw_title: RubyConf 2016 - That Works?! Quines and Other Delightfully Useless Programs by Colin Fulton
-  speakers:
-    - Colin Fulton
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - That Works?! Quines and Other Delightfully Useless Programs by Colin Fulton
+# ---
 
-    Performance, readability and correctness are fine and dandy, but what happens when we start optimizing for whimsy, illegibility and outright silliness? Self-rewriting programs that also function as ASCII art? Yup. Rewrite any JavaScript program only using six characters? Why not?
-
-    Let's take a break from the practical and laugh at some of the most unbelievable code you've ever seen. Then let's pull out the magnifying glass to figure out how it actually works.
-
-    Learn how to read the unreadable and how to write code that—to borrow a phrase from the Ig Nobel Awards—makes people laugh, then think.
-  video_id: DC-bjR6WeaM
-
-- title: How I Corrupted Survey Results and (Maybe) Ruined a Business
-  raw_title: RubyConf 2016 - How I Corrupted Survey Results and (Maybe) Ruined a Business by Mike Calhoun
-  speakers:
-    - Mike Calhoun
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - How I Corrupted Survey Results and (Maybe) Ruined a Business by Mike Calhoun
-
-    It was the perfect storm of events and circumstances: a first job, naïveté of inexperience, a fear of getting fired, and a loud boss prone to yelling. One morning, I realized that the first web “project” of my first job in my new career had gone horribly off track. What came to pass in the following weeks was the most involved and tense coverup I’ve undertaken in my life. This experience can tell us all about how we communicate with each other. How we can create environments where people can ask for help and how an atmosphere of pressure and tension can ruin a business.
-  video_id: NFkym21cl4E
-
-- title: Datacenter Fires and Other "Minor" Disasters
-  raw_title: RubyConf 2016 - Datacenter Fires and Other "Minor" Disasters by Aja Hammerly
-  speakers:
-    - Aja Hammerly
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Datacenter Fires and Other "Minor" Disasters by Aja Hammerly
-
-    Most of us have a "that day I broke the internet" story. Some are amusing and some are disastrous but all of these stories change how we operate going forward. I'll share the amusing stories behind why I always take a database backup, why feature flags are important, the importance of automation, and how having a team with varied backgrounds can save the day. Along the way I'll talk about a data center fire, deleting a production database, and accidentally setting up a DDOS attack against our own site. I hope that by learning from my mistakes you won't have to make them yourself.
-  video_id: ygu45C7bMHk
-
-- title: The Building Built on Stilts
-  raw_title: RubyConf 2016 - The Building Built on Stilts by Nickolas Means
-  speakers:
-    - Nickolas Means
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - The Building Built on Stilts by Nickolas Means
-
-    In the summer of 1978, structural engineer William LeMessurier got a phone call that terrified him. An undergraduate student claimed that LeMessurier's acclaimed 59-story Citicorp Center in Manhattan, just completed the year prior, was dangerously unstable under certain wind conditions. The student was right, and it was almost hurricane season.
-
-    The key to building a culture of innovation in your team is learning how to respond when mistakes inevitably happen. Let's let Bill LeMessurier teach us how to respond when it all goes wrong so that our creations can thrive despite our mistakes.
-  video_id: "-ES1wlV-8lU"
-
-- title: Just a Ruby Minute
-  raw_title: RubyConf 2016 - Just a Ruby Minute by Andrew Faraday
-  speakers:
-    - Andrew Faraday
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Just a Ruby Minute by Andrew Faraday
-
-    Just a Minute is a game show that's a part of the British national consciousness, delighting audiences across the country for almost half a century. In it, speakers are challenged to speak for one minute without hesitation, repetition or deviation, it's much harder than it sounds. It's fast paced, funny, insightful and you might even learn something.
-  video_id: 1hpoyjCB2WY
-
-- title: Evaluate Ruby Without Ruby
-  raw_title: RubyConf 2016 - Evaluate Ruby Without Ruby by Takashi Kokubun
-  speakers:
-    - Takashi Kokubun
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Evaluate Ruby Without Ruby by Takashi Kokubun
-
-    Have you ever wanted to implement a tool that can be configured by Ruby code? You may think such tools require MRI, JRuby or Rubinius to evaluate the configuration. But that's not true! Let's see how we can build a tool that evaluates Ruby without dependency on Ruby interpreter using mruby.
-  video_id: jD0q8uHV5cA
-
+# Track: General 1
 - title: Building a Better OpenStruct
   raw_title: RubyConf 2016 - Building a Better OpenStruct by Ariel Caplan
   speakers:
     - Ariel Caplan
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-10'
   description: |-
     RubyConf 2016 - Building a Better OpenStruct by Ariel Caplan
 
@@ -173,12 +32,60 @@
     Sometimes, we can have our cake and eat it too. But it takes creativity, hard work, and willingness to question why things are the way they are.
   video_id: 2IbJFCbBnQk
 
+# Track: Learning and Teaching
+- title: Bootcamp Grads Have Feelings, Too
+  raw_title: RubyConf 2016 - Bootcamp Grads Have Feelings, Too by Max Tiu
+  speakers:
+    - Megan Tiu
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Bootcamp Grads Have Feelings, Too by Max Tiu
+
+    You’re a bootcamp student. You’re so excited to become a developer! Amidst your excitement about this new industry, you hear everyone say that bootcamps are a blemish on the community, that they’re a waste of time and money. “Maybe I’ve made a huge mistake,” you think. “I don’t know how I’ll fit in here."
+
+    But you can make this community better! In this session, you’ll learn about the varied experiences of bootcamp students and grads, how exclusionary behavior can end up stunting our community as a whole, and what you can to do make a more inclusive environment for everyone of all skill levels.
+  video_id: 133HhIjmfRE
+
+# Track: General 2
+- title: 'Attention Rubyists: You Can Write Video Games'
+  raw_title: 'RubyConf 2016 - Attention Rubyists: you can write video games by Cory Chamblin'
+  speakers:
+    - Cory Chamblin
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Attention Rubyists: you can write video games by Cory Chamblin
+
+    Ruby may seem like a humdrum language best suited for writing web apps, but underneath that cool exterior lies plenty of power -- power we can harness for making our own games!
+
+    In this talk, we'll introduce Gosu, a sweet little game library. We'll talk about how games are structured in pretty much every language and framework ever, where to get ideas for things to make, and ways you can share your game with your friends and the world.
+  video_id: bK9RX_CzCeI
+
+# Track: Comparative Ruby
+- title: Building Maintainable Command-Line Tools with MRuby
+  raw_title: RubyConf 2016 - Building maintainable command-line tools with MRuby by Eric Hodel
+  speakers:
+    - Eric Hodel
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Building maintainable command-line tools with MRuby by Eric Hodel
+
+    mruby and mruby-cli makes it possible to ship single binary command-line tools that can be used without setup effort, but how difficult is development in MRuby?
+
+    In this talk we'll explore how to work with MRuby and mruby-cli. We'll cover the differences in development patterns when using MRuby, the maturity of the MRuby ecosystem, and development patterns when using mruby-cli to build a command-line tool.
+  video_id: 96YgJSGaB3M
+
+# ---
+
+# Track: Tools and Toys
 - title: C Ruby? C Ruby Go! Go Ruby Go!
   raw_title: RubyConf 2016 - C Ruby? C Ruby Go! Go Ruby Go! by Loren Segal
   speakers:
     - Loren Segal
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-10'
   description: |-
     RubyConf 2016 - C Ruby? C Ruby Go! Go Ruby Go! by Loren Segal
 
@@ -187,24 +94,209 @@
     Do you know any Go? Well, if you do, you’re in luck! Join us for this talk about a tool named gorb that will quickly and easily let you generate native Ruby extension wrappers for your Go programs. And if you don’t know Go, come anyway, it’s really easy to learn! We’ll have you writing blazing fast code that you can use right from Ruby, in no time at all.
   video_id: V1ZMQjm9I50
 
+# Track: Learning and Teaching
+- title: Continuing Education at Work
+  raw_title: RubyConf 2016 - Continuing Education at Work by Katherine Wu
+  speakers:
+    - Katherine Wu
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Continuing Education at Work by Katherine Wu
+
+    The list of things we want to learn is infinite. How many of us have marked items to read/watch, yet never go back to them? Despite the best of intentions, I often only learn what I directly need. It wasn’t until I started running a couple lightweight continuing education programs at work that I followed through on my goals. We’ll discuss strategies for making these programs low maintenance and long-lived, as well as flexible enough to help both more and less experienced folks. If you’ve been looking for a more effective approach to learning, but still outside classrooms, this talk is for you!
+  video_id: 9uRho69xSAI
+
+# Track: General 2
+- title: 'Deletion Driven Development: Code to Delete Code!'
+  raw_title: 'RubyConf 2016 - Deletion Driven Development: Code to delete code! by Chris Arcand'
+  speakers:
+    - Chris Arcand
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Deletion Driven Development: Code to delete code! by Chris Arcand
+
+    Good news! Ruby is a successful and mature programming language with a wealth of libraries and legacy applications that have been contributed to for many years. The bad news: Those projects might contain a large amount of useless, unused code which adds needless complexity and confuses new developers. In this talk I'll explain how to build a static analysis tool to help you find unused code and remove it - because there's no code that's easier to maintain than no code at all!
+  video_id: OfiIyNV00uI
+
+# Track: Comparative Ruby
+- title: Composition
+  raw_title: RubyConf 2016 - Composition by James Dabbs
+  speakers:
+    - James Dabbs
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Composition by James Dabbs
+
+    Our work as programmers consists largely of problem decomposition and solution recomposition. This talk is interested in how we cobble small units together into cohesive solutions. We'll examine and compare both object and functional composition, using a Haskell-inspired, functional style of Ruby. Along the way, we'll see how good functional principles can improve our object-oriented design, and vice versa.
+  video_id: zwo7ZTHS8Wg
+
+# Lunch
+
+- title: Just a Ruby Minute
+  raw_title: RubyConf 2016 - Just a Ruby Minute by Andrew Faraday
+  speakers:
+    - Andrew Faraday
+    - Kinsey Ann Durham
+    - Aaron Patterson
+    - Tara Scherner De La Fuente
+    - Sam Phippen
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Just a Ruby Minute by Andrew Faraday
+
+    Just a Minute is a game show that's a part of the British national consciousness, delighting audiences across the country for almost half a century. In it, speakers are challenged to speak for one minute without hesitation, repetition or deviation, it's much harder than it sounds. It's fast paced, funny, insightful and you might even learn something.
+  video_id: 1hpoyjCB2WY
+
+# ---
+
+# Track: Tools and Toys
+- title: Evaluate Ruby Without Ruby
+  raw_title: RubyConf 2016 - Evaluate Ruby Without Ruby by Takashi Kokubun
+  speakers:
+    - Takashi Kokubun
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Evaluate Ruby Without Ruby by Takashi Kokubun
+
+    Have you ever wanted to implement a tool that can be configured by Ruby code? You may think such tools require MRI, JRuby or Rubinius to evaluate the configuration. But that's not true! Let's see how we can build a tool that evaluates Ruby without dependency on Ruby interpreter using mruby.
+  video_id: jD0q8uHV5cA
+
+# Track: Learning and Teaching
+- title: '"Am I Senior Yet?" Grow Your Career by Teaching Your Peers'
+  raw_title: RubyConf 2016 - “Am I Senior Yet?” Grow Your Career by Teaching Your Peers Katlyn Parvin
+  speakers:
+    - Katlyn Parvin
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - “Am I Senior Yet?” Grow Your Career by Teaching Your Peers Katlyn Parvin
+
+    “How do I become a senior engineer?” It’s a question every bootcamp grad will ask. Most engineers look at advancement through a lens of increasing technical skill. More than ever, though, being “senior” means more than just parsing Ruby in your sleep. As our companies grow and as our industry grows, seniority means helping new teammates and colleagues advance their own skills. It means knowing how to teach.
+
+    You don’t need Matz-level knowledge to be a great teacher. With social awareness, a dash of psychology, and some proven approaches, by helping others learn, you’ll earn senior-level respect.
+  video_id: jcTmoOHhG9A
+
+# Track: Ruby Deep Dive
+- title: A Look at Hooks
+  raw_title: RubyConf 2016 - A Look at Hooks by Craig Buchek
+  speakers:
+    - Craig Buchek
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - A Look at Hooks by Craig Buchek
+
+    Ruby has several methods that are invoked implicitly under certain circumstances. These methods are called "hooks", and they provide points to extend behavior. While hooks might seem like "spooky action at a distance", they can be really powerful. In fact, hooks are one of the primary ways that Ruby provides for meta-programming.
+
+    Unfortunately, Ruby's hooks are not all documented very well. We'll take a look at what hooks are available and how to use them. We'll also talk about when to avoid using hooks and provide some tips on how to troubleshoot when hooks are involved.
+  video_id: x7F4kkdKQbQ
+
+# Track: Comparative Ruby
+- title: Why Recursion Matters
+  raw_title: RubyConf 2016 - Why recursion matters by James Coglan
+  speakers:
+    - James Coglan
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Why recursion matters by James Coglan
+
+    In modern programming, recursion is so common that we take it for granted. We work with recursive processes and structures every day, and it's easy to forget that recursion was once a highly contentious issue in programming language design.
+
+    But there's more to recursion than meets the eye. In this talk I'll discuss how it is fundamental to computing; how it can prove programs are correct, make them run faster, and even let you run programs backwards! Along the way we'll meet maths, Haskell, Bash, JavaScript, and our old friend Ruby doing some very surprising things.
+  video_id: qhwG2B77fQk
+
+# ---
+
+# Track: Tools and Toys
 - title: Improving Coverage Analysis
   raw_title: RubyConf 2016 - Improving Coverage Analysis by Ryan Davis
   speakers:
     - Ryan Davis
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-10'
   description: |-
     RubyConf 2016 - Improving Coverage Analysis by Ryan Davis
 
     If you follow modern practices, test coverage analysis is a lie, plain and simple. What it reports is a false positive and leaves you with a false sense of security, vulnerable to regression, and unaware that this is even the case. Come figure out how this happens, why it isn’t your fault, and how coverage analysis can be improved.
   video_id: ljTO3HDw1sI
 
+# Track: General 1
+- title: 'Dōmo Arigatō, Mr. Roboto: Machine Learning with Ruby'
+  raw_title: 'RubyConf 2016 - Dōmo arigatō, Mr. Roboto: Machine Learning with Ruby by Eric Weinstein'
+  speakers:
+    - Eric Weinstein
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Dōmo arigatō, Mr. Roboto: Machine Learning with Ruby by Eric Weinstein
+
+    Machine learning is a popular and rapidly growing field
+    these days, but you don't usually hear it mentioned in the same breath as Ruby.
+    Many developers assume that if you want to do machine learning or computer vision,
+    you've got to do it in Python or Java. Not so! In this talk, we'll walk through
+    training a neural network written in Ruby on the MNIST dataset, then develop an
+    application to use that network to classify handwritten numbers.
+  video_id: T1nFQ49TyeA
+
+# Track: Ruby Deep Dive
+- title: Keyword Args — The Killer Ruby Feature You Aren't Using
+  raw_title: RubyConf 2016 - Keyword Args — the killer Ruby feature you aren't using by  Guyren G. Howe
+  speakers:
+    - Guyren G. Howe
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Keyword Args — the killer Ruby feature you aren't using by  Guyren G. Howe
+
+    Write clearer code more easily. Write functions that are more composable and flexible.
+
+    Ruby 2.0's KWArgs feature isn't just an easier way to write functions that take keyword arguments; KWArgs turn Ruby into a lean, mean Hash processing machine.
+
+    In this talk, you'll learn the details of how to write the next generation of Ruby code. Code that is easier to read, easier to write, more flexible and easier to change, all based on this one simple Ruby feature.
+  video_id: 4e-_bbFjPRg
+
+# Track: Comparative Ruby
+- title: 'To Clojure and Back: Writing and Rewriting in Ruby'
+  raw_title: 'RubyConf 2016 - To Clojure and back: writing and rewriting in Ruby by Phill MV'
+  speakers:
+    - Phill MV
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - To Clojure and back: writing and rewriting in Ruby by Phill MV
+
+    Act 1 - State of Grace
+
+    After many years of Ruby, we built our app in Clojure, why not. Clojure is a breath of fresh air. Learn a lisp today!
+
+    Act 2 - The Fall
+
+    It's harder to succeed when you're in a new and different ecosystem. How Clojure contrasts with Ruby.
+
+    Act 3 - The Wilderness
+
+    Rewriting your app is a bad idea but we did it anyways. How we came to that decision.
+
+    Act 4 - Reconciliation
+
+    How I write Ruby has changed: a discussion.
+  video_id: doZ0XAc9Wtc
+
+# Break
+
+# Track: General 1
 - title: Rainbows! Color Theory for Computers
   raw_title: RubyConf 2016 - Rainbows! Color Theory for Computers by Lito Nicolai
   speakers:
     - Lito Nicolai
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-10'
   description: |-
     RubyConf 2016 - Rainbows! Color Theory for Computers by Lito Nicolai
 
@@ -213,28 +305,79 @@
     The only way to know is to explore the nature of color! We'll build up to the color-handling code that exists in 'graphics.rb', a Ruby-language visualizations library. For free, we'll end up with intuitive models of computer color spaces and tricks for how to think about common color concepts like gradients and paint mixing.
   video_id: pGGY5P9ZCUA
 
+# Track: General 2
+- title: Problem Solved! Using Logic Programming to Find Answers
+  raw_title: RubyConf 2016 - Problem Solved! Using Logic Programming to Find Answers by Gavin McGimpsey
+  speakers:
+    - Gavin McGimpsey
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Problem Solved! Using Logic Programming to Find Answers by Gavin McGimpsey
+
+    We love Ruby's object orientation, and you might have heard functional programming is the new hotness. But don't leave home without one more paradigm! Logic programs express relations and constraints, allowing us to work with incomplete information, build knowledge systems, and find outputs of a system given whatever inputs are available.
+
+    You'll see examples of logic programs using Ruby, learn about an algorithm that searches for a solution in a finite problem space, and explore potential applications for logic programming approaches, both in practical areas and for your mental models.
+  video_id: f5Bi6_GOIB8
+
+# Track: Ruby Deep Dive
+- title: Lies, Damned Lies, and Substrings
+  raw_title: RubyConf 2016 - Lies, Damned Lies, and Substrings by Haseeb Qureshi
+  speakers:
+    - Haseeb Qureshi
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Lies, Damned Lies, and Substrings by Haseeb Qureshi
+
+    Generate all of the substrings of a string—a classic coding problem. But what's its time complexity? In many languages this is a pretty straightforward question, but in Ruby it turns out, it depends.
+
+    Follow me into the matrix as I explore copy-on-write optimization, how substrings are created in MRI, and eventually create a custom build of Ruby to try to speed up this classic coding problem. This talk will be a mix of computer science and a deep dive into how Ruby strings work in MRI.
+  video_id: piLmdh3Am3o
+
+# Track: General 3
+- title: Diving into the Details with DTrace
+  raw_title: RubyConf 2016 - Diving into the Details with DTrace by Colin Jones
+  speakers:
+    - Colin Jones
+  event_name: RubyConf 2016
+  published_at: '2016-11-10'
+  description: |-
+    RubyConf 2016 - Diving into the Details with DTrace by Colin Jones
+    "Argh, why is this so slow?!" We've all asked questions like this without getting satisfying answers. And so we slog along, finding workarounds and architecting around the slow bits.
+
+    But what if we had a friend who could see things we can't? Someone who could say whether our guesses were right, and what to look at next?
+
+    DTrace is that friend, and it's here to help! In this talk, I'll show you how DTrace can answer incredibly general and specific questions about systems performance, and help us to generate new ones. Along the way, we'll see that it's easier to use than you might think!
+  video_id: ZzYyl5vAWcA
+
+# ---
+
 - title: 'Computer Science: The Good Parts'
   raw_title: 'RubyConf 2016 - Computer Science: The Good Parts by Jeffrey Cohen'
   speakers:
     - Jeffrey Cohen
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-10'
   description: |-
     RubyConf 2016 - Computer Science: The Good Parts by Jeffrey Cohen
 
     You don't need a 4-year degree to learn the best parts of computer science. Maybe you've seen jargon like "Big O Notation," "binary trees", "graph theory", "map-reduce", or the "Turing test", but have been afraid to ask. But did you know that that these concepts are responsible for Mars rovers, self-driving cars, mobile databases, our air traffic control system, and and even how we elect presidents? In this beginner-focused talk, I will present some simple and very practical ways apply the "good parts" of computer science to your next app.
   video_id: 4V2kwMSDEsE
 
+
+## Day 2 - 2016-11-11
+
 - title: 'You Have the Empathy of a Goat: Documenting for the User'
   raw_title: RubyConf 2016 - You Have the Empathy of a Goat... by Tara Scherner De La Fuente
   speakers:
     - Tara Scherner De La Fuente
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-11'
   description: "RubyConf 2016 - You Have the Empathy of a Goat: Documenting for the
     User by Tara Scherner De La Fuente
 
-Are you the sort of developer who makes
+    Are you the sort of developer who makes
     the user want to headbutt the computer or hop happily sideways? Documentation
     is often one of the least favorite activities of a developer, and it’s probably
     always going to suck for some people. But it doesn’t have to give you the bleat-down.
@@ -244,24 +387,71 @@ Are you the sort of developer who makes
     justify a salary increase, and even become famous. No, really. I’m not KIDding."
   video_id: 0Szd52CY9hE
 
-- title: "(m)Ruby on small devices"
+# ---
+
+# Track: Ruby and Hardware
+- title: "(m)Ruby on Small Devices"
   raw_title: RubyConf 2016 - (m)Ruby on small devices by Shashank Daté
   speakers:
     - Shashank Daté
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-11'
   description: |-
     RubyConf 2016 - (m)Ruby on small devices by Shashank Daté
 
     mruby is the lightweight implementation of the Ruby language for linking and embedding within your applications. This talk will show how it can be used on small resource constrained devices like Raspberry Pi Zero and exploring some techniques of memory and run-time optimizations.
   video_id: 0q2HRwP7Vzo
 
+# Track: Testing
+- title: Better Code Through Boring(er) Tests
+  raw_title: RubyConf 2016 - Better Code Through Boring(er) Tests by Betsy Haibel
+  speakers:
+    - Betsy Haibel
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - Better Code Through Boring(er) Tests by Betsy Haibel
+
+    Your tests are annoying. Whenever you update your application code, you need to change a lot of them. You've built yourself some test macros, and some nice FactoryGirl factories, and installed this really cool matcher gem... and your tests are still annoying. What if you changed your application code instead? In this talk, you'll learn what "listening to your tests" means in the real world: no mysticism, no arrogant TDD purism, just a few practical refactorings you can use tomorrow at work.
+  video_id: tTQpD3o_FAw
+
+# Track: General 1
+- title: From no OSS Experience to the Core Team in 15 Minutes a Day
+  raw_title: RubyConf 2016 - From no OSS experience to the core team in 15 minutes a day by André Arko
+  speakers:
+    - André Arko
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - From no OSS experience to the core team in 15 minutes a day by André Arko
+
+    Using and contributing to open source has been a cornerstone of the Ruby community for many years. Despite this strong tradition, it’s hard to find anything collecting the likely advantages and costs of working on open source. This talk will introduce open source work, the benefits and costs of doing that work, and then provide a straightforward list of activities that can be done by anyone, no matter their level of experience with programming. Pick a project, schedule at least 15 minutes per day, join the core team. It’s your destiny!
+  video_id: 6jUe-9Y__KM
+
+# Track: Lessons Learned
+- title: Finding Your Edge Through a Culture of Feedback
+  raw_title: RubyConf 2016 - Finding your edge through a culture of feedback by Paulette Luftig
+  speakers:
+    - Paulette Luftig
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - Finding your edge through a culture of feedback by Paulette Luftig
+
+    Have you ever wished for more feedback from colleagues to help you get better at your job? When’s the last time you offered helpful feedback to someone else? Imagine an entire company fluent in the daily practice of giving and receiving constructive feedback. Would your experience improve? What does a team lose when feedback doesn’t flow?
+
+    Feedback conversations can be difficult. But giving and receiving feedback pushes us to the edge of our growth potential, where the biggest payoffs occur. Join this session to grow your career by learning how to get real.
+  video_id: EkLdO-SphxA
+
+# ---
+
+# Track: Ruby and Hardware
 - title: 'Building HAL: Running Ruby with Your Voice'
   raw_title: 'RubyConf 2016 - Building HAL: Running Ruby with Your Voice by Jonan Scheffler'
   speakers:
     - Jonan Scheffler
   event_name: RubyConf 2016
-  published_at: '2016-11-17'
+  published_at: '2016-11-11'
   description: |-
     RubyConf 2016 - Building HAL: Running Ruby with Your Voice by Jonan Scheffler
 
@@ -272,256 +462,13 @@ Are you the sort of developer who makes
     I think we can all agree that the world needs more robots listening to our every word, let’s build an army of them and arm them with Ruby!
   video_id: znvpPsLBZyg
 
-- title: How I Taught My Dog To Text Selfies
-  raw_title: RubyConf 2016 - How I Taught My Dog To Text Selfies by Greg Baugues
-  speakers:
-    - Greg Baugues
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - How I Taught My Dog To Text Selfies by Greg Baugues
-
-    This talk is for the Rubyist who wants to get into hardware hacking but feels intimidated or unsure of where to start. The Arduino Yun is wifi-enabled and runs a stripped-down version of Linux. That means that you can build hardware hacks that execute Ruby scripts and interact with web APIs. In this talk, we'll start from scratch and live code a hardware hack that my dog uses to text me selfies using a webcam, Twilio, and a big red button.
-  video_id: 7ysfTZT_-tY
-
-- title: It's More Fun to Compute
-  raw_title: RubyConf 2016 - It's More Fun to Compute by Julian Cheal
-  speakers:
-    - Julian Cheal
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - It's More Fun to Compute by Julian Cheal
-
-    Come with us now on a journey through time and space. As we explore the world of analog/digital synthesis. From computer generated music to physical synthesisers and everything in between.
-
-    So you want to write music with code, but don’t know the difference between an LFO, ADSR, LMFAO, etc. Or a Sine wave, Saw wave, Google wave. We’ll explore what these mean, and how Ruby can be used to make awesome sounds. Ever wondered what Fizz Buzz sounds like, or which sounds better bubble sort or quick sort? So hey Ruby, let’s make music!
-  video_id: v3wYX-HSkr0
-
-- title: 'Programming in the Small: Kids, Chickens, and Ruby'
-  raw_title: 'RubyConf 2016 - Programming in the Small: Kids, Chickens, and Ruby by Coraline Clark & Jason Clark'
-  speakers:
-    - Coraline Clark
-    - Jason Clark
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Programming in the Small: Kids, Chickens, and Ruby by Coraline Clark & Jason Clark
-
-    After several years of programming in Ruby using Shoes, my daughter and I were hunting for a new project. Something more useful than a game. Something with a real-world connection. Then it struck us: Chickens!
-
-    Join us as we show you how we built our coop monitoring system. It’ll be a wild ride of hardware hacking, weather-proofing, and father-daughter bonding, with Ruby sprinkled throughout. You’ll learn how to modernize your surroundings, and about engaging the young people in your life in technology along the way.
-  video_id: Iah2t1_iSYE
-
-- title: Finding your edge through a culture of feedback
-  raw_title: RubyConf 2016 - Finding your edge through a culture of feedback by Paulette Luftig
-  speakers:
-    - Paulette Luftig
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Finding your edge through a culture of feedback by Paulette Luftig
-
-    Have you ever wished for more feedback from colleagues to help you get better at your job? When’s the last time you offered helpful feedback to someone else? Imagine an entire company fluent in the daily practice of giving and receiving constructive feedback. Would your experience improve? What does a team lose when feedback doesn’t flow?
-
-    Feedback conversations can be difficult. But giving and receiving feedback pushes us to the edge of our growth potential, where the biggest payoffs occur. Join this session to grow your career by learning how to get real.
-  video_id: EkLdO-SphxA
-
-- title: My Meta Moments
-  raw_title: RubyConf 2016 - My Meta Moments by John Dewyze
-  speakers:
-    - John Dewyze
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - My Meta Moments by John Dewyze
-
-    Meta-programming is alluring. To write code that writes more code sounds like the peak of efficiency, but learning it is filled with infinite loops and confusing stack traces. It is a place with lots of hair pulling and endless puts debugging.
-
-    Meta-programming in ruby can be intimidating. Yet, even with all that, it is fun. It is learnable. It is quintessentially ruby. If you’re interested in getting your feet wet, come share my journey of learning things like method dispatch, BasicObject, class ancestry, and the joy of things you should think twice about before doing in production code.
-  video_id: 0OAgZBNIixU
-
-- title: Why Is Open Source So Closed?
-  raw_title: RubyConf 2016 - Why Is Open Source So Closed? by Ra'Shaun Stovall
-  speakers:
-    - Ra'Shaun Stovall
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Why Is Open Source So Closed? by Ra'Shaun Stovall
-
-    Why is Open Source So Closed? With the rapidly increasing amount of students coming out of bootcamp schools we have now created a gap within our communities of the "haves", and the "Looking for job"s. Being the organizer of New York City's 4,500+ member Ruby community with NYC.rb I have discovered ways we can ensure the generations of rubyists after us have a path paved before them. "Cyclical Mentorship" is the answer. Best part is we will know individually how we can immediately begin the feedback loop of not computers, but people!
-  video_id: A5ad52AogJ8
-
-- title: Ruby, Red Pandas, and You
-  raw_title: RubyConf 2016 - Ruby, Red Pandas, and You by Sean Marcia
-  speakers:
-    - Sean Marcia
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Ruby, Red Pandas, and You by Sean Marcia
-
-    Red pandas are adorable, playful, curious, and super cute. Unfortunately, they are in serious trouble. Over 50% of red panda newborns born in captivity do not survive long enough to leave their den and no one knows why. Come find out why red pandas are so amazing, how I met a Smithsonian Zoo researcher studying this and how we’re solving this important problem using Ruby and machine learning. You will also leave this talk knowing how you can get involved (no matter your skill level) with great projects like this.
-  video_id: jm9gEhXFUro
-
-- title: Ruby versus the Titans of FP
-  raw_title: RubyConf 2016 - Ruby versus the Titans of FP by Cassandra Cruz
-  speakers:
-    - Cassandra Cruz
-  event_name: RubyConf 2016
-  published_at: '2016-11-17'
-  description: |-
-    RubyConf 2016 - Ruby versus the Titans of FP by Cassandra Cruz
-
-    Clojure, Haskell and Javascript reign as the dominant functional languages of our era. But surely anything they can do, Ruby can do better? And what is it that they actually do? Come learn about three core concepts of functional programming, and see how Ruby stacks up against its peers when it comes to making them powerful.
-  video_id: 25u-pp-7PHE
-
-- title: Optimizing ruby core
-  raw_title: RubyConf 2016 - Optimizing ruby core by Shyouhei Urabe
-  speakers:
-    - Shyouhei Urabe
-  event_name: RubyConf 2016
-  published_at: '2016-11-18'
-  description: |-
-    RubyConf 2016 - Optimizing ruby core by Shyouhei Urabe
-
-    I made ruby interpreter 10 times faster. Let me show you how
-  video_id: MqhapcDyP00
-
-- title: Lies
-  raw_title: RubyConf 2016 - Lies by Ernie Miller
-  speakers:
-    - Ernie Miller
-  event_name: RubyConf 2016
-  published_at: '2016-11-18'
-  description: |-
-    RubyConf 2016 - Lies by Ernie Miller
-
-    All abstractions are lies, if they are abstractions at all, and as developers, we live our lives surrounded by them. What makes a some abstractions better than others? This will be an opinionated and empowering look at the value and nature of abstractions, with a jaunt through quantum mechanics and the nature of reality.
-
-    You know, just your average, light discussion.
-  video_id: Avf65oHa5vc
-
-- title: Becoming a Mid...
-  raw_title: RubyConf 2016 - Becoming a Mid... by Kimberly D. Barnes & Kinsey Ann Durham
-  speakers:
-    - Kimberly D. Barnes
-    - Kinsey Ann Durham
-  event_name: RubyConf 2016
-  published_at: '2016-11-18'
-  description: |-
-    RubyConf 2016 - Becoming a Mid: Two Perspectives on Leveling Up by Kimberly D. Barnes & Kinsey Ann Durham
-
-    What does becoming a mid-level developer mean? How can a junior set goals and make steps to achieve this? It's difficult to shed the title of 'junior', not only in your own mind, but in the minds of others. It is important to keep progressing in your career as a developer to be able to level up and no longer be seen as the junior on the team. Kim and Kinsey will provide two perspectives to enable you to leave this talk with tangible action items. They will also dive into what employers can do to help build frameworks to allow for this transition.
-  video_id: i_RisLTNZEY
-
-- title: Learning Fluency
-  raw_title: RubyConf 2016 - Learning Fluency by Sara Simon
-  speakers:
-    - Sara Simon
-  event_name: RubyConf 2016
-  published_at: '2016-11-18'
-  description: |-
-    RubyConf 2016 - Learning Fluency by Sara Simon
-
-    All languages work in formulaic ways. Cracking these formulas takes discipline, time, creativity, trial and error. But is there an overarching formula to crack these formulas? Is there a designated set of steps we can take to guarantee fluency?
-
-    In this talk, you will learn about the methods people use to learn both foreign languages and programming languages. As developers, we often just jump in and start building. Why is this? Does full immersion work best always and for everyone? What is fluency, and is it ever something we can achieve in Ruby? Let’s explore.
-  video_id: AZlOjCZlPLU
-
-- title: You graduated from bootcamp, now what?
-  raw_title: RubyConf 2016 - You graduated from bootcamp, now what? by Melanie Gilman
-  speakers:
-    - Melanie Gilman
-  event_name: RubyConf 2016
-  published_at: '2016-11-18'
-  description: |-
-    RubyConf 2016 - You graduated from bootcamp, now what? by Melanie Gilman
-
-    Throughout bootcamp, your biggest worry was finding a job. Now that you’ve found one and you’ve started your career as a developer, what comes next? In this talk, we’ll explore what the career of a bootcamp graduate looks like a few years after the program. We’ll talk about the good and not-so-good parts of being a newly-minted developer. We’ll come away with actionable steps we can take to continue to grow as developers post-bootcamp and be happy and successful, even when we don’t have the mythical perfect job.
-  video_id: pCnvpB9tGws
-
-- title: Methods of Memory Management in MRI
-  raw_title: RubyConf 2016 - Methods of Memory Management in MRI by Aaron Patterson
-  speakers:
-    - Aaron Patterson
-  event_name: RubyConf 2016
-  published_at: '2016-11-18'
-  description: |-
-    RubyConf 2016 - Methods of Memory Management in MRI by Aaron Patterson
-
-    Let's talk about MRI's GC! In this talk we will cover memory management algorithms in MRI. We will cover how objects are allocated and how they are freed. We will start by looking at Ruby's memory layout, including page allocation and object allocations within those pages. Next we'll cover collection algorithms used by MRI starting with the mark and sweep algorithm, followed by generational collection, and the tri color abstraction. Finally we'll cover experimental developments for the GC like heap splitting. Expect to leave this talk with heaps of pointers to add to your remembered set!
-  video_id: r0UjXixkBV8
-
-- title: Seeing Metaprogramming and Lambda Function Patterns in Ruby
-  raw_title: RubyConf 2016 - Seeing Metaprogramming and Lambda Function Patterns in Ruby by Lukas Nimmo
-  speakers:
-    - Lukas Nimmo
-  event_name: RubyConf 2016
-  published_at: '2016-11-18'
-  description: |-
-    RubyConf 2016 - Seeing Metaprogramming and Lambda Function Patterns in Ruby by Lukas Nimmo
-
-    Metaprogramming and lambda functions in Ruby should be explained within their rightful place: living examples. You may have read tutorials on what these concepts are, but still do not understand when or why to use them. I dredged through over 50 prominent Open Source Ruby projects to bring you ten successful patterns that are used time and time again to create some of the most expressive and popular Ruby DSLs. Join me as we cover these patterns so that you can immediately begin using them in your own code to implement powerful DSLs. No vacuum-living, esoteric concepts here.
-  video_id: poAxCd7Z0Kg
-
-- title: Even the Justice League Works Remotely
-  raw_title: RubyConf 2016 -  Even the Justice League Works Remotely by Allison McMillan
-  speakers:
-    - Allison McMillan
-  event_name: RubyConf 2016
-  published_at: '2016-11-18'
-  description: |-
-    RubyConf 2016 -  Even the Justice League Works Remotely by Allison McMillan
-
-    "Remote welcome for senior level". This appears in countless job descriptions. Remote work is largely accepted in the developer community, but often only for very experienced developers. This fear is not without cause. Sometimes hiring remote developers at any level doesn’t turn out well but there’s generally a reason for that. Newer developers can also be very successful remote workers. In this talk, you’ll learn what to look for when hiring remote developers at any level and non-senior developers will learn what characteristics to keep in mind in order to have a successful remote experience.
-  video_id: d7Z0uS2x_cY
-
-- title: Halve Your Memory Usage With These 12 Weird Tricks
-  raw_title: RubyConf 2016 - Halve Your Memory Usage With These 12 Weird Tricks
-  speakers:
-    - Nate Berkopec
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 -  Halve Your Memory Usage With These 12 Weird Tricks by Nate Berkopec
-
-    How does Ruby allocate memory? Ever wonder why that poor application of yours is using hundreds of megabytes of RAM? Ruby's garbage collector means that we don't have to worry about allocating memory in our programs, but an understanding of how C Ruby uses memory can help us avoid bloat and even write faster programs. We'll talk about what causes memory allocation, how the garbage collector works, and how to measure memory activity in our own Ruby programs.
-  video_id: kZcqyuPeDao
-
-- title: Grow Your Team In 90 Days
-  raw_title: RubyConf 2016 - Grow Your Team In 90 Days by Cheryl Gore Schaefer
-  speakers:
-    - Cheryl Gore Schaefer
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Grow Your Team In 90 Days by Cheryl Gore Schaefer
-
-    So you want to work with an awesome ruby developer? Great! But finding one is hard. It’s much easier to hire that apprentice or bootcamp grad, but that person is not an awesome developer. How do you help them get there?
-
-    You will learn how to build a learning plan and become the best mentor to a budding software developer. You have the opportunity to mold your apprentice’s skill set into exactly what you need, while benefiting from their diverse skills and experiences. We will build an example learning plan of a developer learning Ruby, showing clear and specific choices and likely outcomes.
-  video_id: pHABlefSVZk
-
-- title: Better Code Through Boring(er) Tests
-  raw_title: RubyConf 2016 - Better Code Through Boring(er) Tests by Betsy Haibel
-  speakers:
-    - Betsy Haibel
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Better Code Through Boring(er) Tests by Betsy Haibel
-
-    Your tests are annoying. Whenever you update your application code, you need to change a lot of them. You've built yourself some test macros, and some nice FactoryGirl factories, and installed this really cool matcher gem... and your tests are still annoying. What if you changed your application code instead? In this talk, you'll learn what "listening to your tests" means in the real world: no mysticism, no arrogant TDD purism, just a few practical refactorings you can use tomorrow at work.
-  video_id: tTQpD3o_FAw
-
+# Track: Testing
 - title: Surgically Refactoring Ruby with Suture
   raw_title: RubyConf 2016 - Surgically Refactoring Ruby with Suture by Justin Searls
   speakers:
     - Justin Searls
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-11'
   description: |-
     RubyConf 2016 - Surgically Refactoring Ruby with Suture by Justin Searls
 
@@ -537,74 +484,13 @@ Are you the sort of developer who makes
     With renewed confidence and without fear, you grab the card. You've got this.
   video_id: pBginuIW2WU
 
-- title: Test Doubles are Not To Be Mocked
-  raw_title: RubyConf 2016 - Test Doubles are Not To Be Mocked by Noel Rappin
-  speakers:
-    - Noel Rappin
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Test Doubles are Not To Be Mocked by Noel Rappin
-
-    Test doubles (which you may know under the alias “mock objects”) are the most misunderstood and misused testing tools we've got. Starting with the fact that nobody can agree on what to call them. Contrary to what you may have heard, test doubles do not inherently lead to fragile tests. What they do is hold up a harsh mirror to the assumptions in our code. They are the light saber of testing tools: a more elegant weapon for a more civilized age. But be careful not to cut your code in half, so to speak. Herein: a guide to using test doubles without losing your sanity.
-  video_id: qgZu6vEuqBU
-
-- title: Ruby for Home-Ec
-  raw_title: RubyConf 2016 - Ruby for Home-Ec by Adam  Forsyth
-  speakers:
-    - Adam Forsyth
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Ruby for Home-Ec by Adam  Forsyth
-
-    Come learn how to design your own algorithms and code to solve problems around the house. Trying to use your scrap wood efficiently? Want to sort your pantry to maximize variety? I’ll talk about the problem-solving process, walk through code, and touch on the computer science behind it all.
-  video_id: iosgoDJl8VY
-
-- title: JRuby Everywhere! Server, Client, and Embedded
-  raw_title: RubyConf 2016 - JRuby Everywhere! Server, Client, and Embedded by Thomas Enebo
-  speakers:
-    - Thomas E Enebo
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - JRuby Everywhere! Server, Client, and Embedded by Thomas Enebo
-
-    Ruby has seen its heaviest on servers; Client-side Ruby has been limited to experiments and toys, and Ruby C extensions complicate embedded use. But there's a better way: JRuby. Using frameworks like JRubyFX and Shoes 4, among many GUI and graphics libraries, JRuby makes client-side development fast and powerful. With an embedded JVM, JRuby runs your app on mid-level embedded devices without compiling a line of code. And JRuby is still the best way to power up your Rails 5 app. Come learn how to use JRuby everwhere!
-  video_id: Xl7LVkvSnoc
-
-- title: The long strange trip of a senior developer
-  raw_title: RubyConf 2016 - The long strange trip of a senior developer by Brandon Hays
-  speakers:
-    - Brandon Hays
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - The long strange trip of a senior developer by Brandon Hays
-
-    Have you ever felt like you are in the passenger seat of your career? By simply looking around and seeing how few 20+ year veterans you work with, you're actually staring our industry's sustainability problem right in the face. But the software industry needs you still contributing 20 years from now! Fret not, we can start fixing these problems, right now, in your own job.
-
-    Using in-depth research across companies of all sizes, you'll come away with a plan to start designing a sustainable career track to help you grow in skill, influence, and income now and long into the future.
-  video_id: egntf0nykzk
-
-- title: From no OSS experience to the core team in 15 minutes a day
-  raw_title: RubyConf 2016 - From no OSS experience to the core team in 15 minutes a day by André Arko
-  speakers:
-    - André Arko
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - From no OSS experience to the core team in 15 minutes a day by André Arko
-
-    Using and contributing to open source has been a cornerstone of the Ruby community for many years. Despite this strong tradition, it’s hard to find anything collecting the likely advantages and costs of working on open source. This talk will introduce open source work, the benefits and costs of doing that work, and then provide a straightforward list of activities that can be done by anyone, no matter their level of experience with programming. Pick a project, schedule at least 15 minutes per day, join the core team. It’s your destiny!
-  video_id: 6jUe-9Y__KM
-
+# Track: General 1
 - title: Implementing Virtual Machines in Ruby (and C)
   raw_title: RubyConf 2016 - Implementing Virtual Machines in Ruby (and C) by Eleanor McHugh
   speakers:
     - Eleanor McHugh
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-11'
   description: |-
     RubyConf 2016 - Implementing Virtual Machines in Ruby (and C) by Eleanor McHugh
 
@@ -613,12 +499,112 @@ Are you the sort of developer who makes
     In this talk I'll look at the various parts necessary to model a computer-like machine in code, borrowing ideas as I go from real-world hardware design. We'll use a mixture of C and Ruby as our modelling languages: C is the lingua franca of the VM world whilst Ruby is the language which brought us monkey-patching...
   video_id: wN-pNr2arxI
 
+# Track: Lessons Learned
+- title: My Meta Moments
+  raw_title: RubyConf 2016 - My Meta Moments by John Dewyze
+  speakers:
+    - John Dewyze
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - My Meta Moments by John Dewyze
+
+    Meta-programming is alluring. To write code that writes more code sounds like the peak of efficiency, but learning it is filled with infinite loops and confusing stack traces. It is a place with lots of hair pulling and endless puts debugging.
+
+    Meta-programming in ruby can be intimidating. Yet, even with all that, it is fun. It is learnable. It is quintessentially ruby. If you’re interested in getting your feet wet, come share my journey of learning things like method dispatch, BasicObject, class ancestry, and the joy of things you should think twice about before doing in production code.
+  video_id: 0OAgZBNIixU
+
+# Lunch
+
+# Track: Ruby and Hardware
+- title: How I Taught My Dog To Text Selfies
+  raw_title: RubyConf 2016 - How I Taught My Dog To Text Selfies by Greg Baugues
+  speakers:
+    - Greg Baugues
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - How I Taught My Dog To Text Selfies by Greg Baugues
+
+    This talk is for the Rubyist who wants to get into hardware hacking but feels intimidated or unsure of where to start. The Arduino Yun is wifi-enabled and runs a stripped-down version of Linux. That means that you can build hardware hacks that execute Ruby scripts and interact with web APIs. In this talk, we'll start from scratch and live code a hardware hack that my dog uses to text me selfies using a webcam, Twilio, and a big red button.
+  video_id: 7ysfTZT_-tY
+
+# Track: Testing
+- title: Test Doubles are Not To Be Mocked
+  raw_title: RubyConf 2016 - Test Doubles are Not To Be Mocked by Noel Rappin
+  speakers:
+    - Noel Rappin
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - Test Doubles are Not To Be Mocked by Noel Rappin
+
+    Test doubles (which you may know under the alias “mock objects”) are the most misunderstood and misused testing tools we've got. Starting with the fact that nobody can agree on what to call them. Contrary to what you may have heard, test doubles do not inherently lead to fragile tests. What they do is hold up a harsh mirror to the assumptions in our code. They are the light saber of testing tools: a more elegant weapon for a more civilized age. But be careful not to cut your code in half, so to speak. Herein: a guide to using test doubles without losing your sanity.
+  video_id: qgZu6vEuqBU
+
+# Track: Performance
+- title: Ruby 3 Concurrency
+  raw_title: RubyConf 2016 - Ruby 3 Concurrency by Koichi Sasada
+  speakers:
+    - Koichi Sasada
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - Ruby 3 Concurrency by Koichi Sasada
+
+    Learn from Koichi about the work he's doing to bring a new concurrency model to Ruby 3!
+  video_id: mjzmUUQWqco
+
+# Track: Lessons Learned
+- title: Why Is Open Source So Closed?
+  raw_title: RubyConf 2016 - Why Is Open Source So Closed? by Ra'Shaun Stovall
+  speakers:
+    - Ra'Shaun Stovall
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - Why Is Open Source So Closed? by Ra'Shaun Stovall
+
+    Why is Open Source So Closed? With the rapidly increasing amount of students coming out of bootcamp schools we have now created a gap within our communities of the "haves", and the "Looking for job"s. Being the organizer of New York City's 4,500+ member Ruby community with NYC.rb I have discovered ways we can ensure the generations of rubyists after us have a path paved before them. "Cyclical Mentorship" is the answer. Best part is we will know individually how we can immediately begin the feedback loop of not computers, but people!
+  video_id: A5ad52AogJ8
+
+# ---
+
+# Track: Ruby and Hardware
+- title: It's More Fun to Compute
+  raw_title: RubyConf 2016 - It's More Fun to Compute by Julian Cheal
+  speakers:
+    - Julian Cheal
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - It's More Fun to Compute by Julian Cheal
+
+    Come with us now on a journey through time and space. As we explore the world of analog/digital synthesis. From computer generated music to physical synthesisers and everything in between.
+
+    So you want to write music with code, but don’t know the difference between an LFO, ADSR, LMFAO, etc. Or a Sine wave, Saw wave, Google wave. We’ll explore what these mean, and how Ruby can be used to make awesome sounds. Ever wondered what Fizz Buzz sounds like, or which sounds better bubble sort or quick sort? So hey Ruby, let’s make music!
+  video_id: v3wYX-HSkr0
+
+# Track: General 1
+- title: Ruby for Home-Ec
+  raw_title: RubyConf 2016 - Ruby for Home-Ec by Adam  Forsyth
+  speakers:
+    - Adam Forsyth
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - Ruby for Home-Ec by Adam  Forsyth
+
+    Come learn how to design your own algorithms and code to solve problems around the house. Trying to use your scrap wood efficiently? Want to sort your pantry to maximize variety? I’ll talk about the problem-solving process, walk through code, and touch on the computer science behind it all.
+  video_id: iosgoDJl8VY
+
+# Track: Performance
 - title: Ruby’s C Extension Problem and How We're Solving It
   raw_title: RubyConf 2016 - Ruby’s C Extension Problem and How We're Solving It by Chris Seaton
   speakers:
     - Chris Seaton
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-11'
   description: |-
     RubyConf 2016 - Ruby’s C Extension Problem and How We're Solving It by Chris Seaton
 
@@ -627,170 +613,135 @@ Are you the sort of developer who makes
     In JRuby+Truffle we have a radical solution to this problem – we’re going to interpret the source code of your C extensions, like how Ruby interprets Ruby code. Combined with a JIT this lets us optimise Ruby but keep support for C extensions.
   video_id: YLtjkP9bD_U
 
-- title: Ruby 3 Concurrency
-  raw_title: RubyConf 2016 - Ruby 3 Concurrency by Koichi Sasada
+# Track: General 2
+- title: Ruby, Red Pandas, and You
+  raw_title: RubyConf 2016 - Ruby, Red Pandas, and You by Sean Marcia
   speakers:
-    - Koichi Sasada
+    - Sean Marcia
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-11'
   description: |-
-    RubyConf 2016 - Ruby 3 Concurrency by Koichi Sasada
+    RubyConf 2016 - Ruby, Red Pandas, and You by Sean Marcia
 
-    Learn from Koichi about the work he's doing to bring a new concurrency model to Ruby 3!
-  video_id: mjzmUUQWqco
+    Red pandas are adorable, playful, curious, and super cute. Unfortunately, they are in serious trouble. Over 50% of red panda newborns born in captivity do not survive long enough to leave their den and no one knows why. Come find out why red pandas are so amazing, how I met a Smithsonian Zoo researcher studying this and how we’re solving this important problem using Ruby and machine learning. You will also leave this talk knowing how you can get involved (no matter your skill level) with great projects like this.
+  video_id: jm9gEhXFUro
 
-- title: 'Attention Rubyists: you can write video games'
-  raw_title: 'RubyConf 2016 - Attention Rubyists: you can write video games by Cory Chamblin'
+# ---
+
+# Track: Ruby and Hardware
+- title: 'Programming in the Small: Kids, Chickens, and Ruby'
+  raw_title: 'RubyConf 2016 - Programming in the Small: Kids, Chickens, and Ruby by Coraline Clark & Jason Clark'
   speakers:
-    - Cory Chamblin
+    - Coraline Clark
+    - Jason Clark
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-11'
   description: |-
-    RubyConf 2016 - Attention Rubyists: you can write video games by Cory Chamblin
+    RubyConf 2016 - Programming in the Small: Kids, Chickens, and Ruby by Coraline Clark & Jason Clark
 
-    Ruby may seem like a humdrum language best suited for writing web apps, but underneath that cool exterior lies plenty of power -- power we can harness for making our own games!
+    After several years of programming in Ruby using Shoes, my daughter and I were hunting for a new project. Something more useful than a game. Something with a real-world connection. Then it struck us: Chickens!
 
-    In this talk, we'll introduce Gosu, a sweet little game library. We'll talk about how games are structured in pretty much every language and framework ever, where to get ideas for things to make, and ways you can share your game with your friends and the world.
-  video_id: bK9RX_CzCeI
+    Join us as we show you how we built our coop monitoring system. It’ll be a wild ride of hardware hacking, weather-proofing, and father-daughter bonding, with Ruby sprinkled throughout. You’ll learn how to modernize your surroundings, and about engaging the young people in your life in technology along the way.
+  video_id: Iah2t1_iSYE
 
-- title: Bootcamp Grads Have Feelings, Too
-  raw_title: RubyConf 2016 - Bootcamp Grads Have Feelings, Too by Max Tiu
+# Track: General 1
+- title: JRuby Everywhere! Server, Client, and Embedded
+  raw_title: RubyConf 2016 - JRuby Everywhere! Server, Client, and Embedded by Thomas Enebo
   speakers:
-    - Max Tiu
+    - Thomas E Enebo
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-11'
   description: |-
-    RubyConf 2016 - Bootcamp Grads Have Feelings, Too by Max Tiu
+    RubyConf 2016 - JRuby Everywhere! Server, Client, and Embedded by Thomas Enebo
 
-    You’re a bootcamp student. You’re so excited to become a developer! Amidst your excitement about this new industry, you hear everyone say that bootcamps are a blemish on the community, that they’re a waste of time and money. “Maybe I’ve made a huge mistake,” you think. “I don’t know how I’ll fit in here."
+    Ruby has seen its heaviest on servers; Client-side Ruby has been limited to experiments and toys, and Ruby C extensions complicate embedded use. But there's a better way: JRuby. Using frameworks like JRubyFX and Shoes 4, among many GUI and graphics libraries, JRuby makes client-side development fast and powerful. With an embedded JVM, JRuby runs your app on mid-level embedded devices without compiling a line of code. And JRuby is still the best way to power up your Rails 5 app. Come learn how to use JRuby everwhere!
+  video_id: Xl7LVkvSnoc
 
-    But you can make this community better! In this session, you’ll learn about the varied experiences of bootcamp students and grads, how exclusionary behavior can end up stunting our community as a whole, and what you can to do make a more inclusive environment for everyone of all skill levels.
-  video_id: 133HhIjmfRE
-
-- title: Continuing Education at Work
-  raw_title: RubyConf 2016 - Continuing Education at Work by Katherine Wu
-  speakers:
-    - Katherine Wu
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Continuing Education at Work by Katherine Wu
-
-    The list of things we want to learn is infinite. How many of us have marked items to read/watch, yet never go back to them? Despite the best of intentions, I often only learn what I directly need. It wasn’t until I started running a couple lightweight continuing education programs at work that I followed through on my goals. We’ll discuss strategies for making these programs low maintenance and long-lived, as well as flexible enough to help both more and less experienced folks. If you’ve been looking for a more effective approach to learning, but still outside classrooms, this talk is for you!
-  video_id: 9uRho69xSAI
-
-- title: '"Am I Senior Yet?" Grow Your Career by Teaching Your Peers'
-  raw_title: RubyConf 2016 - “Am I Senior Yet?” Grow Your Career by Teaching Your Peers Katlyn Parvin
-  speakers:
-    - Katlyn Parvin
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - “Am I Senior Yet?” Grow Your Career by Teaching Your Peers Katlyn Parvin
-
-    “How do I become a senior engineer?” It’s a question every bootcamp grad will ask. Most engineers look at advancement through a lens of increasing technical skill. More than ever, though, being “senior” means more than just parsing Ruby in your sleep. As our companies grow and as our industry grows, seniority means helping new teammates and colleagues advance their own skills. It means knowing how to teach.
-
-    You don’t need Matz-level knowledge to be a great teacher. With social awareness, a dash of psychology, and some proven approaches, by helping others learn, you’ll earn senior-level respect.
-  video_id: jcTmoOHhG9A
-
-- title: 'Dōmo arigatō, Mr. Roboto: Machine Learning with Ruby'
-  raw_title: 'RubyConf 2016 - Dōmo arigatō, Mr. Roboto: Machine Learning with Ruby by Eric Weinstein'
-  speakers:
-    - Eric Weinstein
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Dōmo arigatō, Mr. Roboto: Machine Learning with Ruby by Eric Weinstein
-
-    Machine learning is a popular and rapidly growing field
-    these days, but you don't usually hear it mentioned in the same breath as Ruby.
-    Many developers assume that if you want to do machine learning or computer vision,
-    you've got to do it in Python or Java. Not so! In this talk, we'll walk through
-    training a neural network written in Ruby on the MNIST dataset, then develop an
-    application to use that network to classify handwritten numbers.
-  video_id: T1nFQ49TyeA
-
-- title: Problem Solved! Using Logic Programming to Find Answers
-  raw_title: RubyConf 2016 - Problem Solved! Using Logic Programming to Find Answers by Gavin McGimpsey
-  speakers:
-    - Gavin McGimpsey
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Problem Solved! Using Logic Programming to Find Answers by Gavin McGimpsey
-
-    We love Ruby's object orientation, and you might have heard functional programming is the new hotness. But don't leave home without one more paradigm! Logic programs express relations and constraints, allowing us to work with incomplete information, build knowledge systems, and find outputs of a system given whatever inputs are available.
-
-    You'll see examples of logic programs using Ruby, learn about an algorithm that searches for a solution in a finite problem space, and explore potential applications for logic programming approaches, both in practical areas and for your mental models.
-  video_id: f5Bi6_GOIB8
-
-- title: 'Deletion Driven Development: Code to delete code!'
-  raw_title: 'RubyConf 2016 - Deletion Driven Development: Code to delete code! by Chris Arcand'
-  speakers:
-    - Chris Arcand
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Deletion Driven Development: Code to delete code! by Chris Arcand
-
-    Good news! Ruby is a successful and mature programming language with a wealth of libraries and legacy applications that have been contributed to for many years. The bad news: Those projects might contain a large amount of useless, unused code which adds needless complexity and confuses new developers. In this talk I'll explain how to build a static analysis tool to help you find unused code and remove it - because there's no code that's easier to maintain than no code at all!
-  video_id: OfiIyNV00uI
-
-- title: A Look at Hooks
-  raw_title: RubyConf 2016 - A Look at Hooks by Craig Buchek
-  speakers:
-    - Craig Buchek
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - A Look at Hooks by Craig Buchek
-
-    Ruby has several methods that are invoked implicitly under certain circumstances. These methods are called "hooks", and they provide points to extend behavior. While hooks might seem like "spooky action at a distance", they can be really powerful. In fact, hooks are one of the primary ways that Ruby provides for meta-programming.
-
-    Unfortunately, Ruby's hooks are not all documented very well. We'll take a look at what hooks are available and how to use them. We'll also talk about when to avoid using hooks and provide some tips on how to troubleshoot when hooks are involved.
-  video_id: x7F4kkdKQbQ
-
-- title: Keyword Args — the killer Ruby feature you aren't using
-  raw_title: RubyConf 2016 - Keyword Args — the killer Ruby feature you aren't using by  Guyren G. Howe
-  speakers:
-    - Guyren G. Howe
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Keyword Args — the killer Ruby feature you aren't using by  Guyren G. Howe
-
-    Write clearer code more easily. Write functions that are more composable and flexible.
-
-    Ruby 2.0's KWArgs feature isn't just an easier way to write functions that take keyword arguments; KWArgs turn Ruby into a lean, mean Hash processing machine.
-
-    In this talk, you'll learn the details of how to write the next generation of Ruby code. Code that is easier to read, easier to write, more flexible and easier to change, all based on this one simple Ruby feature.
-  video_id: 4e-_bbFjPRg
-
-- title: Lies, Damned Lies, and Substrings
-  raw_title: RubyConf 2016 - Lies, Damned Lies, and Substrings by Haseeb Qureshi
-  speakers:
-    - Haseeb Qureshi
-  event_name: RubyConf 2016
-  published_at: '2016-11-21'
-  description: |-
-    RubyConf 2016 - Lies, Damned Lies, and Substrings by Haseeb Qureshi
-
-    Generate all of the substrings of a string—a classic coding problem. But what's its time complexity? In many languages this is a pretty straightforward question, but in Ruby it turns out, it depends.
-
-    Follow me into the matrix as I explore copy-on-write optimization, how substrings are created in MRI, and eventually create a custom build of Ruby to try to speed up this classic coding problem. This talk will be a mix of computer science and a deep dive into how Ruby strings work in MRI.
-  video_id: piLmdh3Am3o
-
+# Track: Performance
 - title: Slo Mo
   raw_title: RubyConf 2016 - Slo Mo by Richard Schneeman
   speakers:
     - Richard Schneeman
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-11'
   description: |-
     RubyConf 2016 - Slo Mo by Richard Schneeman
 
     No one wants to be stuck in the slow lane, especially Rubyists. In this talk we'll look at the slow process of writing fast code. We'll look at several real world performance optimizations that may surprise you. We'll then rewind to see how these slow spots were found and fixed. Come to this talk and we will "C" how fast your Ruby can "Go".
   video_id: xii1oyad_kc
+
+# Track: General 2
+- title: The Little Server That Could
+  raw_title: RubyConf 2016 - The Little Server That Could by Stella Cotton
+  speakers:
+    - Stella Cotton
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - The Little Server That Could by Stella Cotton
+
+    Have you ever wondered what dark magic happens when you start up your Ruby server? Let’s explore the mysteries of the web universe by writing a tiny web server in Ruby! Writing a web server lets you dig deeper into the Ruby Standard Library and the Rack interface. You’ll get friendlier with I/O, signal trapping, file handles, and threading. You’ll also explore dangers first hand that can be lurking inside your production code- like blocking web requests and shared state with concurrency.
+  video_id: AFgDPssfZ9k
+
+# Break
+
+# Track: Ruby and Hardware
+- title: Running Global Manufacturing on Ruby (among other things)
+  raw_title: RubyConf 2016 - Running Global Manufacturing on Ruby (among other things) by Lee Edwards
+  speakers:
+    - Lee Edwards
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - Running Global Manufacturing on Ruby (among other things) by Lee Edwards
+
+    A few miles from this convention center, Teespring prints millions of short-run custom products every year from modern direct-to-garment printers and ships them all over the world. Like most companies, Teespring's architecture is polyglot, but the core business logic is in Ruby. We'll discuss how we use large at-scale manufacturing and production systems to help anyone, anywhere turn their ideas into reality.
+  video_id: fbNfz_Npbic
+
+# Track: General 1
+- title: The Long Strange Trip of a Senior Developer
+  raw_title: RubyConf 2016 - The long strange trip of a senior developer by Brandon Hays
+  speakers:
+    - Brandon Hays
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - The long strange trip of a senior developer by Brandon Hays
+
+    Have you ever felt like you are in the passenger seat of your career? By simply looking around and seeing how few 20+ year veterans you work with, you're actually staring our industry's sustainability problem right in the face. But the software industry needs you still contributing 20 years from now! Fret not, we can start fixing these problems, right now, in your own job.
+
+    Using in-depth research across companies of all sizes, you'll come away with a plan to start designing a sustainable career track to help you grow in skill, influence, and income now and long into the future.
+  video_id: egntf0nykzk
+
+# Track: Performance
+- title: Halve Your Memory Usage With These 12 Weird Tricks
+  raw_title: RubyConf 2016 - Halve Your Memory Usage With These 12 Weird Tricks
+  speakers:
+    - Nate Berkopec
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 -  Halve Your Memory Usage With These 12 Weird Tricks by Nate Berkopec
+
+    How does Ruby allocate memory? Ever wonder why that poor application of yours is using hundreds of megabytes of RAM? Ruby's garbage collector means that we don't have to worry about allocating memory in our programs, but an understanding of how C Ruby uses memory can help us avoid bloat and even write faster programs. We'll talk about what causes memory allocation, how the garbage collector works, and how to measure memory activity in our own Ruby programs.
+  video_id: kZcqyuPeDao
+
+# Track: General 2
+- title: Grow Your Team In 90 Days
+  raw_title: RubyConf 2016 - Grow Your Team In 90 Days by Cheryl Gore Schaefer
+  speakers:
+    - Cheryl Gore Schaefer
+  event_name: RubyConf 2016
+  published_at: '2016-11-11'
+  description: |-
+    RubyConf 2016 - Grow Your Team In 90 Days by Cheryl Gore Schaefer
+
+    So you want to work with an awesome ruby developer? Great! But finding one is hard. It’s much easier to hire that apprentice or bootcamp grad, but that person is not an awesome developer. How do you help them get there?
+
+    You will learn how to build a learning plan and become the best mentor to a budding software developer. You have the opportunity to mold your apprentice’s skill set into exactly what you need, while benefiting from their diverse skills and experiences. We will build an example learning plan of a developer learning Ruby, showing clear and specific choices and likely outcomes.
+  video_id: pHABlefSVZk
+
+# ---
 
 - title: Lightning Talks
   raw_title: RubyConf 2016 - Lightning Talks by Various Presenters
@@ -821,7 +772,7 @@ Are you the sort of developer who makes
     - Mischa Lewis
     - Jeff Foster
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-11'
   description: |-
     RubyConf 2016 - Lightning Talks by Various Presenters
 
@@ -852,95 +803,265 @@ Are you the sort of developer who makes
     01:29:10 - Jeff Foster
   video_id: SswGJpZVNFg
 
-- title: Building maintainable command-line tools with MRuby
-  raw_title: RubyConf 2016 - Building maintainable command-line tools with MRuby by Eric Hodel
+
+# Day 3 - 2016-11-12
+
+- title: Ruby versus The Titans of FP
+  raw_title: RubyConf 2016 - Ruby versus the Titans of FP by Cassandra Cruz
   speakers:
-    - Eric Hodel
+    - Cassandra Cruz
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-12'
   description: |-
-    RubyConf 2016 - Building maintainable command-line tools with MRuby by Eric Hodel
+    RubyConf 2016 - Ruby versus the Titans of FP by Cassandra Cruz
 
-    mruby and mruby-cli makes it possible to ship single binary command-line tools that can be used without setup effort, but how difficult is development in MRuby?
+    Clojure, Haskell and Javascript reign as the dominant functional languages of our era. But surely anything they can do, Ruby can do better? And what is it that they actually do? Come learn about three core concepts of functional programming, and see how Ruby stacks up against its peers when it comes to making them powerful.
+  video_id: 25u-pp-7PHE
 
-    In this talk we'll explore how to work with MRuby and mruby-cli. We'll cover the differences in development patterns when using MRuby, the maturity of the MRuby ecosystem, and development patterns when using mruby-cli to build a command-line tool.
-  video_id: 96YgJSGaB3M
+# ---
 
-- title: Composition
-  raw_title: RubyConf 2016 - Composition by James Dabbs
+# Track: War Stories
+- title: How I Corrupted Survey Results and (Maybe) Ruined a Business
+  raw_title: RubyConf 2016 - How I Corrupted Survey Results and (Maybe) Ruined a Business by Mike Calhoun
   speakers:
-    - James Dabbs
+    - Mike Calhoun
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-12'
   description: |-
-    RubyConf 2016 - Composition by James Dabbs
+    RubyConf 2016 - How I Corrupted Survey Results and (Maybe) Ruined a Business by Mike Calhoun
 
-    Our work as programmers consists largely of problem decomposition and solution recomposition. This talk is interested in how we cobble small units together into cohesive solutions. We'll examine and compare both object and functional composition, using a Haskell-inspired, functional style of Ruby. Along the way, we'll see how good functional principles can improve our object-oriented design, and vice versa.
-  video_id: zwo7ZTHS8Wg
+    It was the perfect storm of events and circumstances: a first job, naïveté of inexperience, a fear of getting fired, and a loud boss prone to yelling. One morning, I realized that the first web “project” of my first job in my new career had gone horribly off track. What came to pass in the following weeks was the most involved and tense coverup I’ve undertaken in my life. This experience can tell us all about how we communicate with each other. How we can create environments where people can ask for help and how an atmosphere of pressure and tension can ruin a business.
+  video_id: NFkym21cl4E
 
-- title: Why recursion matters
-  raw_title: RubyConf 2016 - Why recursion matters by James Coglan
+# Track: General 1
+- title: The Truth About Mentoring Minorities
+  raw_title: RubyConf 2016 - The Truth About Mentoring Minorities by Byron Woodfork
   speakers:
-    - James Coglan
+    - Byron Woodfork
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-12'
   description: |-
-    RubyConf 2016 - Why recursion matters by James Coglan
+    RubyConf 2016 - The Truth About Mentoring Minorities by Byron Woodfork
 
-    In modern programming, recursion is so common that we take it for granted. We work with recursive processes and structures every day, and it's easy to forget that recursion was once a highly contentious issue in programming language design.
+    In the tech industry, we currently lack the ability to produce mentors who are able to effectively teach and connect with their minority protégés. In this talk, we discuss what changes we can make in the way we mentor to give our minority protégés the best chance to succeed. We will take a look at some of the struggles that I faced throughout my software developer apprenticeship, and pinpoint the sources of my success. In conjunction, we will also look at various case studies of other minority professionals who were both successful and unsuccessful in their attempts to climb the corporate ladder.
+  video_id: 1Dttd0eJG94
 
-    But there's more to recursion than meets the eye. In this talk I'll discuss how it is fundamental to computing; how it can prove programs are correct, make them run faster, and even let you run programs backwards! Along the way we'll meet maths, Haskell, Bash, JavaScript, and our old friend Ruby doing some very surprising things.
-  video_id: qhwG2B77fQk
-
-- title: 'To Clojure and back: writing and rewriting in Ruby'
-  raw_title: 'RubyConf 2016 - To Clojure and back: writing and rewriting in Ruby by Phill MV'
+# Track: Ruby Deep Dive
+- title: Methods of Memory Management in MRI
+  raw_title: RubyConf 2016 - Methods of Memory Management in MRI by Aaron Patterson
   speakers:
-    - Phill MV
+    - Aaron Patterson
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-12'
+  slides_url: https://speakerdeck.com/tenderlove/methods-of-memory-management-in-mri
   description: |-
-    RubyConf 2016 - To Clojure and back: writing and rewriting in Ruby by Phill MV
+    RubyConf 2016 - Methods of Memory Management in MRI by Aaron Patterson
 
-    Act 1 - State of Grace
+    Let's talk about MRI's GC! In this talk we will cover memory management algorithms in MRI. We will cover how objects are allocated and how they are freed. We will start by looking at Ruby's memory layout, including page allocation and object allocations within those pages. Next we'll cover collection algorithms used by MRI starting with the mark and sweep algorithm, followed by generational collection, and the tri color abstraction. Finally we'll cover experimental developments for the GC like heap splitting. Expect to leave this talk with heaps of pointers to add to your remembered set!
+  video_id: r0UjXixkBV8
 
-    After many years of Ruby, we built our app in Clojure, why not. Clojure is a breath of fresh air. Learn a lisp today!
-
-    Act 2 - The Fall
-
-    It's harder to succeed when you're in a new and different ecosystem. How Clojure contrasts with Ruby.
-
-    Act 3 - The Wilderness
-
-    Rewriting your app is a bad idea but we did it anyways. How we came to that decision.
-
-    Act 4 - Reconciliation
-
-    How I write Ruby has changed: a discussion.
-  video_id: doZ0XAc9Wtc
-
-- title: Diving into the Details with DTrace
-  raw_title: RubyConf 2016 - Diving into the Details with DTrace by Colin Jones
+# Track: General 2
+- title: The Neuroscience and Psychology of Open Source Communities
+  raw_title: RubyConf 2016 - The Neuroscience and Psychology of Open Source Communities by Elizabeth Barron
   speakers:
-    - Colin Jones
+    - Elizabeth Barron
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-12'
   description: |-
-    RubyConf 2016 - Diving into the Details with DTrace by Colin Jones
-    "Argh, why is this so slow?!" We've all asked questions like this without getting satisfying answers. And so we slog along, finding workarounds and architecting around the slow bits.
+    RubyConf 2016 - The Neuroscience and Psychology of Open Source Communities by Elizabeth Barron
 
-    But what if we had a friend who could see things we can't? Someone who could say whether our guesses were right, and what to look at next?
+    ***Contains explicit language***
 
-    DTrace is that friend, and it's here to help! In this talk, I'll show you how DTrace can answer incredibly general and specific questions about systems performance, and help us to generate new ones. Along the way, we'll see that it's easier to use than you might think!
-  video_id: ZzYyl5vAWcA
+    Because people are complex, diverse creatures, ensuring that your open source community is healthy, vibrant, and welcoming can be challenging. The good news is, science can help you understand human thoughts and behaviors, and the complexities of interacting in a collaborative way online. We'll discuss cognitive biases, the SCARF collaboration model, the online community life cycle, and how these things interact. You'll come away from this talk with a deeper understanding of yourself, your fellow humans, & the knowledge to improve personal interactions and the open source communities you belong to.
+  video_id: VXE42FyFFX4
 
-- title: Running Global Manufacturing on Ruby (among other things)
-  raw_title: RubyConf 2016 - Running Global Manufacturing on Ruby (among other things) by Lee Edwards
+# ---
+
+# Track: War Stories
+- title: Datacenter Fires and Other "Minor" Disasters
+  raw_title: RubyConf 2016 - Datacenter Fires and Other "Minor" Disasters by Aja Hammerly
   speakers:
-    - Lee Edwards
+    - Aja Hammerly
   event_name: RubyConf 2016
-  published_at: '2016-11-21'
+  published_at: '2016-11-12'
   description: |-
-    RubyConf 2016 - Running Global Manufacturing on Ruby (among other things) by Lee Edwards
+    RubyConf 2016 - Datacenter Fires and Other "Minor" Disasters by Aja Hammerly
 
-    A few miles from this convention center, Teespring prints millions of short-run custom products every year from modern direct-to-garment printers and ships them all over the world. Like most companies, Teespring's architecture is polyglot, but the core business logic is in Ruby. We'll discuss how we use large at-scale manufacturing and production systems to help anyone, anywhere turn their ideas into reality.
-  video_id: fbNfz_Npbic
+    Most of us have a "that day I broke the internet" story. Some are amusing and some are disastrous but all of these stories change how we operate going forward. I'll share the amusing stories behind why I always take a database backup, why feature flags are important, the importance of automation, and how having a team with varied backgrounds can save the day. Along the way I'll talk about a data center fire, deleting a production database, and accidentally setting up a DDOS attack against our own site. I hope that by learning from my mistakes you won't have to make them yourself.
+  video_id: ygu45C7bMHk
+
+# Track: Life Beyond Bootcamps
+- title: 'Becoming a Mid: Two Perspectives on Leveling Up'
+  raw_title: RubyConf 2016 - Becoming a Mid... by Kimberly D. Barnes & Kinsey Ann Durham
+  speakers:
+    - Kimberly D. Barnes
+    - Kinsey Ann Durham
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - Becoming a Mid: Two Perspectives on Leveling Up by Kimberly D. Barnes & Kinsey Ann Durham
+
+    What does becoming a mid-level developer mean? How can a junior set goals and make steps to achieve this? It's difficult to shed the title of 'junior', not only in your own mind, but in the minds of others. It is important to keep progressing in your career as a developer to be able to level up and no longer be seen as the junior on the team. Kim and Kinsey will provide two perspectives to enable you to leave this talk with tangible action items. They will also dive into what employers can do to help build frameworks to allow for this transition.
+  video_id: i_RisLTNZEY
+
+# Track: Ruby Deep Dive
+- title: Optimizing Ruby Core
+  raw_title: RubyConf 2016 - Optimizing ruby core by Shyouhei Urabe
+  speakers:
+    - Shyouhei Urabe
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - Optimizing ruby core by Shyouhei Urabe
+
+    I made ruby interpreter 10 times faster. Let me show you how
+  video_id: MqhapcDyP00
+
+# Track: Weird Ruby
+- title: Metaprogramming? Not Good Enough!
+  raw_title: RubyConf 2016 - Metaprogramming? Not good enough! by Justin Weiss
+  speakers:
+    - Justin Weiss
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - Metaprogramming? Not good enough! by Justin Weiss
+
+    If you know how to metaprogram in Ruby, you can create methods and objects on the fly, build Domain Specific Languages, or just save yourself a lot of typing. But can you change how methods are dispatched? Can you decide that the normal inheritance rules don't apply to some object?
+
+    In order to change those core parts of the language, there can't be much difference between how a language is implemented and how it's used. In this talk, you'll make that difference smaller, building a totally extensible object model on top of Ruby, using less than a dozen new classes and methods.
+  video_id: JOvBmhukWI0
+
+# Lunch
+
+# Track: War Stories
+- title: The Building Built on Stilts
+  raw_title: RubyConf 2016 - The Building Built on Stilts by Nickolas Means
+  speakers:
+    - Nickolas Means
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - The Building Built on Stilts by Nickolas Means
+
+    In the summer of 1978, structural engineer William LeMessurier got a phone call that terrified him. An undergraduate student claimed that LeMessurier's acclaimed 59-story Citicorp Center in Manhattan, just completed the year prior, was dangerously unstable under certain wind conditions. The student was right, and it was almost hurricane season.
+
+    The key to building a culture of innovation in your team is learning how to respond when mistakes inevitably happen. Let's let Bill LeMessurier teach us how to respond when it all goes wrong so that our creations can thrive despite our mistakes.
+  video_id: "-ES1wlV-8lU"
+
+# Track: Life Beyond Bootcamps
+- title: Learning Fluency
+  raw_title: RubyConf 2016 - Learning Fluency by Sara Simon
+  speakers:
+    - Sara Simon
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - Learning Fluency by Sara Simon
+
+    All languages work in formulaic ways. Cracking these formulas takes discipline, time, creativity, trial and error. But is there an overarching formula to crack these formulas? Is there a designated set of steps we can take to guarantee fluency?
+
+    In this talk, you will learn about the methods people use to learn both foreign languages and programming languages. As developers, we often just jump in and start building. Why is this? Does full immersion work best always and for everyone? What is fluency, and is it ever something we can achieve in Ruby? Let’s explore.
+  video_id: AZlOjCZlPLU
+
+# Track: Ruby Deep Dive
+- title: Seeing Metaprogramming and Lambda Function Patterns in Ruby
+  raw_title: RubyConf 2016 - Seeing Metaprogramming and Lambda Function Patterns in Ruby by Lukas Nimmo
+  speakers:
+    - Lukas Nimmo
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - Seeing Metaprogramming and Lambda Function Patterns in Ruby by Lukas Nimmo
+
+    Metaprogramming and lambda functions in Ruby should be explained within their rightful place: living examples. You may have read tutorials on what these concepts are, but still do not understand when or why to use them. I dredged through over 50 prominent Open Source Ruby projects to bring you ten successful patterns that are used time and time again to create some of the most expressive and popular Ruby DSLs. Join me as we cover these patterns so that you can immediately begin using them in your own code to implement powerful DSLs. No vacuum-living, esoteric concepts here.
+  video_id: poAxCd7Z0Kg
+
+# Track: Weird Ruby
+- title: Rhythmic Recursion
+  raw_title: RubyConf 2016 - Rhythmic Recursion by Celeen Rusk
+  speakers:
+    - Celeen Rusk
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - Rhythmic Recursion by Celeen Rusk
+
+    One of the best things about multi-disciplinary work is recognizing familiar ideas in a different setting. It’s like running into an old friend while you’re on vacation halfway around the world-- “I had no idea you’d be here! It’s so great to see you!”
+
+    In this talk we’ll run into our old friend recursion in the faraway land of minimalist music, by rewriting a piece of rhythmic music in Ruby.
+  video_id: cSPhgRgjwZs
+
+# ---
+
+# Track: General 1
+- title: Lies
+  raw_title: RubyConf 2016 - Lies by Ernie Miller
+  speakers:
+    - Ernie Miller
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - Lies by Ernie Miller
+
+    All abstractions are lies, if they are abstractions at all, and as developers, we live our lives surrounded by them. What makes a some abstractions better than others? This will be an opinionated and empowering look at the value and nature of abstractions, with a jaunt through quantum mechanics and the nature of reality.
+
+    You know, just your average, light discussion.
+  video_id: Avf65oHa5vc
+
+# Track: Life Beyond Bootcamps
+- title: You Graduated From Bootcamp, Now What?
+  raw_title: RubyConf 2016 - You graduated from bootcamp, now what? by Melanie Gilman
+  speakers:
+    - Melanie Gilman
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - You graduated from bootcamp, now what? by Melanie Gilman
+
+    Throughout bootcamp, your biggest worry was finding a job. Now that you’ve found one and you’ve started your career as a developer, what comes next? In this talk, we’ll explore what the career of a bootcamp graduate looks like a few years after the program. We’ll talk about the good and not-so-good parts of being a newly-minted developer. We’ll come away with actionable steps we can take to continue to grow as developers post-bootcamp and be happy and successful, even when we don’t have the mythical perfect job.
+  video_id: pCnvpB9tGws
+
+# Track: General 2
+- title: Even the Justice League Works Remotely
+  raw_title: RubyConf 2016 -  Even the Justice League Works Remotely by Allison McMillan
+  speakers:
+    - Allison McMillan
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 -  Even the Justice League Works Remotely by Allison McMillan
+
+    "Remote welcome for senior level". This appears in countless job descriptions. Remote work is largely accepted in the developer community, but often only for very experienced developers. This fear is not without cause. Sometimes hiring remote developers at any level doesn’t turn out well but there’s generally a reason for that. Newer developers can also be very successful remote workers. In this talk, you’ll learn what to look for when hiring remote developers at any level and non-senior developers will learn what characteristics to keep in mind in order to have a successful remote experience.
+  video_id: d7Z0uS2x_cY
+
+# Track: Weird Ruby
+- title: That Works?! Quines and Other Delightfully Useless Programs
+  raw_title: RubyConf 2016 - That Works?! Quines and Other Delightfully Useless Programs by Colin Fulton
+  speakers:
+    - Colin Fulton
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - That Works?! Quines and Other Delightfully Useless Programs by Colin Fulton
+
+    Performance, readability and correctness are fine and dandy, but what happens when we start optimizing for whimsy, illegibility and outright silliness? Self-rewriting programs that also function as ASCII art? Yup. Rewrite any JavaScript program only using six characters? Why not?
+
+    Let's take a break from the practical and laugh at some of the most unbelievable code you've ever seen. Then let's pull out the magnifying glass to figure out how it actually works.
+
+    Learn how to read the unreadable and how to write code that—to borrow a phrase from the Ig Nobel Awards—makes people laugh, then think.
+  video_id: DC-bjR6WeaM
+
+# ---
+
+- title: Q&A with Matz
+  raw_title: RubyConf 2016 - Matz Q&A by Yukihiro 'Matz' Matsumoto
+  speakers:
+    - Yukihiro "Matz" Matsumoto
+  event_name: RubyConf 2016
+  published_at: '2016-11-12'
+  description: |-
+    RubyConf 2016 - Matz Q&A by Yukihiro 'Matz' Matsumoto
+
+    Part of our annual tradition, Matz answers questions from Evan as well as the audience
+  video_id: Ohs2hZBzif8


### PR DESCRIPTION
This pull request resolves the TODOs for RubyConf 2016 by:
* adding the talk dates
* adding missing speakers
* adding missing talks
* adding tracks as comments
* adding lunch/breaks as comments
* putting the talks in running order
* fixing talk titles
