### PR TITLE
Use event card image for "explore all talks" card

### DIFF
--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -30,13 +30,7 @@
 
   <%= link_to event_path(@talk.event), id: "explore-event", class: "card bg-gray-200 hover:bg-gray-300/80 transition-bg duration-300 ease-in-out w-full flex flex-row px-6 py-6 gap-8 mt-4 overflow-hidden" do %>
     <div class="aspect-video hidden md:block">
-      <% event_talk = @talk.event.talks.excluding(@talk).sample || @talk %>
-
-      <%= image_tag event_talk.thumbnail_sm,
-            srcset: ["#{event_talk.thumbnail_lg} 2x"],
-            id: dom_id(event_talk),
-            alt: "explore all talks recorded at #{@talk.event.name}",
-            class: "h-24 aspect-video rounded-xl" %>
+      <%= image_tag image_path(@talk.event.card_image_path), id: dom_id(@talk.event, "explore-card-image"), alt: "explore all talks recorded at #{@talk.event.name}", class: "h-24 aspect-video rounded-xl" %>
     </div>
 
     <div class="flex flex-col w-full flex-1 self-start">


### PR DESCRIPTION
This pull request builds on top of #216 by using the artwork introduced in #300 for the card image.

| Before |
| --- | 
| ![CleanShot 2024-10-29 at 21 38 53](https://github.com/user-attachments/assets/98d7753d-f9b8-4db1-b866-c5c0ebc5acb5) |

| After |
| ---| 
| ![CleanShot 2024-10-29 at 21 38 36](https://github.com/user-attachments/assets/cdeef3c3-ce2d-443d-a6bd-f76e6a1f153d) | 

/cc @jmarsh24 
