### PR TITLE
Brand Gotham Ruby Conference as "GORUCO"

### DIFF
--- a/data/goruco/goruco-2008/videos.yml
+++ b/data/goruco/goruco-2008/videos.yml
@@ -5,7 +5,7 @@
   raw_title: "Story Driven Development: The Next Generation of Rails Functional Testing by Bryan Helmkamp"
   speakers:
     - Bryan Helmkamp
-  event_name: GoRuCo 2008
+  event_name: GORUCO 2008
   published_at: "2008-04-26"
   description: |-
     Help us caption & translate this video!
@@ -18,7 +18,7 @@
   raw_title: "Archaeopteryx: A Ruby MIDI Generator by Giles Bowkett"
   speakers:
     - Giles Bowkett
-  event_name: GoRuCo 2008
+  event_name: GORUCO 2008
   published_at: "2008-04-26"
   description: |-
     Help us caption & translate this video!
@@ -31,7 +31,7 @@
   raw_title: "Forbidden Fruit: A Test of Ruby's Parse Tree by Chris Wanstrath"
   speakers:
     - Chris Wanstrath
-  event_name: GoRuCo 2008
+  event_name: GORUCO 2008
   published_at: "2008-04-26"
   description: |-
     Help us caption & translate this video!
@@ -46,7 +46,7 @@
   raw_title: Hurting Code for Fun and Profit by Ryan Davis
   speakers:
     - Ryan Davis
-  event_name: GoRuCo 2008
+  event_name: GORUCO 2008
   published_at: "2008-04-26"
   description: |-
     Help us caption & translate this video!
@@ -59,7 +59,7 @@
   raw_title: Collective Intelligence by Paul Dix
   speakers:
     - Paul Dix
-  event_name: GoRuCo 2008
+  event_name: GORUCO 2008
   published_at: "2008-04-26"
   description: |-
     Help us caption & translate this video!
@@ -72,7 +72,7 @@
   raw_title: Goruco 2008 Merb, All you need, nil you don't by Ezra Zygmuntowicz
   speakers:
     - Ezra Zygmuntowicz
-  event_name: GoRuCo 2008
+  event_name: GORUCO 2008
   published_at: "2008-04-26"
   description: |-
     Help us caption & translate this video!
@@ -96,7 +96,7 @@
     # - TODO # Mindstorms
     - Luke Miglia
     # - Wilson # TODO: missing last name
-  event_name: GoRuCo 2008
+  event_name: GORUCO 2008
   published_at: "2008-04-26"
   description: |-
     Help us caption & translate this video!

--- a/data/goruco/goruco-2009/videos.yml
+++ b/data/goruco/goruco-2009/videos.yml
@@ -5,7 +5,7 @@
   raw_title: GORUCO 2009 -Where is Ruby Really Heading? by Gregory Brown
   speakers:
     - Gregory Brown
-  event_name: GoRuCo 2009
+  event_name: GORUCO 2009
   published_at: "2009-05-30"
   description: |-
     Help us caption & translate this video!
@@ -18,7 +18,7 @@
   raw_title: GORUCO 2009 - The Ruby Guide to *nix Plumbing by Eleanor McHugh
   speakers:
     - Eleanor McHugh
-  event_name: GoRuCo 2009
+  event_name: GORUCO 2009
   published_at: "2009-05-30"
   description: |-
     Help us caption & translate this video!
@@ -31,7 +31,7 @@
   raw_title: GORUCO 2009 - Resource-Oriented Architecture With Waves by Dan Yoder
   speakers:
     - Dan Yoder
-  event_name: GoRuCo 2009
+  event_name: GORUCO 2009
   published_at: "2009-05-30"
   description: |-
     Help us caption & translate this video!
@@ -46,7 +46,7 @@
   raw_title: "GORUCO 2009 - Into the Heart of Darkness: Rails Anti-Patterns by Jake Howerton"
   speakers:
     - Jake Howerton
-  event_name: GoRuCo 2009
+  event_name: GORUCO 2009
   published_at: "2009-05-30"
   description: |-
     Help us caption & translate this video!
@@ -59,7 +59,7 @@
   raw_title: GORUCO 2009 - SOLID Object-Oriented Design by Sandi Metz
   speakers:
     - Sandi Metz
-  event_name: GoRuCo 2009
+  event_name: GORUCO 2009
   published_at: "2009-05-30"
   description: |-
     Help us caption & translate this video!
@@ -74,7 +74,7 @@
   raw_title: GORUCO 2009 - Building Cross Platform Mobile Apps with Ruby and PhoneGap by Ben Stein
   speakers:
     - Ben Stein
-  event_name: GoRuCo 2009
+  event_name: GORUCO 2009
   published_at: "2009-05-30"
   description: |-
     Help us caption & translate this video!
