### PR TITLE
Add tooltips to talks list

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -25,6 +25,9 @@ application.register("scroll-into-view", ScrollIntoViewController)
 import SplideController from "./splide_controller"
 application.register("splide", SplideController)
 
+import TooltipController from "./tooltip_controller"
+application.register("tooltip", TooltipController)
+
 import TransitionController from "./transition_controller"
 application.register("transition", TransitionController)
 

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from '@hotwired/stimulus'
+
+import tippy from 'tippy.js'
+import 'tippy.js/dist/tippy.css'
+
+// Connects to data-controller="tooltip"
+export default class extends Controller {
+  static values = {
+    content: String
+  }
+
+  connect () {
+    tippy(this.element, { content: this.contentValue })
+  }
+}

--- a/app/views/talks/_card_horizontal.html.erb
+++ b/app/views/talks/_card_horizontal.html.erb
@@ -3,7 +3,7 @@
 <% active = talk == current_talk %>
 <%= link_to talk_path(talk), class: class_names("w-full flex items-center gap-4 p-2 rounded-lg hover:bg-gray-200", "bg-gray-200": active),
       id: dom_id(talk, :card_horizontal),
-      data: {talk_horizontal_card: true, scroll_into_view_target: (active ? "active" : nil)} do %>
+      data: {talk_horizontal_card: true, scroll_into_view_target: (active ? "active" : nil), controller: "tooltip", tooltip_content_value: talk.title} do %>
   <div class="flex aspect-video shrink-0 relative w-20">
     <%= image_tag talk.thumbnail_sm, srcset: ["#{talk.thumbnail_sm} 2x"], id: dom_id(talk), class: "w-full h-auto object-cover border rounded", loading: :lazy %>
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "morphdom": "^2.7.0",
     "rfs": "^10.0.0",
     "stimulus-use": "^0.52.0",
+    "tippy.js": "^6.3.7",
     "vlitejs": "^6.0.3"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,6 +288,11 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@popperjs/core@^2.9.0":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@rails/actioncable@^7.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.1.3.tgz#4db480347775aeecd4dde2405659eef74a458881"
@@ -2759,6 +2764,13 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
+
+tippy.js@^6.3.7:
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.7.tgz#8ccfb651d642010ed9a32ff29b0e9e19c5b8c61c"
+  integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==
+  dependencies:
+    "@popperjs/core" "^2.9.0"
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
### Why?

- Issue: #405 
- When watching a talk, you can see the list of other event talks on the right. Some have long titles, so it’d be nice to show a tooltip on hover for the full title.

### What?

I added [Tippy.js](https://atomiks.github.io/tippyjs/) to have proper positioning and flexibility.

![Kapture 2024-11-20 at 13 25 28](https://github.com/user-attachments/assets/8e075c86-b514-45fa-ba41-d8b18b2b9125)
