### PR TITLE
Rename conferences so they sort alphabetically

### DIFF
--- a/data/rubyconf/playlists.yml
+++ b/data/rubyconf/playlists.yml
@@ -87,7 +87,7 @@
   slug: rubyconf-2021
 
 - id: PLE7tQUdRKcyZYz0O3d9ZDdo0-BkOWhrSk
-  title: "RubyConf Mini 2022"
+  title: "RubyConf 2022 Mini"
   description: RubyConf Mini held in Providence, RI
   published_at: "2023-02-28"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ

--- a/data/rubyconf/rubyconf-2022-mini/videos.yml
+++ b/data/rubyconf/rubyconf-2022-mini/videos.yml
@@ -2,7 +2,7 @@
   raw_title: "RubyConf Mini 2022: Weaving and seaming mocks by Vladimir Dementyev"
   speakers:
     - Vladimir Dementyev
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     To mock or not mock is an important question, but let's leave it apart and admit that we, Rubyists, use mocks in our tests.
@@ -16,7 +16,7 @@
   raw_title: "RubyConf Mini 2022: Here Be Dragons: The Hidden Gems of Tech Debt by Ernesto Tagwerker"
   speakers:
     - Ernesto Tagwerker
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   slides_url: https://speakerdeck.com/etagwerker/here-be-dragons-the-hidden-gems-of-technical-debt
   description: |-
@@ -29,7 +29,7 @@
   raw_title: "RubyConf Mini 2022: Looking Into Peephole Optimizations by Maple Ong"
   speakers:
     - Maple Ong
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Did you know Ruby optimizes your code before executing it? If so, ever wonder how that works? The Ruby VM performs various optimizations on bytecode before executing them, one of them called peephole optimizations. Let’s learn about how some peephole optimizations work and how these small changes impact the execution of Ruby’s bytecode. Do these small changes make any impact on the final runtime? Let's find out - experience reading bytecode is not needed!
@@ -39,7 +39,7 @@
   raw_title: "RubyConf Mini: How We Implemented Salary Transparency (And Why It Matters) by Hilary Stohs Krause"
   speakers:
     - Hilary Stohs-Krause
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Depending on where you live, money can be a prickly topic in the workplace; however, survey after survey shows it’s also a conversation many employees actively want started. Data also shows that transparency around wages increases trust and job satisfaction and improves gender and racial salary equity.
@@ -52,7 +52,7 @@
   speakers:
     - Chelsea Kaufman
     - Adam Cuppy
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Starting an internship doesn’t have to reduce your team's progress. On the contrary, a quality internship can benefit interns and senior folks. And, it doesn't take much to set up and start. We've done over 100!
@@ -64,7 +64,7 @@
   raw_title: "RubyConf Mini 2022: Knowing When To Walk Away by Lindsay Kelly"
   speakers:
     - Lindsay Kelly
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Picture this: the job you've always wanted. Doing exactly the kind of work you want. Having great coworkers and management. But then something shifts, and the dream becomes closer to a nightmare. How do you identify these things happening? How do you raise concerns in an appropriate way? And as a last resort, how do you know when it's the right choice to walk away?
@@ -74,7 +74,7 @@
   raw_title: "RubyConf Mini 2022: Functional programming for fun and profit!! by Jenny Shih"
   speakers:
     - Jenny Shih
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Functional programming brings you not just fun, but also profit!
@@ -88,7 +88,7 @@
   raw_title: "RubyConf Mini 2022: Teaching Ruby to Count by Joël Quenneville"
   speakers:
     - Joël Quenneville
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   slides_url: https://speakerdeck.com/joelq/teaching-ruby-to-count
   description: |-