@@ -87,7 +87,7 @@
   raw_title: "GORUCO 2009 - From Rails to Rack: Making Rails 3 a Better Ruby Citizen by Yehuda Katz"
   speakers:
     - Yehuda Katz
-  event_name: GoRuCo 2009
+  event_name: GORUCO 2009
   published_at: "2009-05-30"
   description: |-
     Help us caption & translate this video!
@@ -108,7 +108,7 @@
     - Joe Damato # Fix Ruby Threads: 10x+ Perf Boost*
     - Aman Gupta # Google Pref Tools
     - Eric Hodel # You're Doing it Wrong - Packaging Gems
-  event_name: GoRuCo 2009
+  event_name: GORUCO 2009
   published_at: "2009-05-30"
   description: |-
     Help us caption & translate this video!

--- a/data/goruco/goruco-2012/videos.yml
+++ b/data/goruco/goruco-2012/videos.yml
@@ -11,7 +11,7 @@
   raw_title: "Maintaining Balance while Reducing Duplication: Part II by David Chelimsky,"
   speakers:
     - David Chelimsky
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     This talk is a sequel to the talk David gave at RubyConf 2010, and
@@ -26,7 +26,7 @@
   raw_title: The Front-End Future by Francis Hwang
   speakers:
     - Francis Hwang
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description: |-
     With the rise of Javascript MVC frameworks like Ember and Backbone, web programmers find themselves at a fork in the road. If they keep doing server-side web programming, they'll benefit from tried-and-true tools and techniques. If they jump into Javascript MVC, they may be able to offer a more responsive web experience, but at significant added development cost. Which should they choose?
@@ -45,7 +45,7 @@
   raw_title: Organizing and Packaging Rich Javascript Apps with Ruby by Luke Melia
   speakers:
     - Luke Melia
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     More and more developers are facing the challenge of organizing and
@@ -60,7 +60,7 @@
   raw_title: Your Face in 10 minutes... with Macruby! by Haris Amin,
   speakers:
     - Haris Amin
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     In this talk we will build a face detection and recognition app all
@@ -74,7 +74,7 @@
   raw_title: High Perfmance Caching with Rails by Matt Duncan,
   speakers:
     - Matt Duncan
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     In this talk, I'll dig into how this type of caching allows us to cache
@@ -89,7 +89,7 @@
   raw_title: Why Hashes Will Be Faster in Ruby 2.0 by Pat Shaughnessy,
   speakers:
     - Pat Shaughnessy
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     In this micro talk, I'll review the basic theory behind hash functions
@@ -105,7 +105,7 @@
   raw_title: Goruco 2012 Sensible Testing by Justin Leitgeb,
   speakers:
     - Justin Leitgeb
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description: |-
     Most Ruby programmers spend significant time writing, maintaining and troubleshooting automated tests. While recent discussions in the Ruby community have focused on whether we're writing too few or too many tests, this talk looks at how we can write "sensible" tests that allow our applications to deliver the most possible value with the least amount of development time and effort.
@@ -124,7 +124,7 @@
   raw_title: GoRuCo 2012 Building Developers Lessons Learned from Hungry Academy by Jeff Casimir
   speakers:
     - Jeff Casimir
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     Here's the quick story of what's worked, what hasn't, and the lessons
@@ -136,7 +136,7 @@
   raw_title: GoRuCo 2012 From Zero to API Cache w Grape & MongoDB in 10 minutes by Daniel Doubrovkine
   speakers:
     - Daniel Doubrovkine
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     We'll take a Grape API from zero to cache in 10-minutes. This cookbook
@@ -149,7 +149,7 @@
   raw_title: GoRuCo 2012 Maps want to be free! by Sebastian Delmont,
   speakers:
     - Sebastian Delmont
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     How to build your own online maps and free yourself from Google Maps
@@ -163,7 +163,7 @@
   raw_title: Goruco 2012 Power Rake by Jim Weirich,
   speakers:
     - Jim Weirich
-  event_name: GoRuCo 2012
+  event_name: GORUCO 2012
   published_at: "2012-06-23"
   description:
     In this talk we will cover the "hidden" features of Rake that are not

