### PR TITLE
lazy load the talk sidebar

### DIFF
--- a/app/controllers/events/talks_controller.rb
+++ b/app/controllers/events/talks_controller.rb
@@ -1,0 +1,16 @@
+class Events::TalksController < ApplicationController
+  include WatchedTalks
+  skip_before_action :authenticate_user!, only: %i[index]
+  before_action :set_event, only: %i[index]
+
+  def index
+    @talks = @event.talks
+    @active_talk = Talk.find_by(slug: params[:active_talk])
+  end
+
+  private
+
+  def set_event
+    @event = Event.find_by(slug: params[:event_slug])
+  end
+end

--- a/app/controllers/talks/watched_talks_controller.rb
+++ b/app/controllers/talks/watched_talks_controller.rb
@@ -25,11 +25,11 @@ class Talks::WatchedTalksController < ApplicationController
 
   def broadcast_update_to_event_talks
     Turbo::StreamsChannel.broadcast_update_to [@talk.event, :talks],
-                      target: dom_id(@talk.event, :talks),
-                      partial: "events/talks/list",
-                      method: :morph,
-                      locals: {talks: @talk.event.talks,
-                               active_talk: @talk,
-                               watched_talks_ids: user_watched_talks_ids}
+      target: dom_id(@talk.event, :talks),
+      partial: "events/talks/list",
+      method: :morph,
+      locals: {talks: @talk.event.talks,
+               active_talk: @talk,
+               watched_talks_ids: user_watched_talks_ids}
   end
 end

--- a/app/controllers/talks/watched_talks_controller.rb
+++ b/app/controllers/talks/watched_talks_controller.rb
@@ -1,5 +1,9 @@
 class Talks::WatchedTalksController < ApplicationController
+  include ActionView::RecordIdentifier
+  include WatchedTalks
+
   before_action :set_talk
+  after_action :broadcast_update_to_event_talks
 
   def create
     @talk.mark_as_watched!
@@ -17,5 +21,15 @@ class Talks::WatchedTalksController < ApplicationController
 
   def set_talk
     @talk = Talk.find_by(slug: params[:talk_slug])
+  end
+
+  def broadcast_update_to_event_talks
+    Turbo::StreamsChannel.broadcast_update_to [@talk.event, :talks],
+                      target: dom_id(@talk.event, :talks),
+                      partial: "events/talks/list",
+                      method: :morph,
+                      locals: {talks: @talk.event.talks,
+                               active_talk: @talk,
+                               watched_talks_ids: user_watched_talks_ids}
   end
 end

--- a/app/helpers/events/talks_helper.rb
+++ b/app/helpers/events/talks_helper.rb
@@ -1,0 +1,2 @@
+module Events::TalksHelper
+end

--- a/app/views/events/talks/_list.html.erb
+++ b/app/views/events/talks/_list.html.erb
@@ -6,9 +6,9 @@
           collection: talks,
           as: :talk,
           locals: {compact: true,
-                    current_talk: active_talk,
-                    turbo_frame: "talk",
-                    watched_talks_ids: watched_talks_ids} %>
+                   current_talk: active_talk,
+                   turbo_frame: "talk",
+                   watched_talks_ids: watched_talks_ids} %>
   </div>
   <div class="absolute bottom-0 left-0 w-full h-36 bg-gradient-to-t from-base-100 to-transparent pointer-events-none group-hover:hidden"></div>
 </div>

--- a/app/views/events/talks/_list.html.erb
+++ b/app/views/events/talks/_list.html.erb
@@ -1,0 +1,14 @@
+<%# locals: (talks:, active_talk:, watched_talks_ids:) -%>
+
+<div class="relative group border border-transparent hover:border-gray-200 rounded-xl">
+  <div class="flex flex-col gap-2 lg:max-h-[390px] xl:max-h-[480px] 2xl:max-h-[625px] overflow-y-scroll" data-controller="scroll-into-view talks-navigation">
+    <%= render partial: "talks/card_horizontal",
+          collection: talks,
+          as: :talk,
+          locals: {compact: true,
+                    current_talk: active_talk,
+                    turbo_frame: "talk",
+                    watched_talks_ids: watched_talks_ids} %>
+  </div>
+  <div class="absolute bottom-0 left-0 w-full h-36 bg-gradient-to-t from-base-100 to-transparent pointer-events-none group-hover:hidden"></div>
+</div>

--- a/app/views/events/talks/index.html.erb
+++ b/app/views/events/talks/index.html.erb
@@ -1,0 +1,4 @@
+
+<%= turbo_frame_tag dom_id(@event, :talks) do %>
+  <%= render "events/talks/list", talks: @talks, active_talk: @active_talk, watched_talks_ids: user_watched_talks_ids %>
+<% end %>

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -30,16 +30,8 @@
 
     <div class="gap-4 w-96 flex-shrink-0 hidden lg:flex lg:flex-col px-4">
       <%= link_to @talk.event.name, event_path(@talk.event), class: "text-neutral text-base text-lg font-bold hover:underline" %>
-
-      <div class="relative group border border-transparent hover:border-gray-200 rounded-xl">
-        <div class="flex flex-col gap-2 lg:max-h-[390px] xl:max-h-[480px] 2xl:max-h-[625px] overflow-y-scroll" data-controller="scroll-into-view talks-navigation">
-          <%= render partial: "talks/card_horizontal",
-                collection: @related_talks,
-                as: :talk,
-                locals: {compact: true, current_talk: @talk, turbo_frame: "talk", watched_talks_ids: user_watched_talks_ids} %>
-        </div>
-        <div class="absolute bottom-0 left-0 w-full h-36 bg-gradient-to-t from-base-100 to-transparent pointer-events-none group-hover:hidden"></div>
-      </div>
+      <%= turbo_stream_from [@talk.event, :talks] %>
+      <%= turbo_frame_tag dom_id(@talk.event, :talks), src: event_talks_path(@talk.event, active_talk: @talk), loading: "lazy" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,11 @@ Rails.application.routes.draw do
     end
   end
   resources :speakers, param: :slug, only: [:index, :show, :update, :edit]
-  resources :events, param: :slug, only: [:index, :show, :update, :edit]
+  resources :events, param: :slug, only: [:index, :show, :update, :edit] do
+    scope module: :events do
+      resources :talks, only: [:index]
+    end
+  end
   resources :organisations, param: :slug, only: [:index, :show]
   namespace :speakers do
     resources :enhance, only: [:update], param: :slug

--- a/test/controllers/events/talks_controller_test.rb
+++ b/test/controllers/events/talks_controller_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Events::TalksControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    @event = events(:rails_world_2023)
+    @talks = @event.talks
+    @talk = @talks.first
+    get event_talks_path(@event, active_talk: @talk.slug)
+    assert_response :success
+    assert_equal @event, assigns(:event)
+    assert_equal @event.talks, assigns(:talks)
+    assert_equal @talk, assigns(:active_talk)
+  end
+end


### PR DESCRIPTION
The talks#show page is the most visited page, I would like this page to remains blazing fast.

This PR extract the talk side bar to a lazy frame loaded by Turbo
It also adds a broadcast update of the sidebar when we mark a talk as watched (follow up of https://github.com/adrienpoly/rubyvideo/pull/421)