@@ -102,7 +102,7 @@
   speakers:
     - Alan Ridlehoover
     - Fito von Zastrow
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Mechanical coffee machines are amazing! You drop in a coin, listen for the clink, make a selection, and the machine springs to life, hissing, clicking, and whirring. Then the complex mechanical ballet ends, splashing that glorious, aromatic liquid into the cup. Ah! C’est magnifique!
@@ -114,7 +114,7 @@
   raw_title: "RubyConf Mini 2022: We Need Someone Technical on the Call by Brittany Martin"
   speakers:
     - Brittany Martin
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     A DM. The dreaded message. “They want someone technical on the call.”
@@ -126,7 +126,7 @@
   raw_title: "RubyConf Mini 2022: Making .is_a? Fast by John Hawthorn"
   speakers:
     - John Hawthorn
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Until Ruby 3.2 the `is_a?` method can be a surprising performance bottleneck. It be called directly or through its various synonyms like case statements, rescue statements, protected methods, `Module#===` and more! Recently `is_a?` and its various flavours have been optimized and it's now faster and runs in constant time. Join me in the journey of identifying it as a bottleneck in production, implementing the optimization, squashing bugs, and finally turning it into assembly language in YJIT.
@@ -136,7 +136,7 @@
   raw_title: "RubyConf Mini 2022: From Start to Published, Create a game with Ruby! by Cameron Gose"
   speakers:
     - Cameron Gose
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: We'll be building a game in Ruby from start to finish using the DragonRuby GameToolkit. Finally we'll publish it so that your new creation can be shared.
   video_id: -dz9KGYMT24
@@ -145,7 +145,7 @@
   raw_title: "RubyConf Mini 2022: Anyone Can Play Guitar (With Ruby) by Kevin Murphy"
   speakers:
     - Kevin Murphy
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     I've got the blues. I've been looking for the perfect guitar tone, but haven't found it. To amp up my mood, let's teach a computer to play the guitar through an amplifier.
@@ -158,7 +158,7 @@
   speakers:
     - Rose Wiegley
     - Ufuk Kayserilioglu
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: Curious about Shopify’s relationship with Ruby? Got questions on projects Shopify Ruby on Rails Engineers are currently working on? Join Rose Wiegley (Sr Staff Developer), Ufuk Kayserilioglu (Production Engineering Manager), and other Shopify Engineers for a 30-minute office hours session dedicated to answering your questions on Ruby, Shopify’s relationship with Ruby, and life at Shopify!
   video_id: 37DkMimLG4A
@@ -167,7 +167,7 @@
   raw_title: "RubyConf Mini 2022: Keynote: Learning DNS by Julia Evans"
   speakers:
     - Julia Evans
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: ""
   video_id: HoG2T0aJvfY
@@ -176,7 +176,7 @@
   raw_title: "RubyConf Mini 2022: Zen and the Art of Incremental Automation by Aji Slater"
   speakers:
     - Aji Slater
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Automation doesn’t have to be all or nothing. Automating manual processes is a practice that one can employ via simple principles. Broad enough to be applied to a range of workflows, flexible enough to be tailored to an individual’s personal development routines; these principles are not in themselves complex, and can be performed regularly in the day to day of working in a codebase.
@@ -187,7 +187,7 @@
   raw_title: "RubyConf Mini 2022: Syntax Tree by Kevin Newton"
   speakers:
     - Kevin Newton
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: Syntax Tree is a new toolkit for interacting with the Ruby parse tree. It can be used to analyze, inspect, debug, and format your Ruby code. In this talk we'll walk through how it works, how to use it in your own applications, and the exciting future possibilities enabled by Syntax Tree.
   video_id: Ieq6SKtYJD4
@@ -201,7 +201,7 @@
     - Keith Bennett # Coding with RUby
     - # Jo Ha TODO: double-check name # Church Numerals
     - Max Wofford # Whimsical Features & Junior Developers
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: ""
   video_id: IfzO_yyiYmw
@@ -210,7 +210,7 @@
   raw_title: "RubyConf Mini 2022: Keynote by Barbara Tannenbaum"
   speakers:
     - Barbara Tannenbaum
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: ""
   video_id: JpimJspmess
