### PR TITLE
extract explore event in its own partial

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -39,7 +39,7 @@ class TalksController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_talk
-    @talk = Talk.includes(:speakers, :approved_topics).find_by(slug: params[:slug])
+    @talk = Talk.includes(:event, :speakers, :approved_topics).find_by(slug: params[:slug])
     return redirect_to talks_path, status: :moved_permanently if @talk.blank?
 
     @related_talks = @talk.event.talks.with_essential_card_data.order(date: :desc)

--- a/app/views/talks/_explore_event.html.erb
+++ b/app/views/talks/_explore_event.html.erb
@@ -1,0 +1,29 @@
+<%= link_to event_path(event), id: "explore-event", class: "card group bg-gray-100 border hover:bg-gray-200/50 transition-bg duration-300 ease-in-out w-full flex flex-row px-6 py-6 gap-8 mt-4 overflow-hidden", style: "background: #{event.featured_background}; color: #{event.featured_color}" do %>
+  <div class="aspect-video hidden md:block">
+    <%= image_tag image_path(event.featured_image_path), id: dom_id(event, "explore-card-image"), alt: "explore all talks recorded at #{event.name}", class: "h-24 aspect-video rounded-xl group-hover:scale-105 transition ease-in-out duration-300" %>
+  </div>
+
+  <div class="flex flex-col w-full flex-1 self-start">
+    <span class="text-lg font-semibold sm:text-md">Explore all talks recorded at <%= event.name %></span>
+
+    <div class="avatar-group -space-x-3 rtl:space-x-reverse mt-4">
+      <% speakers_with_avatars = event.speakers.where.not(github: "").sample(12) %>
+
+      <% speakers_with_avatars.each_with_index do |speaker, index| %>
+        <div class="<%= class_names("avatar bg-white border-2", "hidden lg:block" => index > 8) %>">
+          <div class="w-8">
+            <img src="<%= speaker.github_avatar_url %>" loading="lazy">
+          </div>
+        </div>
+      <% end %>
+
+      <% if event.speakers.size > speakers_with_avatars.size %>
+        <div class="avatar placeholder border-2">
+          <div class="bg-neutral text-neutral-content w-8">
+            <span>+<%= event.speakers.size - speakers_with_avatars.size %></span>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/talks/_explore_event.html.erb
+++ b/app/views/talks/_explore_event.html.erb
@@ -7,10 +7,10 @@
     <span class="text-lg font-semibold sm:text-md">Explore all talks recorded at <%= event.name %></span>
 
     <div class="avatar-group -space-x-3 rtl:space-x-reverse mt-4">
-      <% speakers_with_avatars = event.speakers.where.not(github: "").sample(12) %>
+      <% speakers_with_avatars = event.speakers.where.not(github: "").sample(8) %>
 
-      <% speakers_with_avatars.each_with_index do |speaker, index| %>
-        <div class="<%= class_names("avatar bg-white border-2", "hidden lg:block" => index > 8) %>">
+      <% speakers_with_avatars.each do |speaker| %>
+        <div class="avatar bg-white border-2">
           <div class="w-8">
             <img src="<%= speaker.github_avatar_url %>" loading="lazy">
           </div>

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -208,7 +208,7 @@
         </div>
       <% end %>
 
-      <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="<%= "Speaker".pluralize(talk.speakers.count) %>">
+      <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="<%= "Speaker".pluralize(talk.speakers.size) %>">
       <div role="tabpanel" class="tab-content !rounded-s-xl rounded-xl bg-base-200/50 p-6 mt-6 overflow-hidden">
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           <% talk.speakers.each do |speaker| %>
@@ -219,36 +219,6 @@
         </div>
       </div>
 
-    </div>
-  </div>
-<% end %>
-
-<%= link_to event_path(talk.event), id: "explore-event", class: "card group bg-gray-100 border hover:bg-gray-200/50 transition-bg duration-300 ease-in-out w-full flex flex-row px-6 py-6 gap-8 mt-4 overflow-hidden", style: "background: #{talk.event.featured_background}; color: #{talk.event.featured_color}" do %>
-  <div class="aspect-video hidden md:block">
-    <%= image_tag image_path(talk.event.featured_image_path), id: dom_id(talk.event, "explore-card-image"), alt: "explore all talks recorded at #{talk.event.name}", class: "h-24 aspect-video rounded-xl group-hover:scale-105 transition ease-in-out duration-300" %>
-  </div>
-
-  <div class="flex flex-col w-full flex-1 self-start">
-    <span class="text-lg font-semibold sm:text-md">Explore all talks recorded at <%= talk.event.name %></span>
-
-    <div class="avatar-group -space-x-3 rtl:space-x-reverse mt-4">
-      <% speakers_with_avatars = talk.event.speakers.where.not(github: "").sample(12) %>
-
-      <% speakers_with_avatars.each_with_index do |speaker, index| %>
-        <div class="<%= class_names("avatar bg-white border-2", "hidden lg:block" => index > 8) %>">
-          <div class="w-8">
-            <img src="<%= speaker.github_avatar_url %>" loading="lazy">
-          </div>
-        </div>
-      <% end %>
-
-      <% if talk.event.speakers.count > speakers_with_avatars.count %>
-        <div class="avatar placeholder border-2">
-          <div class="bg-neutral text-neutral-content w-8">
-            <span>+<%= talk.event.speakers.count - speakers_with_avatars.count %></span>
-          </div>
-        </div>
-      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -20,6 +20,10 @@
       <% cache cache_key do %>
         <%= render partial: "talks/talk", locals: {talk: @talk} %>
       <% end %>
+
+      <% cache @talk.event do %>
+        <%= render partial: "talks/explore_event", locals: {event: @talk.event} %>
+      <% end %>
     </div>
 
     <div class="gap-4 w-96 flex-shrink-0 hidden lg:flex lg:flex-col px-4">


### PR DESCRIPTION
extract the explore event card in a partial so that _talk partial is less complex and we can cache the explore event card separetly with a simple key 

following to https://github.com/adrienpoly/rubyvideo/pull/423#discussion_r1850597061 the sample is now 8 speakers 