### PR TITLE
Fix Navbar Links : Leaderboard

### DIFF
--- a/app/controllers/leaderboard_controller.rb
+++ b/app/controllers/leaderboard_controller.rb
@@ -12,7 +12,5 @@ class LeaderboardController < ApplicationController
       @ranked_speakers = @ranked_speakers.where("talks.date >= ?", 12.months.ago.to_date)
     end
     @ranked_speakers = @ranked_speakers.limit(100)
-    last_modified_talk = Talk.order(updated_at: :desc).first
-    fresh_when(last_modified: last_modified_talk&.updated_at || Time.current)
   end
 end


### PR DESCRIPTION
Fixes #278 

The fresh_when helper sets an etag cache but the navbar is dependent upon if the user is signed in. I removed the fresh_when. I think the endpoint is fast enough that we don't really need to cache. 248ms response time.

https://share.cleanshot.com/TmhQdDC7

```
18:33:28 web.1  | Started GET "/leaderboard" for ::1 at 2024-10-29 18:33:28 +0100
18:33:28 web.1  | Processing by LeaderboardController#index as HTML
18:33:28 web.1  |   Session Load (0.2ms)  SELECT "sessions".* FROM "sessions" WHERE "sessions"."id" IS NULL LIMIT 1 /*action='index',application='Rubyvideo',controller='leaderboard'*/
18:33:28 web.1  |   ↳ app/controllers/concerns/authenticable.rb:32:in `set_current_request_details'
18:33:28 web.1  |   Rendering layout layouts/application.html.erb
18:33:28 web.1  |   Rendering leaderboard/index.html.erb within layouts/application
18:33:28 web.1  |   Speaker Load (12.0ms)  SELECT speakers.name, speakers.github, speakers.id, speakers.slug, speakers.updated_at, COUNT(talks.id) as talks_count FROM "speakers" LEFT OUTER JOIN "speaker_talks" ON "speaker_talks"."speaker_id" = "speakers"."id" LEFT OUTER JOIN "talks" ON "talks"."id" = "speaker_talks"."talk_id" GROUP BY "speakers"."id" ORDER BY COUNT(talks.id) DESC LIMIT 100 /*action='index',application='Rubyvideo',controller='leaderboard'*/
18:33:28 web.1  |   ↳ app/views/leaderboard/index.html.erb:20
18:33:28 web.1  |   Rendered collection of leaderboard/_speaker.html.erb [100 times] (Duration: 8.9ms | GC: 2.8ms)
18:33:28 web.1  |   Rendered leaderboard/index.html.erb within layouts/application (Duration: 23.2ms | GC: 13.0ms)
18:33:28 web.1  |   Rendered shared/navbar/_link.html.erb (Duration: 0.3ms | GC: 0.0ms)
18:33:28 web.1  |   Rendered shared/navbar/_link.html.erb (Duration: 0.1ms | GC: 0.0ms)
18:33:28 web.1  |   Rendered shared/navbar/_link.html.erb (Duration: 0.0ms | GC: 0.0ms)
18:33:28 web.1  |   Rendered shared/navbar/_link.html.erb (Duration: 0.2ms | GC: 0.0ms)
18:33:28 web.1  |   Rendered shared/navbar/_link.html.erb (Duration: 0.0ms | GC: 0.0ms)
18:33:28 web.1  |   Rendered shared/_user_mobile_dropdown.html.erb (Duration: 6.8ms | GC: 1.2ms)
18:33:28 web.1  |   Rendered shared/_navbar.html.erb (Duration: 9.4ms | GC: 1.2ms)
18:33:28 web.1  |   Rendered shared/_flashes.html.erb (Duration: 0.1ms | GC: 0.0ms)
18:33:29 web.1  |   Rendered shared/_footer.html.erb (Duration: 0.8ms | GC: 0.0ms)
18:33:29 web.1  |   Rendered layout layouts/application.html.erb (Duration: 38.3ms | GC: 14.7ms)
18:33:29 web.1  |   Ahoy::Visit Load (0.2ms)  SELECT "ahoy_visits".* FROM "ahoy_visits" WHERE "ahoy_visits"."visit_token" = '00b36f26-e453-4f77-b7f7-ca23836173f4' LIMIT 1 /*action='index',application='Rubyvideo',controller='leaderboard'*/
18:33:29 web.1  |   ↳ app/controllers/concerns/analytics.rb:11:in `track_action'
18:33:29 web.1  |   TRANSACTION (0.0ms)  BEGIN immediate TRANSACTION /*action='index',application='Rubyvideo',controller='leaderboard'*/
18:33:29 web.1  |   ↳ app/controllers/concerns/analytics.rb:11:in `track_action'
18:33:29 web.1  |   Ahoy::Event Create (0.5ms)  INSERT INTO "ahoy_events" ("visit_id", "user_id", "name", "properties", "time") VALUES (4, NULL, 'leaderboard#index', '{"controller":"leaderboard","action":"index"}', '2024-10-29 17:33:28.894154') RETURNING "id" /*action='index',application='Rubyvideo',controller='leaderboard'*/
18:33:29 web.1  |   ↳ app/controllers/concerns/analytics.rb:11:in `track_action'
18:33:29 web.1  |   TRANSACTION (0.3ms)  COMMIT TRANSACTION /*action='index',application='Rubyvideo',controller='leaderboard'*/
18:33:29 web.1  |   ↳ app/controllers/concerns/analytics.rb:11:in `track_action'
18:33:29 web.1  | Completed 200 OK in 248ms (Views: 26.8ms | ActiveRecord: 13.2ms (4 queries, 0 cached) | GC: 14.7ms)
18:33:29 web.1  |
18:33:29 web.1  |
```