--- a/data/goruco/goruco-2013/videos.yml
+++ b/data/goruco/goruco-2013/videos.yml
@@ -5,7 +5,7 @@
   raw_title: GoRuCo 2013 - Asynchronous Service Oriented Design by John Pignata
   speakers:
     - John Pignata
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     Your monolithic application is getting unwieldy. Concerns are entangled, response time is getting sluggish, and changing anything in production requires deploying your entire system. Teams facing this challenge often have an "Introduce Services" chore in their backlog that inevitably sinks to the bottom of the list. Despite the realization that your monolithic application will sink under its own weight, you fear the inherent operational complexities of a service oriented system.
@@ -23,7 +23,7 @@
   raw_title: GoRuCo 2013 - To Know A Garbage Collector by Mike Bernstein
   speakers:
     - Mike Bernstein
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     It started as an obsession with making the web application used at my day job faster, and ended with trying to implement new Garbage Collection algorithms in a notoriously insane codebase. Garbage collection is an epic hack and a triumphant abstraction that supports various programming paradigms. As hardware and software changes, Garbage Collection's role also changes but remains equally important. I'll discuss my experiments with MRI Ruby, my investigations into other languages and the influence of their GC implementations, the history of the subject, and more.
@@ -40,7 +40,7 @@
   raw_title: "GoRuCo 2013 - Microtalk: Take a picture, it'll last longer by JD Harrington"
   speakers:
     - JD Harrington
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     Cheap code branches permeate our daily workflow, but the code we write is only half the story. Introducing data model changes into production can challenge developers and ops people alike, but how do we deal with these issues in our experimental phase?
@@ -56,7 +56,7 @@
   raw_title: "GoRuCo 2013 - Microtalk: Motion in the Middle - RubyMotion as a Gateway to iOS development"
   speakers:
     - Matthew Salerno
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     By Matt Salerno
@@ -73,7 +73,7 @@
   raw_title: "GoRuCo 2013 - Microtalk: Hacking the Academic Experience by Emily Stolfo"
   speakers:
     - Emily Stolfo
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     When I was asked to teach Ruby on Rails at Columbia University I observed that a significant number of the skills required to become a successful professional in the industry are acquired on the job and aren't being taught in school. Many of us professionals thrive on open source software and on sharing code, but academia is not always teaching this type of resourcefulness to students.
@@ -89,7 +89,7 @@
   raw_title: "GoRuCo 2013 Microtalk: Working with Rubyists by Aaron Quint"
   speakers:
     - Aaron Quint
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     Welcome to the trials and tribulations of managing a Ruby team. Let me introduce you to the characters, the challenges, the high stakes rat race. I'll share as fast as possible, what I've learned and what I failed at and why management shouldnt be an evil word.
@@ -106,7 +106,7 @@
   raw_title: GoRuCo 2013 - Putting off Persistence by Lauren Voswinkel
   speakers:
     - Lauren Voswinkel
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     In Rails, we have a beautiful framework that can take us from a blank slate to a fully-functional app in little time. However, doing things "The Rails Way" has a lot of implicit dependencies, including persistence. Are you really equipped to make one of the largest decisions about your app before any of your code has even been written?
@@ -123,7 +123,7 @@
   raw_title: GoRuCo 2013 - Krypt. Semper Pi. by Martin Bosslet
   speakers:
     - Martin Bosslet
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     Many people don't like Cryptography. Whenever he falls out of a bar, he carries this strong odor of ivory-towering, bikeshedding and plain, outright arrogance. He seems to be a loner and a smartass, rude, and it's hard to follow his boring, lengthy explanations. But once you get to know him better, it actually turns out that he's really a nice guy. Sure, a little bit paranoid, but his intentions are pure and just. He'll probably never be your buddy on Facebook ('cause he likely won't set up an account in the first place), but over time you will realize that it can be quite pleasant having him around.
@@ -143,7 +143,7 @@
   raw_title: GoRuCo 2013 - Deathmatch Bundler vs Rubygems.org by Andre Arko
   speakers:
     - Andre Arko
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     The story of the quest to make bundle install faster; in which Rubyists around the world inadvertently DDoS rubygems.org, witness its ignominious death, and vow to rebuild it from the ashes stronger than it was before. Then, a tour of the changes; why is Redis so much slower than Postgres? Marvel at the gorgeous metrics and graphs used to measure and optimize; gasp in delight as we track, live, exactly how many Heroku dynos are needed. Finally, a happy ending: today, the server responds to requests TWO ORDERS OF MAGNITUDE faster than it did before.
@@ -158,7 +158,7 @@
   raw_title: "GoRuCo 2013 - Microtalk: Building a Theme Engine w/ Ruby Mustache"
   speakers:
     - Kevin Sherus
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     By Kevin Sherus
@@ -177,7 +177,7 @@
   raw_title: GoRuCo 2013 - Microtalk:A House of Cards - The Perils of Maintaining a 7-Year-Old Codebase
   speakers:
     - Julie Gill
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description:
     "By Julie Gill \n\nWith RoR, often the focus is on how easy it is to
