### PR TITLE
Allow everyone to suggest any field on a speaker

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -59,7 +59,7 @@ class SpeakersController < ApplicationController
   end
 
   def speaker_params
-    params.require(:speaker).permit(:name, :twitter, :github, :bio, :website, :speakerdeck, :pronouns_type, :pronouns)
+    params.require(:speaker).permit(:name, :twitter, :github, :bio, :website, :speakerdeck, :pronouns_type, :pronouns, :slug)
   end
 
   def set_user_favorites

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -59,12 +59,7 @@ class SpeakersController < ApplicationController
   end
 
   def speaker_params
-    {
-      anonymous: params.require(:speaker).permit(:github, :pronouns_type, :pronouns),
-      signed_in: params.require(:speaker).permit(:github, :pronouns_type, :pronouns),
-      owner: params.require(:speaker).permit(:name, :twitter, :bio, :website, :speakerdeck, :pronouns_type, :pronouns),
-      admin: params.require(:speaker).permit(:name, :twitter, :github, :bio, :website, :speakerdeck, :pronouns_type, :pronouns)
-    } [user_kind]
+    params.require(:speaker).permit(:name, :twitter, :github, :bio, :website, :speakerdeck, :pronouns_type, :pronouns)
   end
 
   def set_user_favorites

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -72,7 +72,7 @@ class Speaker < ApplicationRecord
   end
 
   def create_suggestion_from(params:, user: Current.user)
-    if (params.keys.include?("github") || params.keys.include?("slug")) && managed_by?(self.user)
+    if (params.key?("github") || params.key?("slug")) && managed_by?(self.user)
       slug = params["slug"]
       github = params["github"]
 
@@ -85,11 +85,9 @@ class Speaker < ApplicationRecord
       suggestion = suggestions.create(content: content, suggested_by_id: user&.id)
 
       return suggestion if params.keys.none?
-
-      super(params:, user:)
-    else
-      super
     end
+
+    super
   end
 
   def github_avatar_url(size: 200)

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -71,6 +71,27 @@ class Speaker < ApplicationRecord
     user == visiting_user
   end
 
+  def create_suggestion_from(params:, user: Current.user)
+    if (params.keys.include?("github") || params.keys.include?("slug")) && managed_by?(self.user)
+      slug = params["slug"]
+      github = params["github"]
+
+      content = {}
+      content["slug"] = slug if slug
+      content["github"] = github if github
+
+      params = params.reject { |key, _value| key.in?(["github", "slug"]) }
+
+      suggestion = suggestions.create(content: content, suggested_by_id: user&.id)
+
+      return suggestion if params.keys.none?
+
+      super(params:, user:)
+    else
+      super
+    end
+  end
+
   def github_avatar_url(size: 200)
     return "" unless github.present?
 

--- a/app/views/speakers/_form.html.erb
+++ b/app/views/speakers/_form.html.erb
@@ -1,43 +1,40 @@
 <%= form_with(model: speaker, class: "flex flex-col gap-4") do |form| %>
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name, class: "input input-bordered w-full" %>
+  </div>
 
-  <% if speaker.github.present? %>
-    <div>
-      <%= form.label :name %>
-      <%= form.text_field :name, class: "input input-bordered w-full" %>
-    </div>
+  <div>
+    <%= form.label :github, "GitHub" %>
+    <%= form.text_field :github, class: "input input-bordered w-full" %>
+  </div>
 
-    <div>
-      <%= form.label :twitter %>
-      <%= form.text_field :twitter, class: "input input-bordered w-full" %>
-    </div>
-
-    <div>
-      <%= form.label :bio %>
-      <%= form.text_area :bio, rows: 4, class: "textarea textarea-bordered w-full" %>
-    </div>
-
-    <div>
-      <%= form.label :pronouns %>
-      <div data-controller="pronouns-select">
-        <%= form.select :pronouns_type, Speaker::PRONOUNS, {}, class: "select select-bordered w-full", data: {action: "pronouns-select#change", pronouns_select_target: "type"} %>
-        <%= form.text_field :pronouns, placeholder: "Custom pronouns", class: "hidden mt-3 input input-bordered w-full", data: {pronouns_select_target: "input"} %>
-      </div>
-    </div>
-
-    <div>
-      <%= form.label :website %>
-      <%= form.text_field :website, class: "input input-bordered w-full" %>
-    </div>
-  <% else %>
-    <div>
-      <%= form.label :github, "GitHub" %>
-      <%= form.text_field :github, class: "input input-bordered w-full" %>
-    </div>
-  <% end %>
+  <div>
+    <%= form.label :twitter %>
+    <%= form.text_field :twitter, class: "input input-bordered w-full" %>
+  </div>
 
   <div>
     <%= form.label :speakerdeck, "Speakerdeck" %>
     <%= form.text_field :speakerdeck, class: "input input-bordered w-full" %>
