### PR TITLE
extract smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     needs: test
     name: Deploy
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,44 @@ jobs:
 
       # - name: Smoke test database seeds
       #   run: sudo bin/rails db:reset
+  seed_smoke_test:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+      SEED_SMOKE_TEST: true
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler: default
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Meilisearch setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:v1.1 meilisearch --no-analytics
+
+      - name: Build assets
+        run: bin/vite build --clear --mode=test
+
+      - name: Prepare database
+        run: |
+          bin/rails db:create
+          bin/rails db:schema:load
+
+      - name: Run Seed Smoke Test
+        run: bin/rails test test/tasks/db_seed_test.rb
   deploy:
-    needs: test
+    needs: [lint, test, seed_smoke_test]
     name: Deploy
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: macos-latest

--- a/test/tasks/db_seed_test.rb
+++ b/test/tasks/db_seed_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class DbSeedTest < ActiveSupport::TestCase
-  if ENV["CI"]
+  if ENV["SEED_SMOKE_TEST"]
     self.use_transactional_tests = false # don't use fixtures for this test
 
     setup do


### PR DESCRIPTION
extract the seed smoke test in its own workflow. I think this should make test/seed/lint all run under 1min

relates to #391 