@@ -219,7 +219,7 @@
   raw_title: "RubyConf Mini 2022: Solo: Building Successful Web Apps By Your Lonesome by Jeremy Smith"
   speakers:
     - Jeremy Smith
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   slides_url: https://speakerdeck.com/jeremysmithco/solo-building-successful-web-apps-by-your-lonesome
   description: |-
@@ -230,7 +230,7 @@
   raw_title: "RubyConf Mini 2022: Empathetic Pair Programming with Nonviolent Communication by Stephanie Minn"
   speakers:
     - Stephanie Minn
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: "2023-02-28"
   description: |-
     Pair programming is intimate. It’s the closest collaboration we do as software developers. When it goes well, it feels great! But when it doesn’t, you might be left feeling frustrated, discouraged, or withdrawn.
@@ -246,7 +246,7 @@
     - Ryan Laughlin
     - Ufuk Kayserilioglu
     - Someone at Shopify
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: ''
   video_id: exxUz9k03s4
@@ -259,7 +259,7 @@
     - Drew Bragg
     - Joël Quenneville
     - Andy Croll
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: ''
   video_id: gOq7PJ-0ngA
@@ -268,7 +268,7 @@
   raw_title: 'RubyConf Mini 2022: Who Wants to be a Ruby Engineer? by Drew Bragg'
   speakers:
     - Drew Bragg
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: 'Welcome to the Ruby game show where one lucky contestant tries to
     guess the output of a small bit of Ruby code. Sound easy? Here''s the challenge:
@@ -281,7 +281,7 @@
   raw_title: 'RubyConf Mini 2022: TDD on the Shoulders of Giants by Jared Norman'
   speakers:
     - Jared Norman
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: Getting started with TDD is hard enough without having to also navigate
     a programming language barrier. Many of the best books on testing focus on very
@@ -297,7 +297,7 @@
   raw_title: 'RubyConf Mini 2022: Crystal for Rubyists by Kirk Haines'
   speakers:
     - Kirk Haines
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: Crystal is a Ruby-like compiled language that was originally built
     using Ruby. Its syntax is remarkably similar to Ruby's, which generally makes
@@ -311,7 +311,7 @@
   raw_title: 'RubyConf Mini 2022: RubyGems.org MFA: The Past, Present and Future by Jenny Shen'
   speakers:
     - Jenny Shen
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: "What do Ruby’s rest-client, Python’s ctx, and npm’s ua-parser-js have
     in common? \n\nThey all suffered account takeovers that were preventable. Attackers
@@ -327,7 +327,7 @@
   raw_title: 'RubyConf Mini 2022: The Case Of The Vanished Variable - A Ruby Mystery Story by Nadia Odunayo'
   speakers:
     - Nadia Odunayo
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: After a stressful couple of days at work, Deirdre Bug is looking forward
     to a quiet evening in. But her plans are thwarted when the phone rings. “I know
@@ -342,7 +342,7 @@
   raw_title: 'RubyConf Mini 2022: Splitwise Sponsor Session: Declare Victory with Class Macros by Jess Hottenstein'
   speakers:
     - Jess Hottenstein
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: |-
     How can we write classes that are easy to understand? How can we write Ruby in a declarative way? How can we use metaprogramming without introducing chaos?
@@ -354,7 +354,7 @@
   raw_title: 'RubyConf Mini 2022: Keynote by Rose Wiegley'
   speakers:
     - Rose Wiegley
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: ''
   video_id: c_HhfehMBHE
@@ -363,7 +363,7 @@
   raw_title: 'RubyConfMini 2022: The Three-Encoding Problem by Kevin Menard'
   speakers:
     - Kevin Menard
-  event_name: RubyConf Mini 2022
+  event_name: RubyConf 2022 Mini
   published_at: '2023-02-28'
   description: You’ve probably heard of UTF-8 and know about strings, but did you
     know that Ruby supports more than 100 other encodings? In fact, your application

