### PR TITLE
Merge some speakers

### DIFF
--- a/data/blue-ridge-ruby/blue-ridge-ruby-2023/videos.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2023/videos.yml
@@ -41,9 +41,9 @@
   video_id: 11yubbTx8Ow
 
 - title: "RSpec: The Bad Parts"
-  raw_title: "BlueRidgeRuby 2023: RSpec: The Bad Parts - Caleb Heart"
+  raw_title: "BlueRidgeRuby 2023: RSpec: The Bad Parts - Caleb Hearth"
   speakers:
-    - Caleb Heart
+    - Caleb Hearth
   event_name: Blue Ridge Ruby 2023
   published_at: "2024-01-01"
   description:

--- a/data/euruko/euruko-2016/videos.yml
+++ b/data/euruko/euruko-2016/videos.yml
@@ -74,19 +74,29 @@
 - title: 'Lightning Talks: Day 1'
   raw_title: EuRuKo 2016 - Day 1 Lightning Talks
   speakers:
-    - Max Gorin # Making a Multiplayer Memoery Game with Elixir and Elm (0:29)
-    - Johanna Lang # Team Joda 2016 (Rails Girls Summer of Code 2016) (6:20)
-    - Dayana Mick # Team Joda 2016 (Rails Girls Summer of Code 2016) (6:20)
+    - Max Gorin # Making a Multiplayer Memory Game with Elixir and Elm (0:29)
+    - Johanna Lang # Team Joda 2016 (Rails Girls Summer of Code 2016) (6:20)
+    - Dayana Mick # Team Joda 2016 (Rails Girls Summer of Code 2016) (6:20)
     - Kinga Kalinowska # We Are Rubycats! (Rails Girls Summer of Code 2016) (12:11)
     - Izabela Komorek # We Are Rubycats! (Rails Girls Summer of Code 2016) (12:11)
-    - Melanie Keatley # Magic Solution to the Tech Gender Gap (18:22)
+    - Melanie Keatley # Magic Solution to the Tech Gender Gap (18:22)
     - Stephanie Nemeth # Magic Solution to the Tech Gender Gap (18:22)
     - Krzysztof (Christopher) Wawer # Validations (23:39)
     - Demir Zekić # The Importance of Teaching and Metoring (28:53)
     - Jan Lelis # Whirly - The Friendly Terminal Spinner (35:25)
   event_name: EuRuKo 2016
   published_at: '2016-09-23'
-  description: ''
+  description: |-
+    Lightning talks from Day 1 of EuRuKo
+
+    * "Making a Multiplayer Memory Game with Elixir and Elm" by Max Gorin (0:29)
+    * "Team Joda 2016 (Rails Girls Summer of Code 2016)" by Johanna Lang & Dayana Mick (6:20)
+    * "We Are Rubycats! (Rails Girls Summer of Code 2016)" by Kinga Kalinowska & Izabela Komorek (12:11)
+    * "Magic Solution to the Tech Gender Gap" by Melanie Keatley & Stephanie Nemeth (18:22)
+    * "Validations" by Krzysztof (Christopher) Wawer (23:39)
+    * "The Importance of Teaching and Metoring" by Demir Zekić (28:53)
+    * "Whirly - The Friendly Terminal Spinner" by Jan Lelis (35:25)
+
   video_id: UehkClMTJDw
 
 
@@ -162,7 +172,16 @@
     - Alex Jahraus # Feel Worse, Do Better (40:35)
   event_name: EuRuKo 2016
   published_at: '2016-09-24'
-  description: ''
+  description: |-
+    Lightning talks from Day 2 of EuRuKo
+
+    * "The HTT(Pancake) Request - Keeping Your Clients Happy, Not Hangry" by Kriselda Rabino (0:57)
+    * "How to decode ADSK data (Commodore 64 Edition)" by Stefan Daschek (7:50)
+    * "Working with PDFs in Ruby" by Thomas Leitner (13:47)
+    * "Ruby for Science and Open Data" by Victor Shepelev (22:55)
+    * "CodeMarathon & HiredInTech - Using Rails to scale teaching CS online" by Anton Dimitrov (29:37)
+    * "Opening a calculator with Rails" by Igor Omokov (34:16)
+    * "Feel Worse, Do Better" by Alex Jahraus (40:35)
   video_id: WnlgKWCt8wQ
 
 - title: The Illusion of Stable APIs

