### PR TITLE
refine talks#show ui

### DIFF
--- a/app/assets/stylesheets/components/video.css
+++ b/app/assets/stylesheets/components/video.css
@@ -1,7 +1,7 @@
 @layer components {
   .banner-img .v-vlite {
     --vlite-controlsColor: #dc143c;
-    --vlite-controlsOpacity: 0.7;
+    --vlite-controlsOpacity: 1;
     --vlite-controlBarBackground: linear-gradient(0deg, #000 -50%, #fff);
   }
 
@@ -12,5 +12,9 @@
 
   .v-loader {
     display: none !important;
+  }
+
+  .v-bigPlay {
+    opacity: 0.5 !important;
   }
 }

--- a/app/assets/stylesheets/components/video.css
+++ b/app/assets/stylesheets/components/video.css
@@ -9,4 +9,8 @@
     color: var(--vlite-controlsColor);
     text-align: center;
   }
+
+  .v-loader {
+    display: none !important;
+  }
 }

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -14,7 +14,7 @@
             loading: :lazy %>
 
       <div class="flex-col flex justify-center">
-        <h1 class="mb-2 text-black font-bold" style="view-transition-name: title"><%= @event.name %></h1>
+        <h1 class="mb-2 text-black font-bold"><%= @event.name %></h1>
         <h3 class="text-[#636B74]"><%= @event.location %> • <%= @event.formatted_dates %></h3>
       </div>
     </div>

--- a/app/views/talks/_card_horizontal.html.erb
+++ b/app/views/talks/_card_horizontal.html.erb
@@ -4,7 +4,7 @@
 
 <div class="<%= class_names("w-full flex items-center gap-2", "border border-secondary rounded-lg p-1": active) %>" id="<%= dom_id(talk, :card_horizontal) %>" data-talk-horizontal-card>
   <%= link_to talk_path(talk), class: "flex aspect-video shrink-0 relative w-28" do %>
-    <%= image_tag talk.thumbnail_sm, srcset: ["#{talk.thumbnail_lg} 2x"], id: dom_id(talk), class: "w-full h-auto object-cover", style: "view-transition-name: #{dom_id(talk, :image)}#{active ? "active" : ""}", loading: :lazy %>
+    <%= image_tag talk.thumbnail_sm, srcset: ["#{talk.thumbnail_lg} 2x"], id: dom_id(talk), class: "w-full h-auto object-cover", loading: :lazy %>
   <% end %>
 
   <div class="flex flex-col gap-2 text-sm">


### PR DESCRIPTION
some small ui refinements

- hide the video loader. I think that while the site is very fast this convey the impression that the videos are slow to load where as you could click even before the loader is finished
- dims a bit the play button to git more focus on the video thumbnail
- removes the page view transition for side bar images 
- removes the page view transition on the event title