### PR TITLE
enforce remote modals 

### DIFF
--- a/app/controllers/concerns/remote_modal.rb
+++ b/app/controllers/concerns/remote_modal.rb
@@ -7,6 +7,7 @@
 #
 module RemoteModal
   extend ActiveSupport::Concern
+  include Turbo::ForceFrameResponse
   DEFAULT_ALLOWED_ACTIONS = %i[new show edit index].freeze
 
   included do

--- a/app/controllers/concerns/remote_modal.rb
+++ b/app/controllers/concerns/remote_modal.rb
@@ -1,45 +1,26 @@
-# frozen_string_literal: true
-
-#
-# include this module in your controller to respond with a remote modal
-# if the request is a turbo frame request with a turbo_frame_id="modal"
-# then the response will use the modal layout (wraps the content into a self opening modal)
-#
 module RemoteModal
   extend ActiveSupport::Concern
   include Turbo::ForceFrameResponse
-  DEFAULT_ALLOWED_ACTIONS = %i[new show edit index].freeze
 
   included do
-    before_action :allowed_action?
     layout :define_layout
   end
 
   class_methods do
-    #
-    # provide a list of actions that should be allowed to be called remotely
-    #
-    # @param [Array<Symbol>] *actions list of actions that should be allowed to be called remotely
-    #
-    # @return [Array<Symbol>]
-    #
-    def allowed_remote_modal_actions(*actions)
-      @allowed_actions = actions
-    end
-
-    def allowed_actions
-      @allowed_actions || DEFAULT_ALLOWED_ACTIONS
+    def respond_with_remote_modal(options = {})
+      before_action :enable_remote_modal, **options
+      force_frame_response(**options)
     end
   end
 
   private
 
-  def allowed_action?
-    self.class.allowed_actions.include?(action_name.to_sym)
+  def enable_remote_modal
+    @remote_modal = true
   end
 
   def define_layout
-    return "modal" if turbo_frame_request_id == "modal" && allowed_action?
+    return "modal" if turbo_frame_request_id == "modal" && @remote_modal
 
     "application"
   end

--- a/app/controllers/concerns/turbo/force_frame_response.rb
+++ b/app/controllers/concerns/turbo/force_frame_response.rb
@@ -13,7 +13,7 @@ module Turbo
     def force_frame_response
       return if turbo_frame_request?
 
-      redirect_to(request.referer || root_path)
+      redirect_back(fallback_location: root_path)
     end
   end
 end

--- a/app/controllers/concerns/turbo/force_frame_response.rb
+++ b/app/controllers/concerns/turbo/force_frame_response.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Turbo
+  module ForceFrameResponse
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def force_frame_response(options = {})
+        before_action :force_frame_response, **options
+      end
+    end
+
+    def force_frame_response
+      return if turbo_frame_request?
+
+      redirect_to(request.referer || root_path)
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,7 @@
 class SessionsController < ApplicationController
   include RemoteModal
   allowed_remote_modal_actions :new
+  force_frame_response only: %i[new]
 
   skip_before_action :authenticate_user!, only: %i[new create]
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,6 @@
 class SessionsController < ApplicationController
   include RemoteModal
-  allowed_remote_modal_actions :new
-  force_frame_response only: %i[new]
+  respond_with_remote_modal only: [:new]
 
   skip_before_action :authenticate_user!, only: %i[new create]
 

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -4,7 +4,7 @@ class SpeakersController < ApplicationController
   before_action :set_user_favorites, only: %i[show]
   include Pagy::Backend
   include RemoteModal
-  allowed_remote_modal_actions :edit
+  respond_with_remote_modal only: [:edit]
 
   # GET /speakers
   def index

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -12,9 +12,16 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should get new" do
+  test "should get new in a remote modal" do
     get sign_in_url, headers: {"Turbo-Frame" => "modal"}
     assert_response :success
+    assert_template "sessions/new"
+  end
+
+  test "should redirect to root when not in a remote modal" do
+    get sign_in_url
+    assert_response :redirect
+    assert_redirected_to root_url
   end
 
   test "should sign in" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -13,7 +13,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get new" do
-    get sign_in_url
+    get sign_in_url, headers: {"Turbo-Frame" => "modal"}
     assert_response :success
   end
 

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -33,9 +33,16 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to speaker_url(@speaker)
   end
 
-  test "should get edit" do
-    get edit_speaker_url(@speaker)
+  test "should get edit in a remote modal" do
+    get edit_speaker_url(@speaker), headers: {"Turbo-Frame" => "modal"}
     assert_response :success
+    assert_template "speakers/edit"
+  end
+
+  test "should redirect to root when not in a remote modal" do
+    get edit_speaker_url(@speaker)
+    assert_response :redirect
+    assert_redirected_to root_url
   end
 
   test "should create a suggestion for speaker" do


### PR DESCRIPTION
close #315

adds a new concerns that works in pair with the remove modal concern
we can now specify that remove modals can only be viewed as remote modal by forcing certain route to be displayed only in turbo frames


```ruby
include RemoteModal
allowed_remote_modal_actions :new
force_frame_response only: %i[new]
```