### PR TITLE
add event, speaker, kind, topics talks filter and asc/desc order_by

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -42,10 +42,10 @@ class TalksController < ApplicationController
       "date_desc" => "talks.date DESC",
       "date_asc" => "talks.date ASC"
     }
-      
+
     @order_by ||= begin
       order = params[:order_by].presence_in(order_by_options.keys) || "date_desc"
- 
+
       order_by_options[order]
     end
   end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -38,11 +38,15 @@ class TalksController < ApplicationController
   private
 
   def order_by
-    @order_by ||= params[:order_by].presence_in(%w[date_desc date_asc]).then do |order|
-      {
-        "date_desc" => "talks.date DESC",
-        "date_asc" => "talks.date ASC"
-      }[order] || "talks.date DESC"
+    order_by_options = {
+      "date_desc" => "talks.date DESC",
+      "date_asc" => "talks.date ASC"
+    }
+      
+    @order_by ||= begin
+      order = params[:order_by].presence_in(order_by_options.keys) || "date_desc"
+ 
+      order_by_options[order]
     end
   end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -7,14 +7,13 @@ class TalksController < ApplicationController
 
   # GET /talks
   def index
-    if params[:q].present?
-      talks = Talk.with_essential_card_data.pagy_search(params[:q])
-      @pagy, @talks = pagy_meilisearch(talks, limit: 20, page: params[:page]&.to_i || 1)
-    elsif params[:s].present?
-      @pagy, @talks = pagy(Talk.with_essential_card_data.ft_search(params[:s]).with_snippets.ranked, items: 20, page: params[:page]&.to_i || 1)
-    else
-      @pagy, @talks = pagy(Talk.all.with_essential_card_data.order(date: :desc), items: 20)
-    end
+    @talks = Talk.with_essential_card_data.order(order_by)
+    @talks = @talks.ft_search(params[:s]).with_snippets.ranked if params[:s].present?
+    @talks = @talks.for_topic(params[:topic]) if params[:topic].present?
+    @talks = @talks.for_event(params[:event]) if params[:event].present?
+    @talks = @talks.for_speaker(params[:speaker]) if params[:speaker].present?
+    @talks = @talks.where(kind: talk_kind) if talk_kind.present?
+    @pagy, @talks = pagy(@talks, items: 20, page: params[:page]&.to_i || 1)
   end
 
   # GET /talks/1
@@ -37,6 +36,19 @@ class TalksController < ApplicationController
   end
 
   private
+
+  def order_by
+    @order_by ||= params[:order_by].presence_in(%w[date_desc date_asc]).then do |order|
+      {
+        "date_desc" => "talks.date DESC",
+        "date_asc" => "talks.date ASC"
+      }[order] || "talks.date DESC"
+    end
+  end
+
+  def talk_kind
+    @talk_kind ||= params[:kind].presence_in(Talk.kinds.keys)
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_talk

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -9,7 +9,7 @@
 #  enhanced_transcript :text             default(#<Transcript:0x0000000120e51930 @cues=[]>), not null
 #  external_player     :boolean          default(FALSE), not null
 #  external_player_url :string           default(""), not null
-#  kind                :string           default("talk"), not null
+#  kind                :string           default("talk"), not null, indexed
 #  language            :string           default("en"), not null
 #  like_count          :integer
 #  raw_transcript      :text             default(#<Transcript:0x0000000120e51a98 @cues=[]>), not null
@@ -34,6 +34,7 @@
 #
 #  index_talks_on_date        (date)
 #  index_talks_on_event_id    (event_id)
+#  index_talks_on_kind        (kind)
 #  index_talks_on_slug        (slug)
 #  index_talks_on_title       (title)
 #  index_talks_on_updated_at  (updated_at)
@@ -130,6 +131,9 @@ class Talk < ApplicationRecord
   scope :without_summary, -> { where("summary IS NULL OR summary = ''") }
   scope :without_topics, -> { where.missing(:talk_topics) }
   scope :with_topics, -> { joins(:talk_topics) }
+  scope :for_topic, ->(topic_slug) { joins(:topics).where(topics: {slug: topic_slug}) }
+  scope :for_speaker, ->(speaker_slug) { joins(:speakers).where(speakers: {slug: speaker_slug}) }
+  scope :for_event, ->(event_slug) { joins(:event).where(events: {slug: event_slug}) }
 
   scope :with_essential_card_data, -> do
     select(:id, :slug, :title, :date, :thumbnail_sm, :thumbnail_lg, :video_id, :video_provider, :event_id, :language)

