### PR TITLE
update entrypoint to match Rails 8

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,7 +1,13 @@
 #!/bin/bash -e
 
+# Enable jemalloc for reduced memory usage and latency.
+if [ -z "${LD_PRELOAD+x}" ]; then
+    LD_PRELOAD=$(find /usr/lib -name libjemalloc.so.2 -print -quit)
+    export LD_PRELOAD
+fi
+
 # If running the rails server then create or migrate existing database
-if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare
 fi
 


### PR DESCRIPTION
close #390

the entry point wasn't updated to match the new entry point from Rails 8 with Thruster so rails db:prepare wasn't triggered on new deploy.

This replace the entry point with the new Rails 8 default