### PR TITLE
remove watched talks n+1

### DIFF
--- a/app/controllers/concerns/watched_talks.rb
+++ b/app/controllers/concerns/watched_talks.rb
@@ -1,0 +1,13 @@
+module WatchedTalks
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :user_watched_talks_ids
+  end
+
+  private
+
+  def user_watched_talks_ids
+    @user_watched_talks_ids ||= Current.user&.watched_talks&.pluck(:talk_id) || []
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 class EventsController < ApplicationController
+  include WatchedTalks
   include Pagy::Backend
   skip_before_action :authenticate_user!, only: %i[index show update]
   before_action :set_event, only: %i[show edit update]

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -4,6 +4,7 @@ class SpeakersController < ApplicationController
   before_action :set_user_favorites, only: %i[show]
   include Pagy::Backend
   include RemoteModal
+  include WatchedTalks
   respond_with_remote_modal only: [:edit]
 
   # GET /speakers
@@ -24,7 +25,6 @@ class SpeakersController < ApplicationController
     @talks = @speaker.talks.with_essential_card_data.order(date: :desc)
     @back_path = speakers_path
     set_meta_tags(@speaker)
-    # fresh_when(@speaker)
   end
 
   # GET /speakers/1/edit

--- a/app/controllers/talks/recommendations_controller.rb
+++ b/app/controllers/talks/recommendations_controller.rb
@@ -1,4 +1,5 @@
 class Talks::RecommendationsController < ApplicationController
+  include WatchedTalks
   skip_before_action :authenticate_user!
   before_action :set_talk, only: %i[index]
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,5 +1,6 @@
 class TalksController < ApplicationController
   include Pagy::Backend
+  include WatchedTalks
   skip_before_action :authenticate_user!
   before_action :set_talk, only: %i[show edit update]
   before_action :set_user_favorites, only: %i[index show]

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,5 +1,6 @@
 class TopicsController < ApplicationController
   include Pagy::Backend
+  include WatchedTalks
   skip_before_action :authenticate_user!
   before_action :set_user_favorites, only: %i[show]
 

--- a/app/controllers/watch_lists_controller.rb
+++ b/app/controllers/watch_lists_controller.rb
@@ -1,4 +1,5 @@
 class WatchListsController < ApplicationController
+  include WatchedTalks
   before_action :authenticate_user!
   before_action :set_watch_list, only: [:show, :edit, :update, :destroy]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy, inverse_of: :user
   has_many :connected_accounts, dependent: :destroy
   has_many :watch_lists, dependent: :destroy
+  has_many :watched_talks, dependent: :destroy
   has_one :speaker, primary_key: :github_handle, foreign_key: :github
 
   validates :email, presence: true, uniqueness: true, format: {with: URI::MailTo::EMAIL_REGEXP}
@@ -60,6 +61,6 @@ class User < ApplicationRecord
   end
 
   def default_watch_list
-    watch_lists.first || watch_lists.create(name: "Favorites")
+    @default_watch_list ||= watch_lists.first || watch_lists.create(name: "Favorites")
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -51,6 +51,7 @@
               locals: {
                 favoritable: true,
                 user_favorite_talks_ids: @user_favorite_talks_ids,
+                watched_talks_ids: user_watched_talks_ids,
                 back_to: request.fullpath,
                 back_to_title: @event.name
               },

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -37,6 +37,7 @@
               locals: {
                 favoritable: true,
                 user_favorite_talks_ids: @user_favorite_talks_ids,
+                watched_talks_ids: user_watched_talks_ids,
                 back_to: request.fullpath,
                 back_to_title: @speaker.name
               } %>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (talk:, user_favorite_talks_ids: [], favoritable: false, back_to: nil, back_to_title: nil) -%>
+<%# locals: (talk:, user_favorite_talks_ids: [], favoritable: false, back_to: nil, back_to_title: nil, watched_talks_ids: []) -%>
 
 <% language = Language.by_code(talk.language) %>
 
@@ -11,7 +11,7 @@
       </div>
     <% end %>
 
-    <% if talk.watched? %>
+    <% if watched_talks_ids.include?(talk.id) %>
       <div class="absolute z-10 flex inset-0 bg-black/50 hover:bg-black/40 justify-center items-center rounded-t-xl">
         <div class="bg-gray-700 rounded-full px-3 py-2 justify-center items-center flex text-white gap-4">
           <%= fa("circle-check", size: :md, class: "fill-white") %>

--- a/app/views/talks/_card_horizontal.html.erb
+++ b/app/views/talks/_card_horizontal.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (talk:, current_talk: nil, compact: false) -%>
+<%# locals: (talk:, current_talk: nil, compact: false, watched_talks_ids:) -%>
 
 <% active = talk == current_talk %>
 <%= link_to talk_path(talk), class: class_names("w-full flex items-center gap-4 p-2 rounded-lg hover:bg-gray-200", "bg-gray-200": active),
@@ -11,7 +11,7 @@
       <div class="absolute inset-0 bg-black/50 flex justify-center items-center rounded">
         <%= fa("play", size: :sm, class: "fill-white") %>
       </div>
-    <% elsif talk.watched? %>
+    <% elsif watched_talks_ids.include?(talk.id) %>
       <button data-tip="Talk Watched" class="tooltip tooltip-right absolute inset-0 bg-black/50 flex justify-center items-center rounded">
         <%= fa("circle-check", size: :sm, class: "fill-white") %>
       </button>

