### PR TITLE
Preserve scroll position when navigating back to talks

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("dropdown", DropdownController)
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 
+import PreserveScrollController from "./preserve_scroll_controller"
+application.register("preserve-scroll", PreserveScrollController)
+
 import PronounsSelectController from "./pronouns_select_controller"
 application.register("pronouns-select", PronounsSelectController)
 

--- a/app/javascript/controllers/preserve_scroll_controller.js
+++ b/app/javascript/controllers/preserve_scroll_controller.js
@@ -1,0 +1,50 @@
+import { Controller } from '@hotwired/stimulus'
+import { nextFrame } from '../helpers/timing_helpers'
+
+// Connects to data-controller="preserve-scroll"
+export default class extends Controller {
+  async connect () {
+    if (this.scrollTop) {
+      await nextFrame() // we need to wait for the next frame to ensure the scroll position is set
+      window.scrollTo(0, this.scrollTop)
+
+      // remove the scrollTop from the url params
+      const url = new URL(window.location)
+      url.searchParams.delete('scroll_top')
+      window.Turbo.navigator.history.replace(url)
+    }
+  }
+
+  updateLinkBackToWithScrollPosition (e) {
+    // usually invoked on an hover event, it will rewrite the back_to url with the current scroll position
+    const link = e.currentTarget.href
+    if (!link) return
+
+    const url = new URL(link)
+    const urlParams = url.searchParams
+    const backTo = urlParams.get('back_to')
+    if (!backTo) return
+
+    // Get current scroll position
+    const scrollY = parseInt(window.scrollY)
+
+    // Create a URL object to handle the backTo path's parameters
+    const backToUrl = new URL(backTo, window.location.origin)
+
+    // Set or update the scroll_top parameter
+    backToUrl.searchParams.set('scroll_top', scrollY)
+
+    // Update the back_to parameter with the modified path + query
+    urlParams.set('back_to', backToUrl.pathname + backToUrl.search)
+
+    console.log(url.toString())
+    // Update the href with the modified URL
+    e.currentTarget.href = url.toString()
+  }
+
+  get scrollTop () {
+    // from url params scroll_top
+    const urlParams = new URLSearchParams(window.location.search)
+    return urlParams.get('scroll_top')
+  }
+}

--- a/app/javascript/helpers/timing_helpers.js
+++ b/app/javascript/helpers/timing_helpers.js
@@ -1,0 +1,19 @@
+export function nextEventLoopTick () {
+  return delay(0)
+}
+
+export function onNextEventLoopTick (callback) {
+  setTimeout(callback, 0)
+}
+
+export function nextFrame () {
+  return new Promise(requestAnimationFrame)
+}
+
+export function nextEventNamed (eventName, element = window) {
+  return new Promise(resolve => element.addEventListener(eventName, resolve, { once: true }))
+}
+
+export function delay (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
     <%= yield :head %>
   </head>
 
-  <body>
+  <body data-controller="preserve-scroll">
     <%= render "shared/navbar" %>
     <%= render "shared/flashes" %>
 

--- a/app/views/page/home.html.erb
+++ b/app/views/page/home.html.erb
@@ -30,7 +30,7 @@
         <%= link_to "see all talks", talks_path, class: "link text-right w-full" %>
       </div>
       <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
-        <%= render partial: "talks/card", collection: @latest_talks, as: :talk, cached: true %>
+        <%= render partial: "talks/card", collection: @latest_talks, as: :talk, cached: true, locals: {back_to: root_path, back_to_title: "Home"} %>
       </div>
     </section>
 

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -3,7 +3,7 @@
 <% language = Language.by_code(talk.language) %>
 
 <div class="card card-compact bg-white shadow-xl w-full" id="<%= dom_id talk %>">
-  <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden relative group" do %>
+  <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), class: "flex aspect-video overflow-hidden relative group", data: {action: "mouseover->preserve-scroll#updateLinkBackToWithScrollPosition"} do %>
     <% if language && language != "English" %>
       <div class="absolute top-0 left-0 z-20 m-3 p-1 px-2 bg-black/15 backdrop-blur-md rounded-full">
         <span><%= language_to_emoji(language) %></span>
@@ -32,7 +32,7 @@
   <div class="card-body flex flex-row justify-between items-start gap-2">
     <div class="flex flex-col items-start h-full justify-between gap-2 w-full">
       <div class="flex items-start justify-between gap-2 w-full">
-        <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title) do %>
+        <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), data: {action: "mouseover->preserve-scroll#updateLinkBackToWithScrollPosition"} do %>
           <%= content_tag :h2, class: "text-sm font-sans font-medium" do %>
             <%= sanitize(talk.title_with_snippet, tags: ["mark"]) %>
           <% end %>


### PR DESCRIPTION
## Problem
Currently, when users scroll down, navigate to a talk, and then return, the scroll position is not preserved. This creates a suboptimal UX: users lose their place on the page, which can be frustrating. Additionally, it causes a jarring visual effect during the page transition, where the talk image quickly snaps to the bottom of the page.

## Solution
This PR introduces a mechanism to preserve the scroll position when navigating back via the app’s back button. Note that handling the browser's native back button will require a different solution (see [Hotwired Turbo issue #37](https://github.com/hotwired/turbo/issues/37) for potential approaches).

## Implementation
- Back URL Rewriting: On hover, we dynamically rewrite the back_to URL to include the current scroll position.
- Scroll Restoration: A Stimulus controller reads the scroll_top position from the URL parameters and restores the scroll position when the user returns to the previous page.

This ensures a smoother and more intuitive user experience when navigating between talks.

## Demo

https://github.com/user-attachments/assets/c7f1ec97-410f-4018-9ab8-2703a63bcfa3