--- a/data/goruco/goruco-2017/videos.yml
+++ b/data/goruco/goruco-2017/videos.yml
@@ -51,9 +51,9 @@
   video_id: 2C_IUMYzM7A
 
 - title: Developer Productivity Engineering
-  raw_title: 'GORUCO 2017: Developer Productivity Engineering by  Panayiotis Thomakos'
+  raw_title: 'GORUCO 2017: Developer Productivity Engineering by Pan Thomakos'
   speakers:
-    - Panayiotis Thomakos
+    - Pan Thomakos
   event_name: GoRuCo 2017
   published_at: '2017-06-24'
   description: |-

--- a/data/keeprubyweird/keep-ruby-weird-2015/videos.yml
+++ b/data/keeprubyweird/keep-ruby-weird-2015/videos.yml
@@ -38,9 +38,9 @@
   video_id: Jcto0Bs1hIA
 
 - title: 'Your Career vs. the 4th Dimension: A Time Travel Story'
-  raw_title: 'KRW 2015 - Your Career vs. the 4th Dimension: A Time Travel Story by Brandon Hayes'
+  raw_title: 'KRW 2015 - Your Career vs. the 4th Dimension: A Time Travel Story by Brandon Hays'
   speakers:
-    - Brandon Hayes
+    - Brandon Hays
   event_name: Keep Ruby Weird 2015
   published_at: '2015-11-02'
   description: |-

--- a/data/keeprubyweird/keep-ruby-weird-2016/videos.yml
+++ b/data/keeprubyweird/keep-ruby-weird-2016/videos.yml
@@ -14,9 +14,9 @@
   video_id: SKlIQLb7U00
 
 - title: Implementing An Esoteric Programming
-  raw_title: Keep Ruby Weird 2016 - Implementing An Esoteric Programming by Tom Enebo
+  raw_title: Keep Ruby Weird 2016 - Implementing An Esoteric Programming by Thomas E Enebo
   speakers:
-    - Tom E Enebo
+    - Thomas E Enebo
   event_name: Keep Ruby Weird 2016
   published_at: '2016-11-04'
   description: Implementing An Esoteric Programming by Tom Enebo

--- a/data/mountainwest-rubyconf/mountainwest-rubyconf-2008/videos.yml
+++ b/data/mountainwest-rubyconf/mountainwest-rubyconf-2008/videos.yml
@@ -29,7 +29,7 @@
     - Chris Shea # Guessmethod (4:35)
     - Josh Susser # Migration Concordance (12:39)
     - Jeremy McAnally # Framework Components (18:06)
-    - Andrew Schafer # Systems Building Systems with Puppet (20:44)
+    - Andrew Shafer # Systems Building Systems with Puppet (20:44)
     - David South # Multi-Image Uploading with SWFUpload & Rails (27:15)
     - Tim Harper # RubyAmp: Ruby Dev in TextMate Amplified (31:56)
     - David Koontz # Build a GUI App in 5 Minutes (37:47)

--- a/data/mountainwest-rubyconf/mountainwest-rubyconf-2010/videos.yml
+++ b/data/mountainwest-rubyconf/mountainwest-rubyconf-2010/videos.yml
@@ -119,7 +119,7 @@
 - title: Ruby 124c41+
   raw_title: MountainWest RubyConf 2010 - Ruby 124c41+ by Yukihio 'Matz' Matsumoto
   speakers:
-    - Yukihio 'Matz' Matsumoto
+    - Yukihiro "Matz" Matsumoto
   event_name: MountainWest RubyConf 2010
   published_at: '2015-02-11'
   description: |-

--- a/data/railsconf/railsconf-2012/videos.yml
+++ b/data/railsconf/railsconf-2012/videos.yml
@@ -835,13 +835,13 @@
     - Charles Max Wood
     - Josh Susser
     - David Brady
-    - Avdi Grim
+    - Avdi Grimm
   event_name: RailsConf 2012
   published_at: "2012-08-22"
   description: |-
     This presentation was recorded on April 25, 2012 in Austin, Texas at RailsConf 2012.
 
-    The presenters are James Edward Gray, Charles Max Wood, Josh Susser, David Brady and Avdi Grim.
+    The presenters are James Edward Gray, Charles Max Wood, Josh Susser, David Brady and Avdi Grimm.
 
     Ruby's favorite podcast comes to RailsConf! Join the Ruby Rogues (David Brady, James Edward Gray II, Avdi Grimm, Josh Susser, and Charles Max Wood) for this live episode on What Rails Developers Should Care About.
 