--- a/data/rubykaigi/playlists.yml
+++ b/data/rubykaigi/playlists.yml
@@ -58,7 +58,7 @@
   slug: rubykaigi-2019
 
 - id: PLbFmgWm555yZeLpdOLhYwORIF9UjBAFHw
-  title: RubyKaigi Takeout 2020
+  title: RubyKaigi 2020 Takeout
   description: https://rubykaigi.org/2020-takeout
   published_at: '2020-09-03'
   channel_id: UCBSg5zH-VFJ42BGQFk4VH2A
@@ -68,7 +68,7 @@
   slug: rubykaigi-2020
 
 - id: PLbFmgWm555yYgc4sx2Dkb7WWcfflbt6AP
-  title: RubyKaigi Takeout 2021
+  title: RubyKaigi 2021 Takeout
   description: ''
   published_at: '2021-09-11'
   channel_id: UCBSg5zH-VFJ42BGQFk4VH2A

--- a/data/rubykaigi/rubykaigi-2020/videos.yml
+++ b/data/rubykaigi/rubykaigi-2020/videos.yml
@@ -3,7 +3,7 @@
   raw_title: "[EN] The State of Ruby 3 Typing / Soutaro Matsumoto @soutaro"
   speakers:
     - Soutaro Matsumoto
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: PvkpW1OEaP8
   language: English
@@ -18,7 +18,7 @@
   raw_title: "[EN] The whys and hows of transpiling Ruby / Vladimir Dementyev @palkan_tula"
   speakers:
     - Vladimir Dementyev
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: zLInIisYlDo
   language: English
@@ -34,7 +34,7 @@
   raw_title: "[EN] Reflecting on Ruby Reflection for Rendering RBIs / Ufuk Kayserilioglu @paracycle"
   speakers:
     - Ufuk Kayserilioglu
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: OJRQAn6BfpE
   language: English
@@ -47,7 +47,7 @@
   raw_title: "[EN] Is it time run Ruby on Web via WebAssembly? / 蒼時弦也 @elct9620"
   speakers:
     - elct9620
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: PJLWoz6K7w4
   language: English
@@ -62,7 +62,7 @@
   raw_title: "[EN] mruby machine: An Operating System for Microcontoller / Hitoshi HASUMI @hasumikin"
   speakers:
     - Hitoshi HASUMI
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: kDOf_tZKlLU
   language: English
@@ -75,7 +75,7 @@
   raw_title: "[EN] Keyword Arguments: Past, Present, and Future / Jeremy Evans @jeremyevans0"
   speakers:
     - Jeremy Evans
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: rxJRrccXRfg
   language: English
@@ -90,7 +90,7 @@
   raw_title: "[EN] Live coding: Grepping Ruby code like a boss / Jônatas Davi Paganini @jonatas"
   speakers:
     - Jônatas Davi Paganini
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: YczrZQC9aP8
   language: English
@@ -104,7 +104,7 @@
   raw_title: "[EN] Now is the time to create your own (m)Ruby computer / Katsuhiko Kageyama @kishima"
   speakers:
     - Katsuhiko Kageyama
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: N24gfQJMXfs
   language: English
@@ -116,7 +116,7 @@
   raw_title: "[JA] Asynchronous Opal / Yoh Osaki @youchan"
   speakers:
     - Yoh Osaki
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: yDUmMuPdSUA
   language: Japanese
@@ -133,7 +133,7 @@
   raw_title: "[JA] Rinda in the real-world embedded systems / Masatoshi SEKI @m_seki"
   speakers:
     - Masatoshi SEKI
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: qwe6qmtxHbk
   language: Japanese
@@ -147,7 +147,7 @@
   raw_title: "[EN] mruby-rr: Time Traveling Debugger For mruby Using rr / Lin Yu Hsiang @johnlinvc"
   speakers:
     - Lin Yu Hsiang
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: E5ifh9yZCKk
   language: English
