### PR TITLE
fix: docker call in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,6 +8,12 @@ def system!(*args)
   system(*args, exception: true)
 end
 
+def docker_compose!(options)
+  system!("docker compose #{options}")
+rescue Errno::ENOENT
+  system!("docker-compose #{options}")
+end
+
 FileUtils.chdir APP_ROOT do
   # This script is a way to set up or update your development environment automatically.
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
@@ -34,7 +40,7 @@ FileUtils.chdir APP_ROOT do
   system! "yarn install"
 
   puts "\n == Starting Meilisearch =="
-  system! "docker-compose up -d"
+  docker_compose! "up -d"
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
@@ -43,10 +49,10 @@ FileUtils.chdir APP_ROOT do
   system! "bin/rails log:clear tmp:clear"
 
   puts "\n == Stoping Meilisearch =="
-  system! "docker-compose down"
+  docker_compose! "down"
 
   puts "\n== How to start the application =="
   puts "you need to launch Meilisearch in one Terminal and Rails in another"
-  puts "\n use 'docker-compose up' to start Meilisearch"
+  puts "\n use 'docker compose up' to start Meilisearch"
   puts "\n use 'bin/dev' to start the Rails server, solid_queue and Vite"
 end


### PR DESCRIPTION
Warm greetings,

What used to be `docker-compose` is now `docker compose`.
Docker introduced that [change](https://docs.docker.com/compose/releases/migrate/) in 2020.

PR modifies setup script.
1. try to use `docker compose`
1. not found? try `docker-compose`
1. still not found? terminate with an unhandled error 🧨

In case `docker compose` is found but runs with error script will not attempt `docker-compose`.
It will terminate with an error, as before. I've checked this manually.
