### PR TITLE
Add pronouns to `Speaker`

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -60,8 +60,8 @@ class SpeakersController < ApplicationController
 
   def speaker_params
     {
-      anonymous: params.require(:speaker).permit(:github),
-      signed_in: params.require(:speaker).permit(:github),
+      anonymous: params.require(:speaker).permit(:github, :pronouns_type, :pronouns),
+      signed_in: params.require(:speaker).permit(:github, :pronouns_type, :pronouns),
       owner: params.require(:speaker).permit(:name, :twitter, :bio, :website, :speakerdeck, :pronouns_type, :pronouns),
       admin: params.require(:speaker).permit(:name, :twitter, :github, :bio, :website, :speakerdeck, :pronouns_type, :pronouns)
     } [user_kind]

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -62,8 +62,8 @@ class SpeakersController < ApplicationController
     {
       anonymous: params.require(:speaker).permit(:github),
       signed_in: params.require(:speaker).permit(:github),
-      owner: params.require(:speaker).permit(:name, :twitter, :bio, :website, :speakerdeck),
-      admin: params.require(:speaker).permit(:name, :twitter, :github, :bio, :website, :speakerdeck)
+      owner: params.require(:speaker).permit(:name, :twitter, :bio, :website, :speakerdeck, :pronouns_type, :pronouns),
+      admin: params.require(:speaker).permit(:name, :twitter, :github, :bio, :website, :speakerdeck, :pronouns_type, :pronouns)
     } [user_kind]
   end
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -18,3 +18,6 @@ application.register("transition", TransitionController)
 
 import VideoPlayerController from "./video_player_controller"
 application.register("video-player", VideoPlayerController)
+
+import PronounsSelectController from "./pronouns_select_controller"
+application.register("pronouns-select", PronounsSelectController)

--- a/app/javascript/controllers/pronouns_select_controller.js
+++ b/app/javascript/controllers/pronouns_select_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = [
+    'type',
+    'input'
+  ]
+
+  connect () {
+    this.updateInputVisibility()
+  }
+
+  change () {
+    if (this.typeTarget.value === 'custom') {
+      this.inputTarget.value = ''
+    } else {
+      this.inputTarget.value = this.typeTarget.selectedOptions[0]?.textContent || ''
+    }
+
+    this.updateInputVisibility()
+  }
+
+  updateInputVisibility () {
+    if (this.typeTarget.value === 'custom') {
+      this.inputTarget.classList.remove('hidden')
+    } else {
+      this.inputTarget.classList.add('hidden')
+    }
+  }
+}

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -22,6 +22,15 @@ class Speaker < ApplicationRecord
   include Suggestable
   slug_from :name
 
+  PRONOUNS = {
+    "Not specified": :not_specified,
+    "Don't specify": :dont_specify,
+    "they/them": :they_them,
+    "she/her": :she_her,
+    "he/him": :he_him,
+    Custom: :custom
+  }.freeze
+
   # associations
   has_many :speaker_talks, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id
   has_many :talks, through: :speaker_talks, inverse_of: :speakers

--- a/app/views/speakers/_about.html.erb
+++ b/app/views/speakers/_about.html.erb
@@ -1,4 +1,9 @@
 <div class="flex flex-col gap-2 pb-4" id="<%= dom_id(speaker, :about) %>">
+  <% if speaker.pronouns.present? && ["dont_specify", "not_specified"].exclude?(speaker.pronouns_type) %>
+    <span>
+      <strong>Pronouns:</strong> <%= speaker.pronouns %>
+    </span>
+  <% end %>
   <% if speaker.github.present? %>
     <span>
       <strong>GitHub:</strong> <%= link_to speaker.github, "https://www.github.com/#{speaker.github}", target: "_blank" %>

--- a/app/views/speakers/_about.html.erb
+++ b/app/views/speakers/_about.html.erb
@@ -1,9 +1,4 @@
 <div class="flex flex-col gap-2 pb-4" id="<%= dom_id(speaker, :about) %>">
-  <% if speaker.pronouns.present? && ["dont_specify", "not_specified"].exclude?(speaker.pronouns_type) %>
-    <span>
-      <strong>Pronouns:</strong> <%= speaker.pronouns %>
-    </span>
-  <% end %>
   <% if speaker.github.present? %>
     <span>
       <strong>GitHub:</strong> <%= link_to speaker.github, "https://www.github.com/#{speaker.github}", target: "_blank" %>

--- a/app/views/speakers/_form.html.erb
+++ b/app/views/speakers/_form.html.erb
@@ -17,6 +17,14 @@
     </div>
 
     <div>
