### PR TITLE
Add job to fetch metadata from Bluesky

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem "countries"
 # ISO 639-1 and ISO 639-2 language code entries and convenience methods
 gem "iso-639"
 
+# A minimal client of Bluesky/ATProto API
+gem "minisky", "~> 0.4.0"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,8 @@ GEM
       actionpack (>= 6.0.0, < 8.1)
     method_source (1.1.0)
     mini_mime (1.1.5)
+    minisky (0.4.0)
+      base64 (~> 0.1)
     minitest (5.25.1)
     mission_control-jobs (0.5.0)
       actioncable (>= 7.1)
@@ -619,6 +621,7 @@ DEPENDENCIES
   litestream (~> 0.10.1)
   meilisearch-rails
   meta-tags (~> 2.18)
+  minisky (~> 0.4.0)
   mission_control-jobs
   net-http (~> 0.3.2)
   omniauth

--- a/app/controllers/speakers/enhance_controller.rb
+++ b/app/controllers/speakers/enhance_controller.rb
@@ -1,9 +1,12 @@
 class Speakers::EnhanceController < ApplicationController
   def update
     @speaker = Speaker.find_by(slug: params[:slug])
-    Speaker::EnhanceProfileJob.perform_later(speaker: @speaker)
+
+    Speaker::EnhanceProfileJob.perform_later(speaker: @speaker) if @speaker.github.present?
+    Speaker::FetchBskyMetadata.perform_later(speaker: @speaker) if @speaker.bsky.present?
 
     flash[:notice] = "Speaker profile will be updated soon."
+
     respond_to do |format|
       format.turbo_stream
     end

--- a/app/jobs/speaker/fetch_bsky_metadata.rb
+++ b/app/jobs/speaker/fetch_bsky_metadata.rb
@@ -1,6 +1,8 @@
 require "minisky"
 
 class Speaker::FetchBskyMetadata < ApplicationJob
+  BSKY_HOST = "api.bsky.app".freeze
+
   queue_as :low
   retry_on StandardError, attempts: 0
   limits_concurrency to: 1, key: "bsky"
@@ -8,7 +10,7 @@ class Speaker::FetchBskyMetadata < ApplicationJob
   def perform(speaker:)
     return if speaker.bsky.blank?
 
-    response = bsky.get_request('app.bsky.actor.getProfile', {
+    response = bsky.get_request("app.bsky.actor.getProfile", {
       actor: speaker.bsky
     })
 
@@ -18,6 +20,6 @@ class Speaker::FetchBskyMetadata < ApplicationJob
   private
 
   def bsky
-    @bsky ||= Minisky.new('api.bsky.app', nil)
+    @bsky ||= Minisky.new(BSKY_HOST, nil)
   end
 end

--- a/app/jobs/speaker/fetch_bsky_metadata.rb
+++ b/app/jobs/speaker/fetch_bsky_metadata.rb
@@ -1,0 +1,23 @@
+require "minisky"
+
+class Speaker::FetchBskyMetadata < ApplicationJob
+  queue_as :low
+  retry_on StandardError, attempts: 0
+  limits_concurrency to: 1, key: "bsky"
+
+  def perform(speaker:)
+    return if speaker.bsky.blank?
+
+    response = bsky.get_request('app.bsky.actor.getProfile', {
+      actor: speaker.bsky
+    })
+
+    speaker.update!(bsky_metadata: response)
+  end
+
+  private
+
+  def bsky
+    @bsky ||= Minisky.new('api.bsky.app', nil)
+  end
+end

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -6,6 +6,7 @@
 #  id            :integer          not null, primary key
 #  bio           :text             default(""), not null
 #  bsky          :string           default(""), not null
+#  bsky_metadata :json             not null
 #  github        :string           default(""), not null
 #  linkedin      :string           default(""), not null
 #  mastodon      :string           default(""), not null

--- a/app/views/speakers/actions/_admin.html.erb
+++ b/app/views/speakers/actions/_admin.html.erb
@@ -8,9 +8,9 @@
     <span>Update speaker page</span>
   <% end %>
 
-  <% if speaker.github.present? %>
+  <% if speaker.github.present? || speaker.bsky.present? %>
     <%= ui_button url: speakers_enhance_path(@speaker), method: :put, kind: :ghost, size: :sm do %>
-      <span>Fetch from GitHub</span>
+      <span>Enhance Profile</span>
     <% end %>
   <% end %>
 

--- a/db/migrate/20241128073415_add_bsky_metadata_to_speaker.rb
+++ b/db/migrate/20241128073415_add_bsky_metadata_to_speaker.rb
@@ -1,0 +1,5 @@
+class AddBskyMetadataToSpeaker < ActiveRecord::Migration[8.0]
+  def change
+    add_column :speakers, :bsky_metadata, :jsonb, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_22_163052) do
+ActiveRecord::Schema[8.0].define(version: 2024_11_28_073415) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -149,6 +149,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_22_163052) do
     t.string "mastodon", default: "", null: false
     t.string "bsky", default: "", null: false
     t.string "linkedin", default: "", null: false
+    t.json "bsky_metadata", default: {}, null: false
     t.index ["canonical_id"], name: "index_speakers_on_canonical_id"
     t.index ["name"], name: "index_speakers_on_name"
     t.index ["slug"], name: "index_speakers_on_slug", unique: true

--- a/test/fixtures/speakers.yml
+++ b/test/fixtures/speakers.yml
@@ -6,6 +6,7 @@
 #  id            :integer          not null, primary key
 #  bio           :text             default(""), not null
 #  bsky          :string           default(""), not null
+#  bsky_metadata :json             not null
 #  github        :string           default(""), not null
 #  linkedin      :string           default(""), not null
 #  mastodon      :string           default(""), not null


### PR DESCRIPTION
This pull request adds a job to fetch public metadata from a speakers Bluesky profile using the [minisky](https://github.com/mackuba/minisky) gem.

The [`app.bsky.actor.getProfile`](https://docs.bsky.app/docs/api/app-bsky-actor-get-profile) endpoint luckily doesn't require any authentication which is we don't need any API keys/app generated passwords for now.