@@ -200,7 +200,7 @@
   raw_title: "GoRuCo 2013 - Microtalk: Nokogiri - History and Future by Mike Dalessio"
   speakers:
     - Mike Dalessio
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     Over the past few years, Nokogiri has slowly eclipsed older XML parsing libraries to garner nearly 10 million downloads from rubygems.org.
@@ -224,7 +224,7 @@
   raw_title: "GoRuCo 2013 - Microtalk: Usability Primer in 10 Minutes Flat by Steve Berry"
   speakers:
     - Steve Berry
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     In this talk we will go over usability heuristics for building better web experiences.
@@ -239,7 +239,7 @@
   raw_title: GoRuCo 2013 - Functional Programming and Ruby by Pat Shaughnessy
   speakers:
     - Pat Shaughnessy
-  event_name: GoRuCo 2013
+  event_name: GORUCO 2013
   published_at: "2013-06-08"
   description: |-
     While Ruby is object oriented and imperative, it does have some features that allow for functional programming. In this talk we'll compare Haskell, a functional programming language, with Ruby while exploring these common functional patterns: higher order functions, lazy evaluation, and memoization.

--- a/data/goruco/goruco-2014/videos.yml
+++ b/data/goruco/goruco-2014/videos.yml
@@ -5,7 +5,7 @@
   raw_title: GoRuCo 2014 - The Future of Ruby Performance Tooling by Aaron Quint
   speakers:
     - Aaron Quint
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-07-16"
   description: |-
     It's just a fact that as a baseline, Ruby is not the fastest language or platform out there. We've always been comfortable with the trade of raw speed for the thrill and happiness of development.
@@ -40,7 +40,7 @@
   raw_title: GoRuCo 2014 - Real-Time Communication for Everyone by Lisa Larson-Kelley
   speakers:
     - Lisa Larson-Kelley
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-06-21"
   description: |-
     WebRTC is a powerful open-source project that seamlessly enables real-time communication (RTC)-- baked right into modern web browsers. This means web developers can now incorporate video, voice and data sharing using peer-to-peer connectivity via simple JavaScript APIs, with no plugins or additional installs required.
@@ -59,7 +59,7 @@
   raw_title: GoRuCo 2014 - Know Your Types - Bringing Static Types to Dynamic Languages by Michael Bernstein
   speakers:
     - Michael Bernstein
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-06-21"
   description: |-
     After several years of being a professional programmer, I realized that I didn't really know what I was doing, and decided to teach myself Computer Science. After spending a year learning Computer Science from the ground up, I thought I was starting to understand things. Then I came across Haskell.
@@ -86,7 +86,7 @@
   raw_title: GoRuCo 2014 - What We Can Learn From COBOL by Andrew Turley
   speakers:
     - Andrew Turley
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-06-21"
   description: |-
     COBOL was originally conceived as a programming language for building business applications. At the time this primarily meant processing large amounts of data and transforming it into useful information (commonly known at ETL). Interest in this kind of programming waned as the personal computing revolution swept through the industry, but it is waxing with the new focus on data science and "big data".
@@ -101,7 +101,7 @@
   raw_title: GoRuCo 2014 - Teaching Kids to Code on Raspberry Pi by Audrey Troutt
   speakers:
     - Audrey Troutt
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-06-21"
   description: |-
     Back in September 2013 I taught a class of 12 middle-school aged girls to write code in Scratch on the Raspberry Pi and program simple electronic circuits. This was a workshop for the Philadelphia non-profit TechGirlz.
@@ -125,7 +125,7 @@
   raw_title: GoRuCo 2014 - BI Tooling with Rails by Kahn Solomon
   speakers:
     - Solomon Kahn
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-07-16"
   description: |-
     Non-technical people in companies need data, but don't have the programming skills to get it themselves. So, it becomes your part-time job to get them data. As your company grows, this problem only gets worse.
@@ -162,7 +162,7 @@
   raw_title: GoRuCo 2014 - Secrets of a World Memory Champion by Chris Hunt
   speakers:
     - Chris Hunt
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-06-21"
   description: |-
     You don't have a bad memory, you were just never taught how to use it. We are going to practice several powerful memory techniques that have been perfected by memory contest champions over the last hundred years.
@@ -181,7 +181,7 @@
   raw_title: GoRuCo 2014 - Growing a Tech Community by Luke Melia
   speakers:
     - Luke Melia
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-07-16"
   description: |-
     For the last two years, I've been growing the Ember.js community in NYC from nearly nothing to a vibrant group. Most of what works well for me are things that I learned from getting my sea legs in the Ruby community, so what better place to share than GORUCO?
@@ -198,7 +198,7 @@
   raw_title: GoRuCo 2014 - An Approach to Developing and Testing Third Party JavaScript Widgets by Nathan Artz
   speakers:
     - Nathan Artz
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-06-21"
   description: |-
     Google Analytics, Like Buttons, Twitter Widgets, Olark chat boxes; all examples of third party JavaScript elements that are embedded by users in their websites.
@@ -223,7 +223,7 @@
   speakers:
     - Samantha John
     - Jason Brennan
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-06-21"
   description: |-
     We will show how new approaches to language design create a better programming community.
