### PR TITLE
Reduce CI test time

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -276,7 +276,7 @@ class Talk < ApplicationRecord
   end
 
   def slug_candidates
-    [
+    @slug_candidates ||= [
       title.parameterize,
       [title.parameterize, event&.name&.parameterize].compact.join("-"),
       [title.parameterize, language.parameterize].compact.join("-"),
@@ -289,7 +289,8 @@ class Talk < ApplicationRecord
   end
 
   def unused_slugs
-    slug_candidates.reject { |slug| Talk.excluding(self).exists?(slug: slug) }
+    used_slugs = Talk.excluding(self).where(slug: slug_candidates).pluck(:slug)
+    slug_candidates - used_slugs
   end
 
   def update_from_yml_metadata!(event: nil)

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -342,7 +342,7 @@ class Talk < ApplicationRecord
   end
 
   def static_metadata
-    Static::Video.find_by(video_id: video_id)
+    @static_metadata ||= Static::Video.find_by(video_id: video_id)
   end
 
   def suggestion_summary


### PR DESCRIPTION
Hi! 👋 

I've been lurking on this project for a little while, and happened to have a free morning available when issue #391 showed up in my inbox. 😄

I did some rough benchmarking of `db:seed` locally, and found that the majority of the time is spent updating talks, and 50%+ of that duration was spent on the following two lines in `Talk#update_from_yml_metadata!`:

* [`assign_attributes`](https://github.com/adrienpoly/rubyvideo/blob/ba946f6c29185718814c889229640b33856661d9/app/models/talk.rb#L316-L331)
* [`unused_slugs.first`](https://github.com/adrienpoly/rubyvideo/blob/ba946f6c29185718814c889229640b33856661d9/app/models/talk.rb#L339)

With these two commits, I'm seeing `db:seed` run in ~27 seconds locally now. 🎉

### Before

```
assign_attributes total elapsed: 46.42051896639168
unused_slugs.first total elapsed: 20.0830240547657
```

### After

```
assign_attributes total elapsed: 0.23879502154886723
unused_slugs.first total elapsed: 2.2362280655652285
```