--- a/db/migrate/20241122163052_add_index_on_kind_for_talks.rb
+++ b/db/migrate/20241122163052_add_index_on_kind_for_talks.rb
@@ -1,0 +1,5 @@
+class AddIndexOnKindForTalks < ActiveRecord::Migration[8.0]
+  def change
+    add_index :talks, :kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_22_155013) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_22_163052) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -207,6 +207,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_22_155013) do
     t.string "kind", default: "talk", null: false
     t.index ["date"], name: "index_talks_on_date"
     t.index ["event_id"], name: "index_talks_on_event_id"
+    t.index ["kind"], name: "index_talks_on_kind"
     t.index ["slug"], name: "index_talks_on_slug"
     t.index ["title"], name: "index_talks_on_title"
     t.index ["updated_at"], name: "index_talks_on_updated_at"

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -19,6 +19,27 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", /search results for "rails"/i
   end
 
+  test "should get index with topic" do
+    get talks_url(topic: "activerecord")
+    assert_response :success
+    assert assigns(:talks).size.positive?
+    assert assigns(:talks).all? { |talk| talk.topics.map(&:slug).include?("activerecord") }
+  end
+
+  test "should get index with event" do
+    get talks_url(event: "rails-world-2023")
+    assert_response :success
+    assert assigns(:talks).size.positive?
+    assert assigns(:talks).all? { |talk| talk.event.slug == "rails-world-2023" }
+  end
+
+  test "should get index with speaker" do
+    get talks_url(speaker: "yaroslav-shmarov")
+    assert_response :success
+    assert assigns(:talks).size.positive?
+    assert assigns(:talks).all? { |talk| talk.speakers.map(&:slug).include?("yaroslav-shmarov") }
+  end
+
   test "should show talk" do
     get talk_url(@talk)
     assert_response :success

--- a/test/fixtures/speaker_talks.yml
+++ b/test/fixtures/speaker_talks.yml
@@ -18,5 +18,5 @@
 # rubocop:enable Layout/LineLength
 
 one:
-  speaker: one
+  speaker: yaroslav
   talk: one

--- a/test/fixtures/speakers.yml
+++ b/test/fixtures/speakers.yml
@@ -68,3 +68,10 @@ michael:
   bio: Author of the @railstutorial, founder of @learnenough, @softcover, and Tau Day.
   website: https://www.michaelhartl.com/
   slug: michael-hartl
+yaroslav:
+  name: Yaroslav Shmarov
+  twitter: yarotheslav
+  github: yshmarov
+  bio: "Source code for My Ruby on Rails tutorials: @corsego"
+  website: https://superails.com/
+  slug: yaroslav-shmarov

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -9,7 +9,7 @@
 #  enhanced_transcript :text             default(#<Transcript:0x0000000120e51930 @cues=[]>), not null
 #  external_player     :boolean          default(FALSE), not null
 #  external_player_url :string           default(""), not null
-#  kind                :string           default("talk"), not null
+#  kind                :string           default("talk"), not null, indexed
 #  language            :string           default("en"), not null
 #  like_count          :integer
 #  raw_transcript      :text             default(#<Transcript:0x0000000120e51a98 @cues=[]>), not null
@@ -34,6 +34,7 @@
 #
 #  index_talks_on_date        (date)
 #  index_talks_on_event_id    (event_id)
+#  index_talks_on_kind        (kind)
 #  index_talks_on_slug        (slug)
 #  index_talks_on_title       (title)
 #  index_talks_on_updated_at  (updated_at)

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -238,4 +238,9 @@ class TalkTest < ActiveSupport::TestCase
     assert_match %r{^/assets/events/brightonruby/brightonruby-2024/poster-.*.webp$}, talk.thumbnail
     assert_match %r{^/assets/events/brightonruby/brightonruby-2024/poster-.*.webp$}, talk.thumbnail(:thumbnail_xl)
   end
+
+  test "for_topic" do
+    talk = talks(:one)
+    assert_includes Talk.for_topic("activerecord"), talk
+  end
 end


### PR DESCRIPTION
It doesn't do much at this point but it give the possibility to manually filter the talks results from the url

**Examples:**

- `/talks?kind=keynote&order_by=date_asc`
- `/talks?speaker=marco-roth&order_by=date_desc&topic=hotwire`

This is the foundation to build filters in addition to the search 