--- a/app/views/talks/recommendations/index.html.erb
+++ b/app/views/talks/recommendations/index.html.erb
@@ -1,10 +1,9 @@
 <%= turbo_frame_tag "recommended_talks" do %>
   <div data-turbo-temporary data-controller="transition" class="hidden" data-transition-enter-after-value="0">
     <%= render partial: "talks/card_horizontal",
-               collection: @talks,
-               as: :talk,
-               locals: {compact: true,
-                        watched_talks_ids: user_watched_talks_ids} %>
+          collection: @talks,
+          as: :talk,
+          locals: {compact: true,
+                   watched_talks_ids: user_watched_talks_ids} %>
   </div>
 <% end %>
-

--- a/app/views/talks/recommendations/index.html.erb
+++ b/app/views/talks/recommendations/index.html.erb
@@ -1,5 +1,10 @@
 <%= turbo_frame_tag "recommended_talks" do %>
   <div data-turbo-temporary data-controller="transition" class="hidden" data-transition-enter-after-value="0">
-    <%= render partial: "talks/card_horizontal", collection: @talks, as: :talk, locals: {compact: true} %>
+    <%= render partial: "talks/card_horizontal",
+               collection: @talks,
+               as: :talk,
+               locals: {compact: true,
+                        watched_talks_ids: user_watched_talks_ids} %>
   </div>
 <% end %>
+

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -30,7 +30,7 @@
           <%= render partial: "talks/card_horizontal",
                 collection: @related_talks,
                 as: :talk,
-                locals: {compact: true, current_talk: @talk} %>
+                locals: {compact: true, current_talk: @talk, watched_talks_ids: user_watched_talks_ids} %>
         </div>
         <div class="absolute bottom-0 left-0 w-full h-36 bg-gradient-to-t from-base-100 to-transparent pointer-events-none group-hover:hidden"></div>
       </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -17,6 +17,7 @@
           locals: {
             favoritable: true,
             user_favorite_talks_ids: @user_favorite_talks_ids,
+            watched_talks_ids: user_watched_talks_ids,
             back_to: request.fullpath,
             back_to_title: @topic.name
           } %>

--- a/app/views/watch_lists/_watch_list.html.erb
+++ b/app/views/watch_lists/_watch_list.html.erb
@@ -7,6 +7,7 @@
           locals: {
             favoritable: true,
             user_favorite_talks_ids: watch_list.talks.ids,
+            watched_talks_ids: user_watched_talks_ids,
             back_to: watch_lists_path,
             back_to_title: watch_list.name
           } %>

--- a/app/views/watch_lists/index.html.erb
+++ b/app/views/watch_lists/index.html.erb
@@ -7,6 +7,8 @@
 
   </div>
   <%= turbo_frame_tag "watch_list_talks", target: "_top", src: watch_list_path(@watch_list) do %>
-    <%= render partial: "watch_lists/watch_list", locals: {watch_list: @watch_list} %>
+    <%= render partial: "watch_lists/watch_list",
+               locals: {watch_list: @watch_list,
+                        watched_talks_ids: user_watched_talks_ids} %>
   <% end %>
 </div>

--- a/app/views/watch_lists/index.html.erb
+++ b/app/views/watch_lists/index.html.erb
@@ -8,7 +8,7 @@
   </div>
   <%= turbo_frame_tag "watch_list_talks", target: "_top", src: watch_list_path(@watch_list) do %>
     <%= render partial: "watch_lists/watch_list",
-               locals: {watch_list: @watch_list,
-                        watched_talks_ids: user_watched_talks_ids} %>
+          locals: {watch_list: @watch_list,
+                   watched_talks_ids: user_watched_talks_ids} %>
   <% end %>
 </div>

--- a/app/views/watch_lists/show.html.erb
+++ b/app/views/watch_lists/show.html.erb
@@ -1,3 +1,5 @@
 <%= turbo_frame_tag "watch_list_talks", target: "" do %>
-  <%= render partial: "watch_lists/watch_list", locals: {watch_list: @watch_list} %>
+  <%= render partial: "watch_lists/watch_list",
+             locals: {watch_list: @watch_list,
+                      watched_talks_ids: user_watched_talks_ids} %>
 <% end %>

--- a/app/views/watch_lists/show.html.erb
+++ b/app/views/watch_lists/show.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "watch_list_talks", target: "" do %>
   <%= render partial: "watch_lists/watch_list",
-             locals: {watch_list: @watch_list,
-                      watched_talks_ids: user_watched_talks_ids} %>
+        locals: {watch_list: @watch_list,
+                 watched_talks_ids: user_watched_talks_ids} %>
 <% end %>


### PR DESCRIPTION
#383 introduced a few perf regressions 

![CleanShot 2024-11-20 at 20 30 02@2x](https://github.com/user-attachments/assets/9cd48f2a-3b33-45ba-ad8e-bf49a0f82910)

![CleanShot 2024-11-20 at 20 26 09@2x](https://github.com/user-attachments/assets/fe5e2639-0406-471c-b8fd-af2d403a9685)

This PR introduce an helper `user_watched_talks_ids` to retrieve all user watched talk ids so that we can test if a talk_id is part of the list to mark it as watch or not within a single query 

