### PR TITLE
Add Speakerdeck column to Speaker

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -62,8 +62,8 @@ class SpeakersController < ApplicationController
     {
       anonymous: params.require(:speaker).permit(:github),
       signed_in: params.require(:speaker).permit(:github),
-      owner: params.require(:speaker).permit(:name, :twitter, :bio, :website),
-      admin: params.require(:speaker).permit(:name, :twitter, :github, :bio, :website)
+      owner: params.require(:speaker).permit(:name, :twitter, :bio, :website, :speakerdeck),
+      admin: params.require(:speaker).permit(:name, :twitter, :github, :bio, :website, :speakerdeck)
     } [user_kind]
   end
 

--- a/app/views/speakers/_about.html.erb
+++ b/app/views/speakers/_about.html.erb
@@ -9,6 +9,11 @@
       <strong>Twitter:</strong> <%= link_to speaker.twitter, "https://www.twitter.com/#{speaker.twitter}", target: "_blank" %>
     </span>
   <% end %>
+  <% if speaker.speakerdeck.present? %>
+    <span>
+      <strong>Speakerdeck:</strong> <%= link_to speaker.speakerdeck, "https://speakerdeck.com/#{speaker.speakerdeck}", target: "_blank" %>
+    </span>
+  <% end %>
   <% if speaker.website.present? %>
     <span>
       <strong>Website:</strong> <%= link_to speaker.website, speaker.valid_website_url, target: "_blank" %>

--- a/app/views/speakers/_form.html.erb
+++ b/app/views/speakers/_form.html.erb
@@ -27,6 +27,11 @@
     </div>
   <% end %>
 
+  <div>
+    <%= form.label :speakerdeck, "Speakerdeck" %>
+    <%= form.text_field :speakerdeck, class: "input input-bordered w-full" %>
+  </div>
+
   <div class="flex items-center gap-4">
     <%= ui_button "Suggest modifications", type: :submit %>
     <%= ui_button "Cancel", data: {action: "click->modal#close"}, role: :button, kind: :ghost %>

--- a/db/migrate/20241020174649_add_speakerdeck_to_speaker.rb
+++ b/db/migrate/20241020174649_add_speakerdeck_to_speaker.rb
@@ -1,0 +1,5 @@
+class AddSpeakerdeckToSpeaker < ActiveRecord::Migration[8.0]
+  def change
+    add_column :speakers, :speakerdeck, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_09_20_154237) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_20_174649) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -140,6 +140,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_09_20_154237) do
     t.datetime "updated_at", null: false
     t.integer "talks_count", default: 0, null: false
     t.integer "canonical_id"
+    t.string "speakerdeck", default: "", null: false
     t.index ["canonical_id"], name: "index_speakers_on_canonical_id"
     t.index ["name"], name: "index_speakers_on_name"
     t.index ["slug"], name: "index_speakers_on_slug", unique: true


### PR DESCRIPTION
This pull request adds a `speakerdeck` column to the `speakers` table. Maybe this allows us in the future to automate the matching of `slides_url` to decks on Speakerdeck.

| Profile Sidebar | Suggestion |
| --- | --- |
| ![CleanShot 2024-10-20 at 19 52 48](https://github.com/user-attachments/assets/33474c40-97c3-43fa-9df6-43272d87935d) | ![CleanShot 2024-10-20 at 19 52 53](https://github.com/user-attachments/assets/094bdc53-c3ba-427a-b979-01085266876f) |
