### PR TITLE
fix css for avatar in tab

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,6 +2,7 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+@import "components/avatar.css";
 @import "components/diff.css";
 @import "components/dropdown.css";
 @import "components/form.css";

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,13 +2,13 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
-@import "components/avatar.css";
 @import "components/diff.css";
 @import "components/dropdown.css";
 @import "components/form.css";
 @import "components/markdown.css";
 @import "components/nav.css";
 @import "components/pagination.css";
+@import "components/tabs.css";
 @import "components/transition.css";
 @import "components/typography.css";
 @import "components/video.css";

--- a/app/assets/stylesheets/components/avatar.css
+++ b/app/assets/stylesheets/components/avatar.css
@@ -1,0 +1,5 @@
+@layer components {
+  .avatar img {
+    height: auto;
+  }
+}

--- a/app/assets/stylesheets/components/avatar.css
+++ b/app/assets/stylesheets/components/avatar.css
@@ -1,5 +1,0 @@
-@layer components {
-  .avatar img {
-    height: auto;
-  }
-}

--- a/app/assets/stylesheets/components/tabs.css
+++ b/app/assets/stylesheets/components/tabs.css
@@ -1,0 +1,14 @@
+@layer components {
+  /* https://github.com/saadeghi/daisyui/issues/2988 */
+  .tabs {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .tab {
+    order: 0;
+  }
+  .tab-content {
+    order: 1;
+    width: 100%;
+  }
+}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,6 +76,10 @@ Rails.application.configure do
 
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  # https://vite-ruby.netlify.app/guide/troubleshooting.html#safari-does-not-reflect-css-and-js-changes-in-development
+  # https://bugs.webkit.org/show_bug.cgi?id=193533
+  config.action_view.preload_links_header = false
+
   if ENV["PROFILE"]
     config.cache_classes = true
     config.eager_load = true


### PR DESCRIPTION
close #411

We had a bug when displaying an avatar inside a tab in Safari 
Setting the img height to auto rather than 100% seems to do the trick