@@ -160,7 +160,7 @@
   raw_title: "[EN] Developing your Dreamcast apps and games with mruby / Yuji Yokoo @yuji_yokoo"
   speakers:
     - Yuji Yokoo
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: oqBTlYUkGXk
   language: English
@@ -173,7 +173,7 @@
   raw_title: "[EN] Don't @ me! Instance Variable Performance in Ruby / Aaron Patterson @tenderlove"
   speakers:
     - Aaron Patterson
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: 4ysxA8DDplQ
   language: English
@@ -187,7 +187,7 @@
   raw_title: "[JA] Don't @ me! Instance Variable Performance in Ruby / Aaron Patterson @tenderlove"
   speakers:
     - Aaron Patterson
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: iDW93fAp2I8
   language: Japanese
@@ -201,7 +201,7 @@
   raw_title: "[JA] Ruby to C Translator by AI / Hideki Miura @miura1729"
   speakers:
     - Hideki Miura
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: kr2RXLoiLNA
   language: Japanese
@@ -216,7 +216,7 @@
   raw_title: "[EN] The Complex Nightmare of the Asian Cultural Area / ITOYANAGI Sakura @aycabta"
   speakers:
     - ITOYANAGI Sakura
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: s7Zc7VJMBv8
   language: English
@@ -229,7 +229,7 @@
   raw_title: "[JA] Dependency Resolution with Standard Libraries"
   speakers:
     - Hiroshi Shibata
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: wvayhyTEL_k
   language: Japanese
@@ -242,7 +242,7 @@
   raw_title: "[JA] msgraph: Microsoft Graph API Client with Ruby / ODA Hirohito @jimlock"
   speakers:
     - ODA Hirohito
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: TrVhnrTPtoI
   language: Japanese
@@ -255,7 +255,7 @@
   raw_title: "[JA] Magic is organizing chaos / Shugo Maeda @shugomaeda"
   speakers:
     - Shugo Maeda
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: QKiQiK7gSHQ
   language: Japanese
@@ -268,7 +268,7 @@
   raw_title: '[JA Keynote] Ruby3 and Beyond / Yukihiro "Matz" Matsumoto @yukihiro_matz'
   speakers:
     - Yukihiro "Matz" Matsumoto
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: wVrJZReHlM8
   language: Japanese
@@ -278,7 +278,7 @@
   raw_title: "[JA] Road to RuboCop 1.0 / Koichi ITO @koic"
   speakers:
     - Koichi ITO
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: jkY7J9k6mHs
   language: Japanese
@@ -293,7 +293,7 @@
   raw_title: "[JA] Goodbye fat gem / Sutou Kouhei @ktou"
   speakers:
     - Sutou Kouhei
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: tGZiCqyMU_g
   language: Japanese
@@ -310,7 +310,7 @@
   raw_title: "[JA] On sending methods / Urabe, Shyouhei @shyouhei"
   speakers:
     - Urabe Shyouhei
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: IAkrGf9XJi0
   language: Japanese
@@ -323,7 +323,7 @@
   raw_title: "[JA] Type Profiler: a Progress Report of a Ruby 3 Type Analyzer / Yusuke Endoh @mametter"
   speakers:
     - Yusuke Endoh
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: 6KcFdQWp8W0
   language: Japanese
@@ -341,7 +341,7 @@
   raw_title: "[JA] Ractor report / Koichi Sasada @ko1"
   speakers:
     - Koichi Sasada
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: 40t8EPpnujg
   language: Japanese
@@ -354,7 +354,7 @@
   raw_title: "[EN] Running Rack and Rails Faster with TruffleRuby / Benoit Daloze @eregontp"
   speakers:
     - Benoit Daloze
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: 281YdMYRAsk
   language: English