+  </div>
+
+  <div>
+    <%= form.label :bio %>
+    <%= form.text_area :bio, rows: 4, class: "textarea textarea-bordered w-full" %>
+  </div>
+
+  <div>
+    <%= form.label :pronouns %>
+    <div data-controller="pronouns-select">
+      <%= form.select :pronouns_type, Speaker::PRONOUNS, {}, class: "select select-bordered w-full", data: {action: "pronouns-select#change", pronouns_select_target: "type"} %>
+      <%= form.text_field :pronouns, placeholder: "Custom pronouns", class: "hidden mt-3 input input-bordered w-full", data: {pronouns_select_target: "input"} %>
+    </div>
+  </div>
+
+  <div>
+    <%= form.label :website %>
+    <%= form.text_field :website, class: "input input-bordered w-full" %>
   </div>
 
   <div class="flex items-center gap-4">

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -94,7 +94,7 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
 
     suggestion = @speaker.suggestions.pending.last
 
-    assert_equal ({ "github" => "new-github", "slug" => "new-slug" }), suggestion.content
+    assert_equal ({"github" => "new-github", "slug" => "new-slug"}), suggestion.content
     assert_equal user.id, suggestion.suggested_by_id
 
     # those attributes can't be changed by the owner

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -41,6 +41,8 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
   test "should create a suggestion for speaker" do
     patch speaker_url(@speaker), params: {speaker: {bio: "new bio", github: "new-github", name: "new-name", slug: "new-slug", twitter: "new-twitter", website: "new-website"}}
 
+    @speaker.reload
+
     assert_redirected_to speaker_url(@speaker)
     assert_not_equal @speaker.reload.bio, "new bio"
     assert_equal 1, @speaker.suggestions.pending.count
@@ -50,13 +52,15 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     sign_in_as users(:admin)
     patch speaker_url(@speaker), params: {speaker: {bio: "new bio", github: "new-github", name: "new-name", slug: "new-slug", twitter: "new-twitter", website: "new-website"}}
 
+    @speaker.reload
+
     assert_redirected_to speaker_url(@speaker)
     assert_equal "new bio", @speaker.reload.bio
     assert_equal 0, @speaker.suggestions.pending.count
     assert_equal users(:admin).id, @speaker.suggestions.last.suggested_by_id
   end
 
-  test "owner can update directly the speaker" do
+  test "owner can update the speaker directly" do
     user = User.create!(email: "test@example.com", password: "Secret1*3*5*", github_handle: @speaker.github, verified: true)
     assert user.persisted?
     assert_equal user, @speaker.user
@@ -64,7 +68,7 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     sign_in_as user
 
     assert_no_changes -> { @speaker.suggestions.pending.count } do
-      patch speaker_url(@speaker), params: {speaker: {bio: "new bio", github: "new-github", name: "new-name", slug: "new-slug", twitter: "new-twitter", website: "new-website"}}
+      patch speaker_url(@speaker), params: {speaker: {bio: "new bio", name: "new-name", twitter: "new-twitter", website: "new-website"}}
     end
 
     assert_redirected_to speaker_url(@speaker)
@@ -73,10 +77,54 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_equal @speaker.twitter, "new-twitter"
     assert_equal @speaker.website, "new-website"
     assert_equal user.id, @speaker.suggestions.last.suggested_by_id
+  end
+
+  test "owner can't update own github handle or slug" do
+    user = User.create!(email: "test@example.com", password: "Secret1*3*5*", github_handle: @speaker.github, verified: true)
+    assert user.persisted?
+    assert_equal user, @speaker.user
+
+    sign_in_as user
+
+    assert_difference -> { @speaker.suggestions.pending.count }, 1 do
+      patch speaker_url(@speaker), params: {speaker: {github: "new-github", slug: "new-slug"}}
+    end
+
+    assert_redirected_to speaker_url(@speaker)
+
+    suggestion = @speaker.suggestions.pending.last
+
+    assert_equal ({ "github" => "new-github", "slug" => "new-slug" }), suggestion.content
+    assert_equal user.id, suggestion.suggested_by_id
 
     # those attributes can't be changed by the owner
-    assert_not_equal @speaker.github, "new-github"
     assert_not_equal @speaker.slug, "new-slug"
+    assert_not_equal @speaker.github, "new-github"
+  end
+
+  test "should create a second suggestion if owner updates bio and github handle" do
+    user = User.create!(email: "test@example.com", password: "Secret1*3*5*", github_handle: @speaker.github, verified: true)
+    assert user.persisted?
+    assert_equal user, @speaker.user
+
+    sign_in_as user
+
+    assert_equal 0, @speaker.suggestions.approved.count
+    assert_equal 0, @speaker.suggestions.pending.count
+
+    assert_difference -> { @speaker.suggestions.count }, 2 do
+      patch speaker_url(@speaker), params: {speaker: {name: "new-name", github: "new-github"}}
+    end
+
+    assert_redirected_to speaker_url(@speaker)
+
+    assert_equal 1, @speaker.suggestions.approved.count
+    assert_equal 1, @speaker.suggestions.pending.count
+
+    @speaker.reload
+
+    assert_equal @speaker.name, "new-name"
+    assert_not_equal @speaker.github, "new-github"
   end
 
   test "should get index as JSON" do


### PR DESCRIPTION
Resolves #292 

This pull request extends the suggestion form for speakers to accept changes for all fields, no matter the user type. Sometimes we also have the wrong GitHub account linked, which is why I think it makes sense to be able to suggest a different GitHub handle too.

![CleanShot 2024-10-24 at 18 26 58](https://github.com/user-attachments/assets/54aa2093-4068-4529-99dc-0b5f6d7d04f2)
