### PR TITLE
Fix Spanish language lookup

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -23,6 +23,10 @@ class Language
     ALL_LANGUAGES
   end
 
+  def self.by_code(code)
+    ALL_LANGUAGES[code]
+  end
+
   def self.used
     assigned_languages = Talk.distinct.pluck(:language)
 

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -1,13 +1,13 @@
 <%# locals: (talk:, user_favorite_talks_ids: [], favoritable: false, back_to: nil, back_to_title: nil) -%>
 
-<% language = Language.find(talk.language) %>
+<% language = Language.by_code(talk.language) %>
 
 <div class="card card-compact bg-white shadow-xl w-full" id="<%= dom_id talk %>" style="<%= "view-transition-name: #{dom_id(talk, :talk_card)}" %>">
   <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden relative" do %>
-    <% if language && language.english_name != "English" %>
+    <% if language && language != "English" %>
       <div class="absolute top-0 left-0 z-10 m-3 p-1 px-2 bg-black/15 backdrop-blur-md rounded-full group">
-        <span><%= language_to_emoji(language.english_name) %></span>
-        <span class="group-hover:inline-block hidden text-white text-sm ml-1"><%= language.english_name %></span>
+        <span><%= language_to_emoji(language) %></span>
+        <span class="group-hover:inline-block hidden text-white text-sm ml-1"><%= language %></span>
       </div>
     <% end %>
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![CleanShot 2024-10-29 at 08 47 32](https://github.com/user-attachments/assets/90c95305-bc59-4265-b276-2ee1616f52f3) | ![CleanShot 2024-10-29 at 08 41 48](https://github.com/user-attachments/assets/2e144821-f8de-4687-93a2-2f4721ac8384) |

**Before:**
```ruby
rubyvideo(dev)> Language.find("es").english_name
=> "Spanish; Castilian"
```

**After:**
```ruby
rubyvideo(dev)> Language::ALL_LANGUAGES["es"]
=> "Spanish"

# and now thanks to the new method
rubyvideo(dev)> Language.by_code("es")
=> "Spanish"
```