@@ -244,7 +244,7 @@
   raw_title: GoRuCo 2014 - Edge Caching Dynamic Rails Apps by Michael May
   speakers:
     - Michael May
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-06-21"
   description: |-
     Your rails app is slow. Even after memory caching, optimizing queries, and adding servers the problem persists, killing your user experience. You've heard of services called "Content Delivery Networks" (CDNs), that could help, but they only seem to work with static content. Worry not, for there is a solution: dynamic content caching at the edge. In this talk, we explain how CDNs can be used to accelerate dynamic rails applications.
@@ -274,7 +274,7 @@
   raw_title: GoRuCo 2014 - How to Debug Anything by James Golick
   speakers:
     - James Golick
-  event_name: GoRuCo 2014
+  event_name: GORUCO 2014
   published_at: "2014-07-16"
   description: |-
     Does your code work? Probably not. The libraries you're using probably don't work either. If you're lucky, the OS does, but even then you'll probably find something wrong if you look hard enough.

--- a/data/goruco/goruco-2015/videos.yml
+++ b/data/goruco/goruco-2015/videos.yml
@@ -5,7 +5,7 @@
   raw_title: "GORUCO 2015: Nadia Odunayo: Keynote Playing games in the clouds"
   speakers:
     - Nadia Odunayo
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @nodunayo
@@ -21,7 +21,7 @@
   raw_title: "GORUCO 2015: Eileen Uchitelle: How to Performance"
   speakers:
     - Eileen M. Uchitelle
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @eileencodes
@@ -38,7 +38,7 @@
   raw_title: "GORUCO 2015: Zachary Feldman: Home Automation with the Amazon Echo and Ruby"
   speakers:
     - Zachary Feldman
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description:
     "@zachfeldman\nThe Amazon Echo recently debuted and made a big splash
@@ -60,7 +60,7 @@
   raw_title: "GORUCO 2015: Lisa van Gelder: Great Caching Disasters!"
   speakers:
     - Lisa van Gelder
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @techbint
@@ -74,7 +74,7 @@
   raw_title: "GORUCO 2015: Amy Wibowo: Sweaters as a service"
   speakers:
     - Amy Wibowo
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @sailorhg
@@ -88,7 +88,7 @@
   raw_title: "GORUCO 2015: Nate Berkopec: Rails 5, Turbolinks 3, and the future of View-Over-the-Wire"
   speakers:
     - Nate Berkopec
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @nateberkopec
@@ -104,7 +104,7 @@
   raw_title: "GORUCO 2015: Godfrey Chan: Dropping down to The Metal™"
   speakers:
     - Godfrey Chan
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @chancancode
@@ -120,7 +120,7 @@
   raw_title: "GORUCO 2015: Bryan Reinero: Event sourcing"
   speakers:
     - Bryan Reinero
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @blimpyacht
@@ -134,7 +134,7 @@
   raw_title: "GORUCO 2015: Melinda Seckington: Un-Artificial Intelligence"
   speakers:
     - Melinda Seckington
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @mseckington
@@ -149,7 +149,7 @@
   raw_title: "GORUCO 2015: Rachel Warbelow: Common pitfalls of junior developers"
   speakers:
     - Rachel Warbelow
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @rwarbelow
@@ -165,7 +165,7 @@
   raw_title: "GORUCO 2015: Simon Eskildsen: Building and testing resilient applications"
   speakers:
     - Simon Eskildsen
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @Sirupsen
@@ -181,7 +181,7 @@
   raw_title: "GORUCO 2015: Aaron Patterson: Closing Keynote"
   speakers:
     - Aaron Patterson
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @tenderlove
@@ -196,7 +196,7 @@
   raw_title: "GORUCO 2015: Kara Bernert: Of Mice and Metrics"
   speakers:
     - Kara Bernert
-  event_name: GoRuCo 2015
+  event_name: GORUCO 2015
   published_at: "2015-06-20"
   description: |-
     @_beavz

