### PR TITLE
navigate talks in turbo frame

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -25,6 +25,9 @@ application.register("scroll-into-view", ScrollIntoViewController)
 import SplideController from "./splide_controller"
 application.register("splide", SplideController)
 
+import TalksNavigationController from "./talks_navigation_controller"
+application.register("talks-navigation", TalksNavigationController)
+
 import TooltipController from "./tooltip_controller"
 application.register("tooltip", TooltipController)
 

--- a/app/javascript/controllers/preserve_scroll_controller.js
+++ b/app/javascript/controllers/preserve_scroll_controller.js
@@ -37,7 +37,6 @@ export default class extends Controller {
     // Update the back_to parameter with the modified path + query
     urlParams.set('back_to', backToUrl.pathname + backToUrl.search)
 
-    console.log(url.toString())
     // Update the href with the modified URL
     e.currentTarget.href = url.toString()
   }

--- a/app/javascript/controllers/talks_navigation_controller.js
+++ b/app/javascript/controllers/talks_navigation_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller="talks-navigation"
+export default class extends Controller {
+  static targets = ['card']
+
+  connect () {
+    this.elementToScroll.scrollIntoView({ block: 'center' })
+  }
+
+  setActive (e) {
+    this.cardTargets.forEach(card => {
+      card.classList.remove('active')
+    })
+    e.currentTarget.classList.add('active')
+  }
+
+  get elementToScroll () {
+    return this.hasActiveTarget ? this.activeTarget : this.element
+  }
+}

--- a/app/views/talks/_card_horizontal.html.erb
+++ b/app/views/talks/_card_horizontal.html.erb
@@ -1,21 +1,25 @@
-<%# locals: (talk:, current_talk: nil, compact: false, watched_talks_ids:) -%>
+<%# locals: (talk:, current_talk: nil, compact: false, turbo_frame: nil, watched_talks_ids:) -%>
 
 <% active = talk == current_talk %>
-<%= link_to talk_path(talk), class: class_names("w-full flex items-center gap-4 p-2 rounded-lg hover:bg-gray-200", "bg-gray-200": active),
+<%= link_to talk_path(talk),
+      class: class_names("w-full flex items-center gap-4 p-2 rounded-lg hover:bg-gray-200 group", active: active, watched: watched_talks_ids.include?(talk.id)),
       id: dom_id(talk, :card_horizontal),
-      data: {talk_horizontal_card: true, scroll_into_view_target: (active ? "active" : nil), controller: "tooltip", tooltip_content_value: talk.title} do %>
+      data: {talk_horizontal_card: true,
+             scroll_into_view_target: (active ? "active" : nil),
+             talks_navigation_target: "card",
+             action: "talks-navigation#setActive",
+             turbo_frame: turbo_frame,
+             controller: "tooltip", tooltip_content_value: talk.title} do %>
   <div class="flex aspect-video shrink-0 relative w-20">
     <%= image_tag talk.thumbnail_sm, srcset: ["#{talk.thumbnail_sm} 2x"], id: dom_id(talk), class: "w-full h-auto object-cover border rounded", loading: :lazy %>
 
-    <% if active %>
-      <div class="absolute inset-0 bg-black/50 flex justify-center items-center rounded">
-        <%= fa("play", size: :sm, class: "fill-white") %>
-      </div>
-    <% elsif watched_talks_ids.include?(talk.id) %>
-      <button data-tip="Talk Watched" class="tooltip tooltip-right absolute inset-0 bg-black/50 flex justify-center items-center rounded">
-        <%= fa("circle-check", size: :sm, class: "fill-white") %>
-      </button>
-    <% end %>
+    <div class="absolute inset-0 bg-black/50 justify-center items-center rounded hidden group-[.active]:flex">
+      <%= fa("play", size: :sm, class: "fill-white") %>
+    </div>
+
+    <button data-tip="Talk Watched" class="tooltip tooltip-right absolute inset-0 bg-black/50 justify-center items-center rounded hidden group-[.watched]:flex group-[.active]:hidden">
+      <%= fa("circle-check", size: :sm, class: "fill-white") %>
+    </button>
   </div>
 
   <div class="flex flex-col gap-1 text-sm">

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -17,8 +17,10 @@
         <% cache_key = [@talk] %>
       <% end %>
 
-      <% cache cache_key do %>
-        <%= render partial: "talks/talk", locals: {talk: @talk} %>
+      <%= turbo_frame_tag "talk", target: "_top", data: {turbo_action: "advance"} do %>
+        <% cache cache_key do %>
+          <%= render partial: "talks/talk", locals: {talk: @talk} %>
+        <% end %>
       <% end %>
 
       <% cache @talk.event do %>
@@ -30,11 +32,11 @@
       <%= link_to @talk.event.name, event_path(@talk.event), class: "text-neutral text-base text-lg font-bold hover:underline" %>
 
       <div class="relative group border border-transparent hover:border-gray-200 rounded-xl">
-        <div class="flex flex-col gap-2 lg:max-h-[390px] xl:max-h-[480px] 2xl:max-h-[625px] overflow-y-scroll" data-controller="scroll-into-view">
+        <div class="flex flex-col gap-2 lg:max-h-[390px] xl:max-h-[480px] 2xl:max-h-[625px] overflow-y-scroll" data-controller="scroll-into-view talks-navigation">
           <%= render partial: "talks/card_horizontal",
                 collection: @related_talks,
                 as: :talk,
-                locals: {compact: true, current_talk: @talk, watched_talks_ids: user_watched_talks_ids} %>
+                locals: {compact: true, current_talk: @talk, turbo_frame: "talk", watched_talks_ids: user_watched_talks_ids} %>
         </div>
         <div class="absolute bottom-0 left-0 w-full h-36 bg-gradient-to-t from-base-100 to-transparent pointer-events-none group-hover:hidden"></div>
       </div>


### PR DESCRIPTION
Display talk in a turbo frame so that we can navigate from one event talk to the other instantly without loosing track

https://github.com/user-attachments/assets/1daeebdd-9a1a-4255-8482-99d048c0363a


