### PR TITLE
lazy load speaker index

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -9,7 +9,7 @@ class SpeakersController < ApplicationController
 
   # GET /speakers
   def index
-    @speakers = Speaker.order(:name).canonical
+    @speakers = Speaker.with_talks.order(:name).canonical
     @speakers = @speakers.where("lower(name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
     @speakers = @speakers.ft_search(params[:s]) if params[:s].present?
     @pagy, @speakers = pagy(@speakers, limit: 100, page: params[:page])

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -9,12 +9,13 @@ class SpeakersController < ApplicationController
 
   # GET /speakers
   def index
+    @speakers = Speaker.order(:name).canonical
+    @speakers = @speakers.where("lower(name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
+    @speakers = @speakers.ft_search(params[:s]) if params[:s].present?
+    @pagy, @speakers = pagy(@speakers, limit: 100, page: params[:page])
     respond_to do |format|
-      format.html do
-        @speakers = Speaker.with_talks.order(:name).select(:id, :name, :slug, :talks_count, :github, :updated_at)
-        @speakers = @speakers.where("lower(name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
-        @speakers = @speakers.ft_search(params[:s]) if params[:s].present?
-      end
+      format.html
+      format.turbo_stream
       format.json do
         @pagy, @speakers = pagy(Speaker.includes(:canonical).order(:name), limit: params[:per_page])
       end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("dropdown", DropdownController)
 import EventController from "./event_controller"
 application.register("event", EventController)
 
+import LazyLoadingController from "./lazy_loading_controller"
+application.register("lazy-loading", LazyLoadingController)
+
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)
 

--- a/app/javascript/controllers/lazy_loading_controller.js
+++ b/app/javascript/controllers/lazy_loading_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from '@hotwired/stimulus'
+import { useIntersection } from 'stimulus-use'
+
+// Connects to data-controller="lazy-loading"
+export default class extends Controller {
+  static values = {
+    src: String,
+    rootMargin: { type: String, default: '100px 0px 0px 0px' }
+  }
+
+  initialize () {
+    useIntersection(this, { rootMargin: this.rootMarginValue })
+  }
+
+  appear () {
+    this.element.setAttribute('src', this.srcValue)
+  }
+}

--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -24,7 +24,7 @@
     <%= turbo_frame_tag :pagination,
                         data: {
                           controller: "lazy-loading",
-                          lazy_loading_src_value: speakers_path(letter: params[:letter], page: @pagy.next, format: :turbo_stream)
+                          lazy_loading_src_value: speakers_path(letter: params[:letter], s: params[:s], page: @pagy.next, format: :turbo_stream)
                         } %>
   <% end %>
 </div>

--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -22,9 +22,9 @@
   </div>
   <% if @pagy.next.present? %>
     <%= turbo_frame_tag :pagination,
-                        data: {
-                          controller: "lazy-loading",
-                          lazy_loading_src_value: speakers_path(letter: params[:letter], s: params[:s], page: @pagy.next, format: :turbo_stream)
-                        } %>
+          data: {
+            controller: "lazy-loading",
+            lazy_loading_src_value: speakers_path(letter: params[:letter], s: params[:s], page: @pagy.next, format: :turbo_stream)
+          } %>
   <% end %>
 </div>

--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -20,4 +20,11 @@
       <%= render partial: "speakers/speaker", collection: @speakers, as: :speaker, cached: true %>
     <% end %>
   </div>
+  <% if @pagy.next.present? %>
+    <%= turbo_frame_tag :pagination,
+                        data: {
+                          controller: "lazy-loading",
+                          lazy_loading_src_value: speakers_path(letter: params[:letter], page: @pagy.next, format: :turbo_stream)
+                        } %>
+  <% end %>
 </div>

--- a/app/views/speakers/index.turbo_stream.erb
+++ b/app/views/speakers/index.turbo_stream.erb
@@ -9,7 +9,7 @@
     <%= turbo_frame_tag :pagination,
                         data: {
                           controller: "lazy-loading",
-                          lazy_loading_src_value: speakers_path(letter: params[:letter], page: @pagy.next, format: :turbo_stream)
+                          lazy_loading_src_value: speakers_path(letter: params[:letter], s: params[:s], page: @pagy.next, format: :turbo_stream)
                         } %>
   <% end %>
 <% end %>

--- a/app/views/speakers/index.turbo_stream.erb
+++ b/app/views/speakers/index.turbo_stream.erb
@@ -1,0 +1,15 @@
+<%= turbo_stream.append "speakers" do %>
+  <% cache @speakers do %>
+    <%= render partial: "speakers/speaker", collection: @speakers, as: :speaker, cached: true %>
+  <% end %>
+<% end %>
+
+<% if @pagy.next.present? %>
+  <%= turbo_stream.replace "pagination" do %>
+    <%= turbo_frame_tag :pagination,
+                        data: {
+                          controller: "lazy-loading",
+                          lazy_loading_src_value: speakers_path(letter: params[:letter], page: @pagy.next, format: :turbo_stream)
+                        } %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
with more than 2k speakers to display the speaker index page starts to be very long 

This PR adds an infinite scroll display where speakers are loaded by chunk of 100

https://github.com/user-attachments/assets/920a4f75-7ffc-42d6-bf98-08059935aa3a