+      <%= form.label :pronouns %>
+      <div data-controller="pronouns-select">
+        <%= form.select :pronouns_type, Speaker::PRONOUNS, {}, class: "select select-bordered w-full", data: {action: "pronouns-select#change", pronouns_select_target: "type"} %>
+        <%= form.text_field :pronouns, placeholder: "Custom pronouns", class: "hidden mt-3 input input-bordered w-full", data: {pronouns_select_target: "input"} %>
+      </div>
+    </div>
+
+    <div>
       <%= form.label :website %>
       <%= form.text_field :website, class: "input input-bordered w-full" %>
     </div>

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -3,11 +3,11 @@
 <div class="container py-8">
   <div class="flex items-start flex-wrap sm:flex-nowrap gap-8 w-full">
     <div class="w-full sm:w-1/3">
-      <h1 class="mb-4" style="view-transition-name: title">
+      <h1 class="mb-4 flex gap-2" style="view-transition-name: title">
         <%= @speaker.name %>
 
         <% if @speaker.pronouns.present? && ["dont_specify", "not_specified"].exclude?(@speaker.pronouns_type) %>
-          <span class="text-sm" >(<%= @speaker.pronouns %>)</span>
+          <span class="text-sm content-center text-[#737373]">(<%= @speaker.pronouns %>)</span>
         <% end %>
       </h1>
 

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -3,20 +3,27 @@
 <div class="container py-8">
   <div class="flex items-start flex-wrap sm:flex-nowrap gap-8 w-full">
     <div class="w-full sm:w-1/3">
-      <h1 class="mb-4" style="view-transition-name: title"> <%= @speaker.name %></h1>
-      <% if @speaker.github.present? %>
-      <div class="relative w-fit">
-        <%= image_tag @speaker.github_avatar_url(size: 200),
-              class: "rounded-full mb-4",
-              height: 200,
-              width: 200,
-              alt: "GitHub picture profile of #{@speaker.github}",
-              loading: :lazy %>
+      <h1 class="mb-4" style="view-transition-name: title">
+        <%= @speaker.name %>
 
-        <% if @speaker.verified? %>
-          <div class="absolute right-0 top-0 badge badge-accent">Verified</div>
+        <% if @speaker.pronouns.present? && ["dont_specify", "not_specified"].exclude?(@speaker.pronouns_type) %>
+          <span class="text-sm" >(<%= @speaker.pronouns %>)</span>
         <% end %>
-      </div>
+      </h1>
+
+      <% if @speaker.github.present? %>
+        <div class="relative w-fit">
+          <%= image_tag @speaker.github_avatar_url(size: 200),
+                class: "rounded-full mb-4",
+                height: 200,
+                width: 200,
+                alt: "GitHub picture profile of #{@speaker.github}",
+                loading: :lazy %>
+
+          <% if @speaker.verified? %>
+            <div class="absolute right-0 top-0 badge badge-accent">Verified</div>
+          <% end %>
+        </div>
       <% end %>
       <%= render "speakers/about", speaker: @speaker %>
       <%= render "speakers/actions", speaker: @speaker %>

--- a/db/migrate/20241023093844_add_pronouns_to_speaker.rb
+++ b/db/migrate/20241023093844_add_pronouns_to_speaker.rb
@@ -1,0 +1,6 @@
+class AddPronounsToSpeaker < ActiveRecord::Migration[8.0]
+  def change
+    add_column :speakers, :pronouns_type, :string, default: "not_specified", null: false
+    add_column :speakers, :pronouns, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,6 +141,8 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_23_154126) do
     t.integer "talks_count", default: 0, null: false
     t.integer "canonical_id"
     t.string "speakerdeck", default: "", null: false
+    t.string "pronouns_type", default: "not_specified", null: false
+    t.string "pronouns", default: "", null: false
     t.index ["canonical_id"], name: "index_speakers_on_canonical_id"
     t.index ["name"], name: "index_speakers_on_name"
     t.index ["slug"], name: "index_speakers_on_slug", unique: true


### PR DESCRIPTION
This pull request adds the option for speakers to add their pronouns to their profile.

The value is set to `not_specified` by default and therefore doesn't show anything on the profile. If a speaker chooses the `dont_specify` option it will also not be shown.

Additionally the `custom` type allows to enter pronouns as a freeform field.

| Speakers#edit | Pronouns Select Options |
| ---- | ---- |
| ![CleanShot 2024-10-23 at 12 42 09](https://github.com/user-attachments/assets/6ab8ffe4-0099-4b45-9e5b-047f9afa33ab) | ![CleanShot 2024-10-23 at 12 42 13](https://github.com/user-attachments/assets/05f7b306-e10f-464c-ab04-fe18fbdfdf58) |

| Custom Pronouns | Speakers#show (in about) |
| --- | --- |
| ![CleanShot 2024-10-23 at 12 42 22](https://github.com/user-attachments/assets/adc65d80-40a8-4077-ba47-6b01e8f80d04) | ![CleanShot 2024-10-24 at 00 32 01](https://github.com/user-attachments/assets/0671a51d-17a5-4605-8578-ee015f91f275) |