@@ -367,7 +367,7 @@
   raw_title: "[EN] RubyMem: The Leaky Gems Database for Bundler / Ernesto Tagwerker @etagwerker"
   speakers:
     - Ernesto Tagwerker
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   slides_url: https://speakerdeck.com/etagwerker/rubymem-the-leaky-gems-database-for-bundler-at-ruby-kaigi-takeout-2020
   video_id: ghaA6LD5OEo
@@ -381,7 +381,7 @@
   raw_title: "[EN] Prettier Ruby / Kevin Deisz @kddeisz"
   speakers:
     - Kevin Newton
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: 3945FmGGHhw
   language: English
@@ -394,7 +394,7 @@
   raw_title: "[EN] Don't Wait For Me! Scalable Concurrency for Ruby 3! / Samuel Williams @ioquatix"
   speakers:
     - Samuel Williams
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: Y29SSOS4UOc
   language: English
@@ -412,7 +412,7 @@
   raw_title: Ruby committers vs the World - Day 1 (extended)
   speakers:
     - Ruby Committers # TODO: list each person
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: D-AK1x4vuRU
   language:
@@ -422,7 +422,7 @@
   raw_title: Ruby committers vs the World - Day 2
   speakers:
     - Ruby Committers # TODO: list each person
-  event_name: RubyKaigi Takeout 2020
+  event_name: RubyKaigi 2020 Takeout
   published_at: "2020-09-04"
   video_id: 20VDvtpjGn0
   language:

--- a/data/rubykaigi/rubykaigi-2021/videos.yml
+++ b/data/rubykaigi/rubykaigi-2021/videos.yml
@@ -3,7 +3,7 @@
   raw_title: "[JA] How to develop the Standard Libraries of Ruby? / Hiroshi SHIBATA @hsbt"
   speakers:
     - Hiroshi SHIBATA
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: 0yZ2fle1zTo
   language: Japanese
@@ -18,7 +18,7 @@
   raw_title: "[JA] Toycol: Define your own application protocol / Misaki Shioi @shioimm"
   speakers:
     - Misaki Shioi
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: zfuYguzvlbg
   language: Japanese
@@ -35,7 +35,7 @@
   raw_title: "[EN] Do regex dream of Turing Completeness? / Daniel Magliola @dmagliola"
   speakers:
     - Daniel Magliola
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: hkDZCFBlD5Q
   language: English
@@ -52,7 +52,7 @@
   raw_title: "[EN] Optimizing Partial Backtraces in Ruby 3 / Jeremy Evans @jeremyevans"
   speakers:
     - Jeremy Evans
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: QDbj4Y0E5xo
   language: English
@@ -66,7 +66,7 @@
   speakers:
     - Masatoshi SEKI
     - Tatsuya Sonokawa
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: kkXKHPRxeyM
   language: Japanese
@@ -82,7 +82,7 @@
   raw_title: "[EN] It is time to build your mruby VM on the microcontroller? / 蒼時弦也 @elct9620"
   speakers:
     - elct9620
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: IqZW3i7HbmY
   language: English
@@ -95,7 +95,7 @@
   raw_title: "[EN] Regular Expressions: Amazing and Dangerous / Martin J. Dürst @duerst"
   speakers:
     - Martin J. Dürst
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: bLzUiOm97Ps
   language: English
@@ -109,7 +109,7 @@
   speakers:
     - Peter Zhu
     - Matt Valentine-House
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: 7C3bdT6Ri2Q
   language: English
@@ -125,7 +125,7 @@
   raw_title: "[EN] 10 years of Ruby-powered citizen science / Mat Schaffer @matschaffer"
   speakers:
     - Mat Schaffer
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: Jg8PY00HDnA
   language: English
@@ -140,7 +140,7 @@
   raw_title: "[EN] YJIT - Building a new JIT Compiler inside CRuby / Maxime Chevalier-Boisvert @maximecb"
   speakers:
     - Maxime Chevalier-Boisvert
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: PBVLf3yfMs8
   language: English
