### PR TITLE
Store `github_metadata` to serve avatar using `avatar_url`

### DIFF
--- a/app/jobs/speaker/enhance_profile_job.rb
+++ b/app/jobs/speaker/enhance_profile_job.rb
@@ -30,7 +30,11 @@ class Speaker::EnhanceProfileJob < ApplicationJob
       bsky: speaker.bsky.presence || bsky || "",
       linkedin: speaker.linkedin.presence || linkedin || "",
       bio: speaker.bio.presence || profile.bio || "",
-      website: speaker.website.presence || profile.blog || ""
+      website: speaker.website.presence || profile.blog || "",
+      github_metadata: {
+        profile: JSON.parse(profile.body),
+        socials: JSON.parse(socials.body)
+      }
     )
 
     speaker.broadcast_about
@@ -44,7 +48,7 @@ class Speaker::EnhanceProfileJob < ApplicationJob
   end
 
   def user_social_accounts(username)
-    client.social_accounts(username).parsed_body
+    client.social_accounts(username)
   end
 
   def client

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -3,24 +3,25 @@
 #
 # Table name: speakers
 #
-#  id            :integer          not null, primary key
-#  bio           :text             default(""), not null
-#  bsky          :string           default(""), not null
-#  bsky_metadata :json             not null
-#  github        :string           default(""), not null
-#  linkedin      :string           default(""), not null
-#  mastodon      :string           default(""), not null
-#  name          :string           default(""), not null, indexed
-#  pronouns      :string           default(""), not null
-#  pronouns_type :string           default("not_specified"), not null
-#  slug          :string           default(""), not null, indexed
-#  speakerdeck   :string           default(""), not null
-#  talks_count   :integer          default(0), not null
-#  twitter       :string           default(""), not null
-#  website       :string           default(""), not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  canonical_id  :integer          indexed
+#  id              :integer          not null, primary key
+#  bio             :text             default(""), not null
+#  bsky            :string           default(""), not null
+#  bsky_metadata   :json             not null
+#  github          :string           default(""), not null
+#  github_metadata :json             not null
+#  linkedin        :string           default(""), not null
+#  mastodon        :string           default(""), not null
+#  name            :string           default(""), not null, indexed
+#  pronouns        :string           default(""), not null
+#  pronouns_type   :string           default("not_specified"), not null
+#  slug            :string           default(""), not null, indexed
+#  speakerdeck     :string           default(""), not null
+#  talks_count     :integer          default(0), not null
+#  twitter         :string           default(""), not null
+#  website         :string           default(""), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  canonical_id    :integer          indexed
 #
 # Indexes
 #
@@ -145,6 +146,10 @@ class Speaker < ApplicationRecord
 
   def github_avatar_url(size: 200)
     return nil unless github.present?
+
+    metadata_avatar_url = github_metadata.dig("profile", "avatar_url")
+
+    return "#{metadata_avatar_url}&size=#{size}" if metadata_avatar_url.present?
 
     "https://github.com/#{github}.png?size=#{size}"
   end

--- a/db/migrate/20241203001515_add_github_metadata_to_speaker.rb
+++ b/db/migrate/20241203001515_add_github_metadata_to_speaker.rb
@@ -1,0 +1,5 @@
+class AddGitHubMetadataToSpeaker < ActiveRecord::Migration[8.0]
+  def change
+    add_column :speakers, :github_metadata, :jsonb, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_28_073415) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_03_001515) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -150,6 +150,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_28_073415) do
     t.string "bsky", default: "", null: false
     t.string "linkedin", default: "", null: false
     t.json "bsky_metadata", default: {}, null: false
+    t.json "github_metadata", default: {}, null: false
     t.index ["canonical_id"], name: "index_speakers_on_canonical_id"
     t.index ["name"], name: "index_speakers_on_name"
     t.index ["slug"], name: "index_speakers_on_slug", unique: true

--- a/test/fixtures/speakers.yml
+++ b/test/fixtures/speakers.yml
@@ -3,24 +3,25 @@
 #
 # Table name: speakers
 #
-#  id            :integer          not null, primary key
-#  bio           :text             default(""), not null
-#  bsky          :string           default(""), not null
-#  bsky_metadata :json             not null
-#  github        :string           default(""), not null
-#  linkedin      :string           default(""), not null
-#  mastodon      :string           default(""), not null
-#  name          :string           default(""), not null, indexed
-#  pronouns      :string           default(""), not null
-#  pronouns_type :string           default("not_specified"), not null
-#  slug          :string           default(""), not null, indexed
-#  speakerdeck   :string           default(""), not null
-#  talks_count   :integer          default(0), not null
-#  twitter       :string           default(""), not null
-#  website       :string           default(""), not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  canonical_id  :integer          indexed
+#  id              :integer          not null, primary key
+#  bio             :text             default(""), not null
+#  bsky            :string           default(""), not null
+#  bsky_metadata   :json             not null
+#  github          :string           default(""), not null
+#  github_metadata :json             not null
+#  linkedin        :string           default(""), not null
+#  mastodon        :string           default(""), not null
+#  name            :string           default(""), not null, indexed
+#  pronouns        :string           default(""), not null
+#  pronouns_type   :string           default("not_specified"), not null
+#  slug            :string           default(""), not null, indexed
+#  speakerdeck     :string           default(""), not null
+#  talks_count     :integer          default(0), not null
+#  twitter         :string           default(""), not null
+#  website         :string           default(""), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  canonical_id    :integer          indexed
 #
 # Indexes
 #

--- a/test/jobs/speaker/enhance_profile_job_test.rb
+++ b/test/jobs/speaker/enhance_profile_job_test.rb
@@ -15,6 +15,10 @@ class Speaker::EnhanceProfileJobTest < ActiveJob::TestCase
       assert_equal "https://mastodon.social/@tenderlove", speaker.mastodon
 
       assert speaker.bio.present?
+      assert speaker.github_metadata.present?
+
+      assert_equal 3124, speaker.github_metadata.dig("profile", "id")
+      assert_equal "https://twitter.com/tenderlove", speaker.github_metadata.dig("socials", 0, "url")
     end
   end
 
@@ -23,6 +27,9 @@ class Speaker::EnhanceProfileJobTest < ActiveJob::TestCase
 
     Speaker::EnhanceProfileJob.new.perform(speaker: speaker)
 
-    assert_equal "", speaker.reload.github
+    speaker.reload
+
+    assert_equal "", speaker.github
+    assert_equal({}, speaker.github_metadata)
   end
 end


### PR DESCRIPTION
This pull_requests adds a `github_metadata` to the  `Speaker`  model so we can store the direct-link `avatar_url` for the speakers.

The current approach of using `https://github.com/[username].png` is always doing a redirect which sometimes wouldn't resolve. This makes it more reliable since we don't have to depend on the redirect to happen.

Resolves #330 