### PR TITLE
Add more Talk kinds and improve the matching of existing kinds

### DIFF
--- a/app/models/static/backends/multi_file_backend.rb
+++ b/app/models/static/backends/multi_file_backend.rb
@@ -12,7 +12,12 @@ module Static::Backends
     def load(file_path = @glob)
       Dir.glob(file_path).flat_map { |file|
         begin
-          @backend.load(file)
+          @backend.load(file).map { |item|
+            {
+              **item,
+              "__file_path" => Pathname.new(file).relative_path_from(Rails.root).to_s
+            }.freeze
+          }
         rescue Psych::SyntaxError => e
           puts "#{e.message} in #{file}"
           raise e

--- a/app/models/static/playlist.rb
+++ b/app/models/static/playlist.rb
@@ -13,15 +13,13 @@ module Static
 
     def start_date
       Date.parse(super)
-    rescue => e
-      puts e.inspect
+    rescue TypeError
       super
     end
 
     def end_date
       Date.parse(super)
-    rescue => e
-      puts e.inspect
+    rescue TypeError
       super
     end
   end

--- a/app/models/static/playlist.rb
+++ b/app/models/static/playlist.rb
@@ -13,13 +13,13 @@ module Static
 
     def start_date
       Date.parse(super)
-    rescue TypeError
+    rescue TypeError, Date::Error
       super
     end
 
     def end_date
       Date.parse(super)
-    rescue TypeError
+    rescue TypeError, Date::Error
       super
     end
   end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -82,7 +82,7 @@ class Talk < ApplicationRecord
   # enums
   enum :video_provider, %w[youtube mp4 scheduled not_recorded].index_by(&:itself)
   enum :kind,
-    %w[talk keynote lightning_talk micro_talk panel workshop gameshow fishbowl podcast q_and_a discussion fireside_chat
+    %w[talk keynote lightning_talk panel workshop gameshow podcast q_and_a discussion fireside_chat
       award].index_by(&:itself)
 
   # attributes

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -374,7 +374,7 @@ class Talk < ApplicationRecord
         :fishbowl
       when /.*(podcast:|podcast\ recording:|live\ podcast:).*/i
         :podcast
-      when /.*(q&a|q&a:|ama|q&a\ with).*/i
+      when /.*(q&a|q&a:|ama|q&a\ with|ruby\ committers\ vs\ the\ world|ruby\ committers\ and\ the\ world).*/i
         :q_and_a
       when /.*(discussion:|discussion).*/i
         :discussion

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -81,7 +81,9 @@ class Talk < ApplicationRecord
 
   # enums
   enum :video_provider, %w[youtube mp4 scheduled not_recorded].index_by(&:itself)
-  enum :kind, %w[talk keynote lightning_talk micro_talk panel workshop gameshow fishbowl podcast q_and_a discussion fireside_chat award].index_by(&:itself)
+  enum :kind,
+    %w[talk keynote lightning_talk micro_talk panel workshop gameshow fishbowl podcast q_and_a discussion fireside_chat
+      award].index_by(&:itself)
 
   # attributes
   attribute :video_provider, default: :youtube
@@ -356,34 +358,33 @@ class Talk < ApplicationRecord
   end
 
   def set_kind
-    self.kind =
-      case title
-      when /.*(keynote:|opening\ keynote|closing\ keynote|keynote|opening\ keynote|closing\ keynote).*/i
-        :keynote
-      when /.*(lightning\ talk:|lightning\ talk|lightning\ talks).*/i
-        :lightning_talk
-      when /.*(micro\ talk:|micro\ talk).*/i
-        :micro_talk
-       when /.*(panel:|panel).*/i
-        :panel
-      when /.*(workshop:|workshop).*/i
-        :workshop
-      when /.*(gameshow|game\ show|gameshow:|game\ show:).*/i
-        :gameshow
-      when /.*(fishbowl:|fishbowl\ discussion:).*/i
-        :fishbowl
-      when /.*(podcast:|podcast\ recording:|live\ podcast:).*/i
-        :podcast
-      when /.*(q&a|q&a:|ama|q&a\ with|ruby\ committers\ vs\ the\ world|ruby\ committers\ and\ the\ world).*/i
-        :q_and_a
-      when /.*(discussion:|discussion).*/i
-        :discussion
-      when /.*(fireside\ chat:|fireside\ chat).*/i
-        :fireside_chat
-      when /.*(award:|award\ show|ruby\ hero\ awards|ruby\ hero\ award|rails\ luminary).*/i
-        :award
-      else
-        :talk
-      end
+    self.kind = case title
+    when /.*(keynote:|opening\ keynote|closing\ keynote|keynote|opening\ keynote|closing\ keynote).*/i
+      :keynote
+    when /.*(lightning\ talk:|lightning\ talk|lightning\ talks).*/i
+      :lightning_talk
+    when /.*(micro\ talk:|micro\ talk).*/i
+      :micro_talk
+    when /.*(panel:|panel).*/i
+      :panel
+    when /.*(workshop:|workshop).*/i
+      :workshop
+    when /.*(gameshow|game\ show|gameshow:|game\ show:).*/i
+      :gameshow
+    when /.*(fishbowl:|fishbowl\ discussion:).*/i
+      :fishbowl
+    when /.*(podcast:|podcast\ recording:|live\ podcast:).*/i
+      :podcast
+    when /.*(q&a|q&a:|ama|q&a\ with|ruby\ committers\ vs\ the\ world|ruby\ committers\ and\ the\ world).*/i
+      :q_and_a
+    when /.*(discussion:|discussion).*/i
+      :discussion
+    when /.*(fireside\ chat:|fireside\ chat).*/i
+      :fireside_chat
+    when /.*(award:|award\ show|ruby\ hero\ awards|ruby\ hero\ award|rails\ luminary).*/i
+      :award
+    else
+      :talk
+    end
   end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -358,6 +358,15 @@ class Talk < ApplicationRecord
   end
 
   def set_kind
+    if static_metadata && static_metadata.kind.present?
+      unless static_metadata.kind.in?(Talk.kinds.keys)
+        puts %(WARN: "#{title}" has an unknown talk kind defined in #{static_metadata.__file_path})
+      end
+
+      self.kind = static_metadata.kind
+      return
+    end
+
     self.kind = case title
     when /.*(keynote:|opening\ keynote|closing\ keynote|keynote|opening\ keynote|closing\ keynote).*/i
       :keynote

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -370,23 +370,19 @@ class Talk < ApplicationRecord
     self.kind = case title
     when /.*(keynote:|opening\ keynote|closing\ keynote|keynote|opening\ keynote|closing\ keynote).*/i
       :keynote
-    when /.*(lightning\ talk:|lightning\ talk|lightning\ talks).*/i
+    when /.*(lightning\ talk:|lightning\ talk|lightning\ talks|micro\ talk:|micro\ talk).*/i
       :lightning_talk
-    when /.*(micro\ talk:|micro\ talk).*/i
-      :micro_talk
     when /.*(panel:|panel).*/i
       :panel
     when /.*(workshop:|workshop).*/i
       :workshop
     when /.*(gameshow|game\ show|gameshow:|game\ show:).*/i
       :gameshow
-    when /.*(fishbowl:|fishbowl\ discussion:).*/i
-      :fishbowl
     when /.*(podcast:|podcast\ recording:|live\ podcast:).*/i
       :podcast
     when /.*(q&a|q&a:|ama|q&a\ with|ruby\ committers\ vs\ the\ world|ruby\ committers\ and\ the\ world).*/i
       :q_and_a
-    when /.*(discussion:|discussion).*/i
+    when /.*(fishbowl:|fishbowl\ discussion:|discussion:|discussion).*/i
       :discussion
     when /.*(fireside\ chat:|fireside\ chat).*/i
       :fireside_chat

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -81,7 +81,7 @@ class Talk < ApplicationRecord
 
   # enums
   enum :video_provider, %w[youtube mp4 scheduled not_recorded].index_by(&:itself)
-  enum :kind, %w[talk keynote lightning_talk panel workshop].index_by(&:itself)
+  enum :kind, %w[talk keynote lightning_talk micro_talk panel workshop gameshow fishbowl podcast q_and_a discussion fireside_chat award].index_by(&:itself)
 
   # attributes
   attribute :video_provider, default: :youtube
@@ -358,14 +358,30 @@ class Talk < ApplicationRecord
   def set_kind
     self.kind =
       case title
-      when /.*(keynote:|opening\ keynote|closing\ keynote).*/i
+      when /.*(keynote:|opening\ keynote|closing\ keynote|keynote|opening\ keynote|closing\ keynote).*/i
         :keynote
-      when /.*workshop:.*/i
-        :workshop
-      when /.*panel:.*/i
-        :panel
-      when /.*lightning\ talk: .*/i
+      when /.*(lightning\ talk:|lightning\ talk|lightning\ talks).*/i
         :lightning_talk
+      when /.*(micro\ talk:|micro\ talk).*/i
+        :micro_talk
+       when /.*(panel:|panel).*/i
+        :panel
+      when /.*(workshop:|workshop).*/i
+        :workshop
+      when /.*(gameshow|game\ show|gameshow:|game\ show:).*/i
+        :gameshow
+      when /.*(fishbowl:|fishbowl\ discussion:).*/i
+        :fishbowl
+      when /.*(podcast:|podcast\ recording:|live\ podcast:).*/i
+        :podcast
+      when /.*(q&a|q&a:|ama|q&a\ with).*/i
+        :q_and_a
+      when /.*(discussion:|discussion).*/i
+        :discussion
+      when /.*(fireside\ chat:|fireside\ chat).*/i
+        :fireside_chat
+      when /.*(award:|award\ show|ruby\ hero\ awards|ruby\ hero\ award|rails\ luminary).*/i
+        :award
       else
         :talk
       end

--- a/data/brightonruby/brightonruby-2024/videos.yml
+++ b/data/brightonruby/brightonruby-2024/videos.yml
@@ -197,6 +197,7 @@
   raw_title: "Who Wants to be a Ruby Engineer?"
   speakers:
     - Drew Bragg
+  kind: gameshow
   event_name: Brighton Ruby 2024
   published_at: "2024-06-28"
   external_player: true

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -36,7 +36,7 @@ class TalkTest < ActiveSupport::TestCase
       gameshow: ["Gameshow", "Game Show", "Gameshow: Something", "Game Show: Something"],
       fishbowl: ["Fishbowl: Topic", "Fishbowl Discussion: Topic"],
       podcast: ["Podcast: Something", "Podcast Recording: Something", "Live Podcast: Something"],
-      q_and_a: ["Q&A", "Q&A: Something", "Something AMA", "Q&A with Somebody"],
+      q_and_a: ["Q&A", "Q&A: Something", "Something AMA", "Q&A with Somebody", "Ruby Committers vs The World", "Ruby Committers and the World"],
       discussion: ["Discussion: Something", "Discussion"],
       fireside_chat: ["Fireside Chat: Something", "Fireside Chat"],
       award: ["Award: Something", "Award Show", "Ruby Hero Awards", "Ruby Hero Award", "Rails Luminary"],

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -29,7 +29,7 @@ class TalkTest < ActiveSupport::TestCase
     kind_with_titles = {
       talk: ["I love Ruby"],
       keynote: ["Keynote: Something ", "foo Opening keynote bar", "closing keynote foo bar", "Keynote", "Keynote by Someone", "Opening Keynote", "Closing Keynote"],
-      lightning_talk: ["Lightning Talk: Something", "lightning talk: Something", "Lightning talk: Something", "lightning talk", "Lightning Talks", "Lightning talks", "lightning talks",  "Lightning Talks Day 1", "Lightning Talks (Day 1)", "Lightning Talks - Day 1"],
+      lightning_talk: ["Lightning Talk: Something", "lightning talk: Something", "Lightning talk: Something", "lightning talk", "Lightning Talks", "Lightning talks", "lightning talks", "Lightning Talks Day 1", "Lightning Talks (Day 1)", "Lightning Talks - Day 1"],
       micro_talk: ["Micro Talk: Something", "micro talk: Something", "micro talk: Something", "micro talk"],
       panel: ["Panel: foo", "Panel", "Something Panel"],
       workshop: ["Workshop: Something", "workshop: Something"],
@@ -39,7 +39,7 @@ class TalkTest < ActiveSupport::TestCase
       q_and_a: ["Q&A", "Q&A: Something", "Something AMA", "Q&A with Somebody", "Ruby Committers vs The World", "Ruby Committers and the World"],
       discussion: ["Discussion: Something", "Discussion"],
       fireside_chat: ["Fireside Chat: Something", "Fireside Chat"],
-      award: ["Award: Something", "Award Show", "Ruby Hero Awards", "Ruby Hero Award", "Rails Luminary"],
+      award: ["Award: Something", "Award Show", "Ruby Hero Awards", "Ruby Hero Award", "Rails Luminary"]
     }
 
     kind_with_titles.each do |kind, titles|

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -29,15 +29,13 @@ class TalkTest < ActiveSupport::TestCase
     kind_with_titles = {
       talk: ["I love Ruby"],
       keynote: ["Keynote: Something ", "foo Opening keynote bar", "closing keynote foo bar", "Keynote", "Keynote by Someone", "Opening Keynote", "Closing Keynote"],
-      lightning_talk: ["Lightning Talk: Something", "lightning talk: Something", "Lightning talk: Something", "lightning talk", "Lightning Talks", "Lightning talks", "lightning talks", "Lightning Talks Day 1", "Lightning Talks (Day 1)", "Lightning Talks - Day 1"],
-      micro_talk: ["Micro Talk: Something", "micro talk: Something", "micro talk: Something", "micro talk"],
+      lightning_talk: ["Lightning Talk: Something", "lightning talk: Something", "Lightning talk: Something", "lightning talk", "Lightning Talks", "Lightning talks", "lightning talks", "Lightning Talks Day 1", "Lightning Talks (Day 1)", "Lightning Talks - Day 1", "Micro Talk: Something", "micro talk: Something", "micro talk: Something", "micro talk"],
       panel: ["Panel: foo", "Panel", "Something Panel"],
       workshop: ["Workshop: Something", "workshop: Something"],
       gameshow: ["Gameshow", "Game Show", "Gameshow: Something", "Game Show: Something"],
-      fishbowl: ["Fishbowl: Topic", "Fishbowl Discussion: Topic"],
       podcast: ["Podcast: Something", "Podcast Recording: Something", "Live Podcast: Something"],
       q_and_a: ["Q&A", "Q&A: Something", "Something AMA", "Q&A with Somebody", "Ruby Committers vs The World", "Ruby Committers and the World"],
-      discussion: ["Discussion: Something", "Discussion"],
+      discussion: ["Discussion: Something", "Discussion", "Fishbowl: Topic", "Fishbowl Discussion: Topic"],
       fireside_chat: ["Fireside Chat: Something", "Fireside Chat"],
       award: ["Award: Something", "Award Show", "Ruby Hero Awards", "Ruby Hero Award", "Rails Luminary"]
     }

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -60,6 +60,16 @@ class TalkTest < ActiveSupport::TestCase
     assert_equal "panel", talk.kind
   end
 
+  test "should not guess a kind if it's provided in the static metadata" do
+    talk = Talk.create!(
+      title: "Who Wants to be a Ruby Engineer?",
+      video_provider: "mp4",
+      video_id: "https://videos.brightonruby.com/videos/2024/drew-bragg-who-wants-to-be-a-ruby-engineer.mp4"
+    )
+
+    assert_equal "gameshow", talk.kind
+  end
+
   test "transcript should default to raw_transcript" do
     raw_transcript = Transcript.new(cues: [Cue.new(start_time: 0, end_time: 1, text: "Hello")])
     talk = Talk.new(title: "Sample Talk", raw_transcript: raw_transcript)

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -28,10 +28,18 @@ class TalkTest < ActiveSupport::TestCase
   test "should guess kind from title" do
     kind_with_titles = {
       talk: ["I love Ruby"],
-      keynote: ["Keynote: foo ", "foo Opening keynote bar", "closing keynote foo bar"],
-      lightning_talk: ["lightning talk: foo"],
-      panel: ["Panel: foo"],
-      workshop: ["workshop: foo"]
+      keynote: ["Keynote: Something ", "foo Opening keynote bar", "closing keynote foo bar", "Keynote", "Keynote by Someone", "Opening Keynote", "Closing Keynote"],
+      lightning_talk: ["Lightning Talk: Something", "lightning talk: Something", "Lightning talk: Something", "lightning talk", "Lightning Talks", "Lightning talks", "lightning talks",  "Lightning Talks Day 1", "Lightning Talks (Day 1)", "Lightning Talks - Day 1"],
+      micro_talk: ["Micro Talk: Something", "micro talk: Something", "micro talk: Something", "micro talk"],
+      panel: ["Panel: foo", "Panel", "Something Panel"],
+      workshop: ["Workshop: Something", "workshop: Something"],
+      gameshow: ["Gameshow", "Game Show", "Gameshow: Something", "Game Show: Something"],
+      fishbowl: ["Fishbowl: Topic", "Fishbowl Discussion: Topic"],
+      podcast: ["Podcast: Something", "Podcast Recording: Something", "Live Podcast: Something"],
+      q_and_a: ["Q&A", "Q&A: Something", "Something AMA", "Q&A with Somebody"],
+      discussion: ["Discussion: Something", "Discussion"],
+      fireside_chat: ["Fireside Chat: Something", "Fireside Chat"],
+      award: ["Award: Something", "Award Show", "Ruby Hero Awards", "Ruby Hero Award", "Rails Luminary"],
     }
 
     kind_with_titles.each do |kind, titles|
@@ -40,6 +48,8 @@ class TalkTest < ActiveSupport::TestCase
         talk.save!
 
         assert_equal kind.to_s, talk.kind
+
+        talk.destroy!
       end
     end
   end


### PR DESCRIPTION
We have a lot more different kinds of "talks" in our current dataset. This pull request adds a few more kinds to better represent our dataset:

<img src="https://github.com/user-attachments/assets/2830db9a-2ad2-4784-bee3-eb74ad8fc397" width="50%"/>

Follow up on #334 