@@ -153,7 +153,7 @@
   raw_title: "[EN] Graphical Terminal User Interface of Ruby 3.1 / ITOYANAGI Sakura @aycabta"
   speakers:
     - ITOYANAGI Sakura
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: xLeLW-p43bc
   language: English
@@ -168,7 +168,7 @@
   raw_title: "[EN] Why Ruby's JIT was slow / Takashi Kokubun @k0kubun"
   speakers:
     - Takashi Kokubun
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: db3GHHllRyQ
   language: English
@@ -185,7 +185,7 @@
   raw_title: "[JA] Why Ruby's JIT was slow / Takashi Kokubun @k0kubun"
   speakers:
     - Takashi Kokubun
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: rE5OucBHm18
   language: Japanese
@@ -202,7 +202,7 @@
   raw_title: "[JA] The Art of Execution Control for Ruby's Debugger / Koichi Sasada @ko1"
   speakers:
     - Koichi Sasada
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: tfXiL5wDA6Q
   language: Japanese
@@ -225,7 +225,7 @@
   raw_title: "[JA][Keynote] TypeProf for IDE: Enrich Dev-Experience without Annotations / Yusuke Endoh @mame"
   speakers:
     - Yusuke Endoh
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: uNttp63ELoE
   language: Japanese
@@ -238,7 +238,7 @@
   raw_title: "[EN] Building Native Extensions. This Could Take A While... / Mike Dalessio @flavorjones"
   speakers:
     - Mike Dalessio
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: oktN_CbOJKc
   language: English
@@ -253,7 +253,7 @@
   raw_title: "[EN] Parsing Ruby / Kevin Newton @kddnewton"
   speakers:
     - Kevin Newton
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: ijPE7k7iW8I
   language: English
@@ -266,7 +266,7 @@
   raw_title: "[EN] Ruby Archaeology / Nick Schwaderer @schwad"
   speakers:
     - Nick Schwaderer
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: qv4XniFPapQ
   language: English
@@ -287,7 +287,7 @@
   raw_title: "[EN][Keynote] The Future Shape of Ruby Objects / Chris Seaton @chrisseaton"
   speakers:
     - Chris Seaton
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: RqwVEw-Rd5c
   language: English
@@ -300,7 +300,7 @@
   raw_title: "[EN] Demystifying DSLs for better analysis and understanding / Ufuk Kayserilioglu @paracycle"
   speakers:
     - Ufuk Kayserilioglu
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: Ms7_PrryvMM
   language: English
@@ -315,7 +315,7 @@
   raw_title: "[EN] Parallel testing with Ractors: putting CPUs to work / Vinicius Stock @vinistock"
   speakers:
     - Vinicius Stock
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: bvFj6_dulSo
   language: English
@@ -330,7 +330,7 @@
   raw_title: "[JA] The newsletter of RBS updates / Masataka Kuwabara @pocke"
   speakers:
     - Masataka Kuwabara
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: AwuSHC6j-48
   language: Japanese
@@ -345,7 +345,7 @@
   raw_title: '[EN] Ractor''s speed is not light-speed / Satoshi "moris" Tagomori @tagomoris'
   speakers:
     - Satoshi "moris" Tagomori
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: TR_3xFPCGO8
   language: English
@@ -359,7 +359,7 @@
   speakers:
     - Benoit Daloze
     - Josef Haider
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: DYPCkR7Ngx8
   language: English
@@ -375,7 +375,7 @@
   raw_title: "[JA] Red Arrow - Ruby and Apache Arrow / Sutou Kouhei @kou"
   speakers:
     - Sutou Kouhei
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: okXiuYiP2C4
   language: Japanese
@@ -392,7 +392,7 @@
   raw_title: "[JA] Charty: Statistical data visualization in Ruby / Kenta Murata @mrkn"
   speakers:
     - Kenta Murata
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: iHOWyQt4y-Q
   language: Japanese