--- a/data/railsconf/railsconf-2012/videos.yml
+++ b/data/railsconf/railsconf-2012/videos.yml
@@ -831,7 +831,7 @@
 - title: Ruby Rogues - Live Podcast!
   raw_title: RailsConf 2012 - Ruby Rogues - Live Podcast!
   speakers:
-    - James Edward Gray
+    - James Edward Gray II
     - Charles Max Wood
     - Josh Susser
     - David Brady

--- a/data/railsconf/railsconf-2013/videos.yml
+++ b/data/railsconf/railsconf-2013/videos.yml
@@ -863,9 +863,9 @@
   video_id: xi7z-vGNNGw
 
 - title: A Guide to Crafting Gems
-  raw_title: Rails Conf 2013 Crafting Gems by Pat Allen
+  raw_title: Rails Conf 2013 Crafting Gems by Pat Allan
   speakers:
-    - Pat Allen
+    - Pat Allan
   event_name: RailsConf 2013
   thumbnail_xs: https://i.ytimg.com/vi/Mmm1cVvPEYU/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/Mmm1cVvPEYU/mqdefault.jpg

--- a/data/railsconf/railsconf-2014/videos.yml
+++ b/data/railsconf/railsconf-2014/videos.yml
@@ -667,9 +667,9 @@
   video_id: "-q_oUyEHiEw"
 
 - title: Tricks That Rails Didn't Tell You About
-  raw_title: RailsConf 2014 - Tricks That Rails Didn't Tell You About by Carlos Antionio da Silva
+  raw_title: RailsConf 2014 - Tricks That Rails Didn't Tell You About by Carlos Antonio da Silva
   speakers:
-    - Carlos Antionio da Silva
+    - Carlos Antonio da Silva
   event_name: RailsConf 2014
   thumbnail_xs: https://i.ytimg.com/vi/YKm0v_weFZs/default.jpg
   thumbnail_sm: https://i.ytimg.com/vi/YKm0v_weFZs/mqdefault.jpg

--- a/data/rocky-mountain-ruby/rocky-mountain-ruby-2012/videos.yml
+++ b/data/rocky-mountain-ruby/rocky-mountain-ruby-2012/videos.yml
@@ -65,7 +65,7 @@
     - Mike Gehard
     - Elain Marina
     - Jim Denton
-    - Tom Frei
+    - Thomas Frey
   event_name: Rocky Mountain Ruby 2012
   published_at: '2012-10-26'
   description: There is a shortage of software developers today. Programs like CodeAcademy,

--- a/data/rubyconf/rubyconf-2018/videos.yml
+++ b/data/rubyconf/rubyconf-2018/videos.yml
@@ -735,7 +735,7 @@
     - Jamie Gaskins
     - Aja Hammerly
     - Isaac Sloan
-    - Zackary Schroder
+    - Zachary Schroeder
     - Junichi Ito
     - Tom Black
     - Quinn Stearns
@@ -759,7 +759,7 @@
     00:38:03 Jamie Gaskins
     00:42:14 Aja Hammerly
     00:45:47 Isaac Sloan
-    00:50:45 Zackary Schroder
+    00:50:45 Zachary Schroeder
     00:55:49 Junichi Ito
     01:00:40 Tom Black
     01:05:40 Quinn Stearns

--- a/data/rubyconf/rubyconf-2022/videos.yml
+++ b/data/rubyconf/rubyconf-2022/videos.yml
@@ -541,9 +541,9 @@
   video_id: _UFE0t2Sgaw
 
 - title: 'Data indexing with RGB (Ruby, Graphs and Bitmaps)'
-  raw_title: 'RubyConf 2022: Data indexing with RGB (Ruby, Graphs and Bitmaps) by Benjamin Lewis'
+  raw_title: 'RubyConf 2022: Data indexing with RGB (Ruby, Graphs and Bitmaps) by Benji Lewis'
   speakers:
-    - Benjamin Lewis
+    - Benji Lewis
   event_name: RubyConf 2022
   published_at: '2023-03-06'
   description: In this talk, we will go on a journey through Zappi’s data history

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -1807,11 +1807,11 @@
   canonical_slug:
 - name: Benjamin Lewis
   twitter: ""