--- a/data/goruco/goruco-2016/videos.yml
+++ b/data/goruco/goruco-2016/videos.yml
@@ -5,7 +5,7 @@
   raw_title: "GORUCO 2016 - Keynote: Code Quality Lessons Learned Bryan Helmkamp"
   speakers:
     - Bryan Helmkamp
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Keynote: Code Quality Lessons Learned Bryan Helmkamp
@@ -22,7 +22,7 @@
   raw_title: "GORUCO 2016 - The Guest: A Guide To Code Hospitality by Nadia Odunayo"
   speakers:
     - Nadia Odunayo
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     The Guest: A Guide To Code Hospitality by Nadia Odunayo
@@ -38,7 +38,7 @@
   raw_title: GORUCO 2016 - Symmetric API Testing by Aditya Mukerjee
   speakers:
     - Aditya Mukerjee
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Symmetric API Testing by Aditya Mukerjee
@@ -55,7 +55,7 @@
   raw_title: GORUCO 2016 - Pipe Operator for Ruby by Fabio Akita
   speakers:
     - Fabio Akita
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Pipe Operator for Ruby by Fabio Akita
@@ -72,7 +72,7 @@
   raw_title: GORUCO 2016 - Introducing the Crystal Programming Language by Will Leinweber
   speakers:
     - Will Leinweber
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Introducing the Crystal Programming Language by Will Leinweber
@@ -89,7 +89,7 @@
   raw_title: "GORUCO 2016 - Ruby Racing: Challenging Ruby Methods Danielle Adams"
   speakers:
     - Danielle Adams
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Ruby Racing: Challenging Ruby Methods Danielle Adams
@@ -108,7 +108,7 @@
   raw_title: GORUCO 2016 - Just A Ruby Minute by Andrew Faraday
   speakers:
     - Andrew Faraday
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Just A Ruby Minute by Andrew Faraday
@@ -125,7 +125,7 @@
   raw_title: "GORUCO 2016 - Impactful Refactors: Refactoring for Readability by Kinsey Ann Durham"
   speakers:
     - Kinsey Ann Durham
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Impactful Refactors: Refactoring for Readability by Kinsey Ann Durham
@@ -142,7 +142,7 @@
   raw_title: GORUCO 2016 - Database Performance at Scale for RoR Applications by Rocio Delgado
   speakers:
     - Rocio Delgado
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Database Performance at Scale for RoR Applications by Rocio Delgado
@@ -159,7 +159,7 @@
   raw_title: GORUCO 2016 -  Enumerable's Ugly Cousin by Ross Kaffenberger
   speakers:
     - Ross Kaffenberger
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Enumerable's Ugly Cousin by Ross Kaffenberger
@@ -176,7 +176,7 @@
   raw_title: GORUCO 2016 - Exploring Big Data with rubygems.org Download Data by Aja Hammerly
   speakers:
     - Aja Hammerly
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   slides_url: https://thagomizer.com/files/GoRuCo2016.pdf
   description: |-
@@ -194,7 +194,7 @@
   raw_title: "GORUCO 2016 - Keynote: Cult(ure) by Adam Cuppy"
   speakers:
     - Adam Cuppy
-  event_name: GoRuCo 2016
+  event_name: GORUCO 2016
   published_at: "2016-06-25"
   description: |-
     Keynote: Cult(ure) by Adam Cuppy

--- a/data/goruco/goruco-2017/videos.yml
+++ b/data/goruco/goruco-2017/videos.yml
@@ -5,7 +5,7 @@
   raw_title: "GORUCO 2017: The Rubyist's Illustrated Rust Adventure Survival Guide by Liz Baillie"
   speakers:
     - Liz Baillie
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     The Rubyist's Illustrated Rust Adventure Survival Guide by Liz Baillie
@@ -18,7 +18,7 @@
   raw_title: "GORUCO 2017: Optimizing for API Consumers with GraphQL by Brooks Swinnerton"
   speakers:
     - Brooks Swinnerton
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Optimizing for API Consumers with GraphQL by Brooks Swinnerton
@@ -31,7 +31,7 @@
   raw_title: "GORUCO 2017: Trust and Teams by Rebecca Miller-Webster"
   speakers:
     - Rebecca Miller-Webster
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Trust and Teams by Rebecca Miller-Webster
@@ -44,7 +44,7 @@
   raw_title: "GORUCO 2017: Object Oriented Thinking with Elixir and OTP by Ryan Findley"
   speakers:
     - Ryan Findley
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Object Oriented Thinking with Elixir and OTP by Ryan Findley
@@ -57,7 +57,7 @@
   raw_title: "GORUCO 2017: Developer Productivity Engineering by Pan Thomakos"
   speakers:
     - Pan Thomakos
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Developer Productivity Engineering by  Panayiotis Thomakos
@@ -70,7 +70,7 @@
   raw_title: "GORUCO 2017: SQL to NoSQL to NewSQL and the rise of polyglot persistence Paul Dix"
   speakers:
     - Paul Dix
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     SQL to NoSQL to NewSQL and the rise of polyglot persistence Paul Dix
@@ -85,7 +85,7 @@
   raw_title: "GORUCO 2017: Difficult Conversations by Adam Cuppy"
   speakers:
     - Adam Cuppy
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Difficult Conversations by Adam Cuppy
@@ -98,7 +98,7 @@
   raw_title: "GORUCO 2017: What I Learned to Love About Ruby When I Switched to Python by Lauren Ellsworth"
   speakers:
     - Lauren Ellsworth
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     What I Learned to Love About Ruby When I Switched to Python by Lauren Ellsworth
@@ -111,7 +111,7 @@
   raw_title: "GORUCO 2017: Front-End Sadness to Happiness: The React on Rails Story by Justin Gordon"
   speakers:
     - Justin Gordon
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Front-End Sadness to Happiness: The React on Rails Story by Justin Gordon
@@ -124,7 +124,7 @@
   raw_title: "GORUCO 2017: Shaving my head made me a better programmer by Alex Qin"
   speakers:
     - Alex Qin
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Shaving my head made me a better programmer by Alex Qin
@@ -137,7 +137,7 @@
   raw_title: "GORUCO 2017: Beyond OSS by Veronica Lopez"
   speakers:
     - Verónica López
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Beyond OSS by Veronica Lopez
@@ -150,7 +150,7 @@
   raw_title: "GORUCO 2017: Scars: On Handling Adversity by Ross Kaffenberger"
   speakers:
     - Ross Kaffenberger
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Scars: On Handling Adversity by Ross Kaffenberger
@@ -163,7 +163,7 @@
   raw_title: "GORUCO 2017: How to Load 1m Lines of Ruby in 5s by Andrew Metcalf"
   speakers:
     - Andrew Metcalf
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     How to Load 1m Lines of Ruby in 5s by Andrew Metcalf
@@ -176,7 +176,7 @@
   raw_title: "GORUCO 2017: Type. Context. by Sam Phippen"
   speakers:
     - Sam Phippen
