### PR TITLE
Talks json api endpoint

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -57,9 +57,8 @@ class TalksController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_talk
     @talk = Talk.includes(:approved_topics, speakers: :user, event: :organisation).find_by(slug: params[:slug])
-    return redirect_to talks_path, status: :moved_permanently if @talk.blank?
 
-    @related_talks = @talk.event.talks.with_essential_card_data.order(date: :desc)
+    redirect_to talks_path, status: :moved_permanently if @talk.blank?
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/views/talks/index.json.jbuilder
+++ b/app/views/talks/index.json.jbuilder
@@ -1,0 +1,24 @@
+json.talks @talks do |talk|
+  json.slug talk.slug
+  json.title talk.title
+  json.date talk.date
+  json.url talk_url(talk)
+
+  json.event do
+    json.slug talk.event&.slug
+    json.name talk.event&.name
+  end
+
+  json.speakers talk.speakers do |speaker|
+    json.slug speaker.slug
+    json.name speaker.name
+  end
+end
+
+json.pagination do
+  json.current_page @pagy.page
+  json.total_pages @pagy.pages
+  json.total_count @pagy.count
+  json.next_page @pagy.next
+  json.prev_page @pagy.prev
+end

--- a/app/views/talks/show.json.jbuilder
+++ b/app/views/talks/show.json.jbuilder
@@ -1,0 +1,52 @@
+json.talk do
+  json.slug @talk.slug
+  json.title @talk.title
+  json.description @talk.description
+  json.summary @talk.summary
+  json.date @talk.date
+  json.kind @talk.kind
+  json.video_provider @talk.video_provider
+  json.video_id @talk.video_id
+  json.slides_url @talk.slides_url
+
+  if @talk.event.present?
+    json.event do
+      json.slug @talk.event.slug
+      json.name @talk.event.name
+      json.start_date @talk.event.start_date
+      json.end_date @talk.event.end_date
+
+      if @talk.event.organisation.present?
+        json.organisation do
+          json.id @talk.event.organisation.id
+          json.name @talk.event.organisation.name
+          json.slug @talk.event.organisation.slug
+        end
+      end
+    end
+  end
+
+  json.speakers @talk.speakers do |speaker|
+    json.id speaker.id
+    json.name speaker.name
+    json.slug speaker.slug
+    if speaker.user.present?
+      json.bio speaker.user.bio
+      json.avatar_url speaker.user.avatar_url
+    end
+  end
+
+  json.topics @talk.approved_topics do |topic|
+    json.id topic.id
+    json.name topic.name
+    json.slug topic.slug
+  end
+
+  json.transcript do
+    json.raw @talk.raw_transcript
+    json.enhanced @talk.enhanced_transcript
+  end
+
+  json.created_at @talk.created_at
+  json.updated_at @talk.updated_at
+end

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -119,4 +119,12 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     json_response = JSON.parse(response.body)
     assert_equal @talk.slug, json_response["talks"].first["slug"]
   end
+
+  test "should get show as JSON" do
+    get talk_url(@talk, format: :json)
+    assert_response :success
+
+    json_response = JSON.parse(response.body)
+    assert_equal @talk.slug, json_response["talk"]["slug"]
+  end
 end

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -111,4 +111,12 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     assert_select "a .badge", count: 1, text: "#activerecord"
     assert_select "a .badge", count: 0, text: "#rejected"
   end
+
+  test "should get index as JSON" do
+    get talks_url(format: :json)
+    assert_response :success
+
+    json_response = JSON.parse(response.body)
+    assert_equal @talk.slug, json_response["talks"].first["slug"]
+  end
 end


### PR DESCRIPTION
This PR adds a JSON API endpoint for the talks

I see several use cases for that 
1. ability to easily dump locally all the AI data such as topics/transcripts (similar to what we have for the speakers end point)
2. I got requests from other services willing to index RubyVideo.dev and that would be usesful