-  github: benjaminhawkeslewis
+  github: BenjiLewis
   bio: ""
   website: ""
   slug: benjamin-lewis
-  canonical_slug:
+  canonical_slug: banji-lewis
 - name: Benjamin Roth
   twitter: ""
   github: apneadiving

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -14912,13 +14912,6 @@
   website: http://hcaz.me.uk
   slug: zachary-scott
   canonical_slug:
-- name: Zackary Schroder
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: zackary-schroder
-  canonical_slug:
 - name: Zahary Karadjov
   twitter: ""
   github: ""

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -5919,7 +5919,7 @@
   bio: ""
   website: http://graysoftinc.com/
   slug: james-edward-gray
-  canonical_slug:
+  canonical_slug: james-edward-gray-ii
 - name: James Edward Gray II
   twitter: ""
   github: JEG2

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -1592,13 +1592,6 @@
   website: https://austio.com
   slug: austin-story
   canonical_slug:
-- name: Avdi Grim
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: avdi-grim
-  canonical_slug:
 - name: Avdi Grimm
   twitter: avdi
   github: avdi

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -1085,6 +1085,13 @@
   website: ""
   slug: andrew-radev
   canonical_slug:
+- name: Andrew Shafer
+  twitter: ""
+  github: littleidea
+  bio: ""
+  website: ""
+  slug: andrew-shafer
+  canonical_slug:
 - name: Andrew Turley
   twitter: ""
   github: ""

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -10943,7 +10943,7 @@
   bio: ""
   website: ""
   slug: panayiotis-thomakos
-  canonical_slug:
+  canonical_slug: pan-thomakos
 - name: Paolo "Nusco" Perrotta
   twitter: ""
   github: nusco

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -2352,13 +2352,6 @@
   website: https://calebden.io
   slug: caleb-denio
   canonical_slug:
-- name: Caleb Heart
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: caleb-heart
-  canonical_slug:
 - name: Caleb Hearth
   twitter: ""
   github: calebhearth

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -2424,13 +2424,6 @@
   website: carlastabile.tech
   slug: carla-urrea-stabile
   canonical_slug:
-- name: Carlos Antionio da Silva
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: carlos-antionio-da-silva
-  canonical_slug:
 - name: Carlos Antonio Da Silva
   twitter: cantoniodasilva
   github: carlosantoniodasilva

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -13905,7 +13905,7 @@
   bio: ""
   website: ""
   slug: tom-e-enebo
-  canonical_slug:
+  canonical_slug: thomas-e-enebo
 - name: Tom Frei
   twitter: ""
   github: ""

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -10983,15 +10983,6 @@
   website: https://freelancing-gods.com
   slug: pat-allan
   canonical_slug:
-- name: Pat Allen
-  twitter: layer8packet
-  github: pallen182
-  bio:
-    Network guy trying to learn some coding to help build new/better skills. Host
-    of Breaking Down the Bytes Podcast. Here to learn.
-  website: https://breakingbytespod.io
-  slug: pat-allen
-  canonical_slug:
 - name: Pat Nakajima
   twitter: ""
   github: ""

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -9690,13 +9690,6 @@
   website: ""
   slug: melanie-keatley
   canonical_slug:
-- name: Melanie Keatley # Magic Solution to the Tech Gender Gap (18:22)
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: melanie-keatley-magic-solution-to-the-tech-gender-gap-18-22
-  canonical_slug:
 - name: Melinda Seckington
   twitter: ""
   github: ""

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -2028,13 +2028,6 @@
   website: http://brblck.com
   slug: brandon-black
   canonical_slug:
-- name: Brandon Hayes
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: brandon-hayes
-  canonical_slug:
 - name: Brandon Hays
   twitter: ""
   github: tehviking


### PR DESCRIPTION
I spotted some speaker issues with wrong attribution or duplicate versions, so this PR fixes a bunch.

TBH I just eyeballed the [speakers page](https://www.rubyvideo.dev/speakers) and spotted a few discrepancies.  I suspect there's a bunch more if you go digging (particularly with things like how people typically style their names vs longer or shorter versions).

Probably easiest to look commit by commit in the off chance you disagree with any particular changes (e.g. I have removed people from `speakers.yml` if I've merged them - maybe that's not right?).