-  event_name: GoRuCo 2017
+  event_name: GORUCO 2017
   published_at: "2017-06-24"
   description: |-
     Type. Context. by Sam Phippen

--- a/data/goruco/goruco-2018/videos.yml
+++ b/data/goruco/goruco-2018/videos.yml
@@ -5,7 +5,7 @@
   raw_title: "GORUCO 2018: Opening Keynote: The Good Bad Bug: Fail Your Way to Better Code by Jessica Rudder"
   speakers:
     - Jessica Rudder
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: Opening Keynote: The Good Bad Bug: Fail Your Way to
     Better Code by Jessica Rudder"
@@ -16,7 +16,7 @@
   raw_title: "GORUCO 2018: Evented Autonomous Services in Ruby by Scott Bellware"
   speakers:
     - Scott Bellware
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: Evented Autonomous Services in Ruby by Scott Bellware"
   video_provider: youtube
@@ -26,7 +26,7 @@
   raw_title: "GORUCO 2018: Locking It Down with Ruby & Lockfiles by Danielle Adams"
   speakers:
     - Danielle Adams
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: Locking It Down with Ruby & Lockfiles by Danielle Adams"
   video_provider: youtube
@@ -36,7 +36,7 @@
   raw_title: "GORUCO 2018: Running Jobs at Scale by Kir Shatrov"
   speakers:
     - Kir Shatrov
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: Running Jobs at Scale by Kir Shatrov"
   video_provider: youtube
@@ -46,7 +46,7 @@
   raw_title: "GORUCO 2018: Encryption Pitfalls and Workarounds by Melissa Wahnish"
   speakers:
     - Melissa Wahnish
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: Encryption Pitfalls and Workarounds by Melissa Wahnish"
   video_provider: youtube
@@ -56,7 +56,7 @@
   raw_title: "GORUCO 2018: The Practical Guide to Building an Apprenticeship by Max Tiu"
   speakers:
     - Max Tiu
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description:
     "GORUCO 2018: The Practical Guide to Building an Apprenticeship by
@@ -68,7 +68,7 @@
   raw_title: "GORUCO 2018: The Impermanence of Software by Andy Croll"
   speakers:
     - Andy Croll
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: The Impermanence of Software by Andy Croll"
   video_provider: youtube
@@ -78,7 +78,7 @@
   raw_title: "GORUCO 2018:  I've Made a Huge Mistake: We Did Services All Wrong by Kelly Sutton"
   speakers:
     - Kelly Sutton
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: I've Made a Huge Mistake: We Did Services All Wrong
     by Kelly Sutton"
@@ -89,7 +89,7 @@
   raw_title: "GORUCO 2018: Writing Ruby Like it's 2018 by Joe Leo"
   speakers:
     - Joe Leo
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: Writing Ruby Like it's 2018 by Joe Leo"
   video_provider: youtube
@@ -99,7 +99,7 @@
   raw_title: "GORUCO 2018: Building Efficient APIs with JSON-API by Rushaine McBean"
   speakers:
     - Rushaine McBean
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: Building Efficient APIs with JSON-API by Rushaine McBean"
   video_provider: youtube
@@ -109,7 +109,7 @@
   raw_title: "GORUCO 2018:  The Twelve-Factor Function by Desmond Rawls"
   speakers:
     - Desmond Rawls
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: The Twelve-Factor Function by Desmond Rawls"
   video_provider: youtube