@@ -407,7 +407,7 @@
   raw_title: "[JA] RuboCop in 2021: Stable and Beyond / Koichi ITO @koic"
   speakers:
     - Koichi ITO
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: yJF5EKM_zPw
   language: Japanese
@@ -424,7 +424,7 @@
   raw_title: "[EN] Beware the Dead End!! / Richard Schneeman @schneems"
   speakers:
     - Richard Schneeman
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: oL_yxJN8534
   language: English
@@ -437,7 +437,7 @@
   raw_title: "[JA] Falling down from FreeBSD / やもり @yamori813"
   speakers:
     - yamori813
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: JvFCljZeF1w
   language: Japanese
@@ -450,7 +450,7 @@
   raw_title: '[JA] Matz Keynote / Yukihiro "Matz" Matsumoto @matz'
   speakers:
     - Yukihiro "Matz" Matsumoto
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: QQASprf5EGw
   language: Japanese
@@ -460,7 +460,7 @@
   raw_title: "[JA] PRK Firmware: Keyboard is Essentially Ruby / Hitoshi HASUMI @hasumikin"
   speakers:
     - Hitoshi HASUMI
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: 5unMW_BAd4A
   language: Japanese
@@ -477,7 +477,7 @@
   raw_title: Ruby Committers vs the World / CRuby Committers @rubylangorg
   speakers:
     - Ruby Committers # TODO: list each person
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: zQnN1pqK4FQ
   language:
@@ -490,7 +490,7 @@
   raw_title: "[JA] Ruby, Ractor, QUIC / Yusuke Nakamura @unasuke"
   speakers:
     - Yusuke Nakamura
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: 9da7QccHXV4
   language: Japanese
@@ -503,7 +503,7 @@
   raw_title: "[JA] Dive into Encoding / Mari Imaizumi @ima1zumi"
   speakers:
     - Mari Imaizumi
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: 9PA6twS9Oq4
   language: Japanese
@@ -516,7 +516,7 @@
   raw_title: "[EN] Crafting exploits, tools and havoc with Ruby / Mauro Eldritch @MauroEldritch"
   speakers:
     - Mauro Eldritch
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: LIECErdtTDc
   language: English
@@ -535,7 +535,7 @@
   raw_title: '[EN] Story of Rucy - How to "compile" a BPF binary from Ruby / Uchio KONDO @udzura'
   speakers:
     - Uchio KONDO
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: qvaXv8exFFQ
   language: English
@@ -556,7 +556,7 @@
   raw_title: "[JA] Use Macro all the time ~ マクロを使いまくろ ~ / osyo @osyo-manga"
   speakers:
     - osyo
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: w2B99qYrkX8
   language: Japanese
@@ -573,7 +573,7 @@
   raw_title: "[JA] include/prepend in refinements should be prohibited / Shugo Maeda @shugo"
   speakers:
     - Shugo Maeda
-  event_name: RubyKaigi Takeout 2021
+  event_name: RubyKaigi 2021 Takeout
   published_at: "2021-09-09"
   video_id: b4ls7Y_vZMg
   language: Japanese


### PR DESCRIPTION
| RubyKaigi Before|
| --- |
| ![CleanShot 2024-10-24 at 00 57 00](https://github.com/user-attachments/assets/2e192a06-57a5-4402-b6bf-75f9da7706b5) |

| RubyKaigi After|
| --- |
| ![CleanShot 2024-10-24 at 01 01 35](https://github.com/user-attachments/assets/f7240aad-5712-4d00-b1d2-3e687feb17f1) |

---

| RubyConf Before |
| --- |
| ![CleanShot 2024-10-24 at 00 58 59](https://github.com/user-attachments/assets/037969a4-47f7-47b8-9b18-35a7309ceaac) |

| RubyConf After|
| --- |
| ![CleanShot 2024-10-24 at 01 01 23](https://github.com/user-attachments/assets/e7d24ce3-62c5-4b6a-be12-92a8d5f69dbd) |