@@ -119,7 +119,7 @@
   raw_title: "GORUCO 2018: After Death by Sam Phippen"
   speakers:
     - Sam Phippen
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018:  After Death by Sam Phippen"
   video_provider: youtube
@@ -131,7 +131,7 @@
     by  Aaron Patterson"
   speakers:
     - Aaron Patterson
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: Closing Keynote: Analyzing and Reducing Ruby Memory
     Usage by  Aaron Patterson"
@@ -142,7 +142,7 @@
   raw_title: "GORUCO 2018: GORUCO Memories Francis Hwang"
   speakers:
     - Francis Hwang
-  event_name: GoRuCo 2018
+  event_name: GORUCO 2018
   published_at: "2018-06-18"
   description: "GORUCO 2018: GORUCO Memories Francis Hwang"
   video_provider: youtube

--- a/data/goruco/playlists.yml
+++ b/data/goruco/playlists.yml
@@ -1,6 +1,6 @@
 ---
 - id: ""
-  title: GoRuCo 2007
+  title: GORUCO 2007
   description: "http://2007.goruco.com"
   published_at: "2007-04-21"
   channel_id: ""
@@ -10,7 +10,7 @@
   slug: goruco-2007
 
 - id: PL12686083008C28A5
-  title: GoRuCo 2008
+  title: GORUCO 2008
   description: "http://2008.goruco.com"
   published_at: "2008-04-26"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
@@ -20,7 +20,7 @@
   slug: goruco-2008
 
 - id: PLE7tQUdRKcyYk-_BMaCwBWgBzAuNcwMGZ
-  title: GoRuCo 2009
+  title: GORUCO 2009
   description: "http://2009.goruco.com"
   published_at: "2009-05-30"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
@@ -30,7 +30,7 @@
   slug: goruco-2009
 
 - id: ""
-  title: GoRuCo 2010
+  title: GORUCO 2010
   description: "http://2010.goruco.com"
   published_at: "2010-05-22"
   channel_id: ""
@@ -40,7 +40,7 @@
   slug: goruco-2010
 
 - id: ""
-  title: GoRuCo 2011
+  title: GORUCO 2011
   description: "http://2011.goruco.com"
   published_at: "2011-06-04"
   channel_id:
@@ -50,7 +50,7 @@
   slug: goruco-2011
 
 - id: PLFE5C32B5513E0555
-  title: GoRuCo 2012
+  title: GORUCO 2012
   description: ""
   published_at: "2012-06-23"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
@@ -60,7 +60,7 @@
   slug: goruco-2012
 
 - id: PLE7tQUdRKcyZ4RsnTOCdqgWPXtm1h_Ale
-  title: GoRuCo 2013
+  title: GORUCO 2013
   description: "http://goruco.github.io"
   published_at: "2013-06-08"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
@@ -70,7 +70,7 @@
   slug: goruco-2013
 
 - id: PLE7tQUdRKcyZj4qdxsQKW4-8KnlpoGfgf
-  title: GoRuCo 2014
+  title: GORUCO 2014
   description: "https://web.archive.org/web/20141008055937/http://goruco.com/"
   published_at: "2014-06-21"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
@@ -80,7 +80,7 @@
   slug: goruco-2014
 
 - id: PLE7tQUdRKcyb6MU6H8PratMhV4bWUL8bv
-  title: GoRuCo 2015
+  title: GORUCO 2015
   description: "http://2015.goruco.com"
   published_at: "2015-06-20"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
@@ -90,7 +90,7 @@
   slug: goruco-2015
 
 - id: PLE7tQUdRKcybaE0Xm_yOK8-a-WAcltv1q
-  title: GoRuCo 2016
+  title: GORUCO 2016
   description: "https://web.archive.org/web/20160715194849/http://goruco.com/"
   published_at: "2016-06-25"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
@@ -100,7 +100,7 @@
   slug: goruco-2016
 
 - id: PLE7tQUdRKcybxOnh9S9Hk-RDRXZRkrWwR
-  title: GoRuCo 2017
+  title: GORUCO 2017
   description: "http://2017.goruco.com"
   published_at: "2017-06-24"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
@@ -110,7 +110,7 @@
   slug: goruco-2017
 
 - id: PLE7tQUdRKcya2z3Q5AiwNqjV968p2TvHu
-  title: GoRuCo 2018
+  title: GORUCO 2018
   description: "http://goruco.com"
   published_at: "2018-06-18"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ


### PR DESCRIPTION
Brand Gotham Ruby Conference as "GORUCO" and not "GoRuCo"

Although it's appeared both ways, as a co-organizer of the event I can vouch that the preferred branding is shoutcaps.