### PR TITLE
Sort Talks by ranking and Events by year in Spotlight Search

### DIFF
--- a/app/controllers/spotlight/events_controller.rb
+++ b/app/controllers/spotlight/events_controller.rb
@@ -3,7 +3,7 @@ class Spotlight::EventsController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @events = Event.includes(:organisation).canonical
+    @events = Event.includes(:organisation).canonical.order(date: :desc)
     @events = @events.ft_search(search_query) if search_query.present?
     @events_count = @events.count
     @events = @events.limit(5)

--- a/app/controllers/spotlight/talks_controller.rb
+++ b/app/controllers/spotlight/talks_controller.rb
@@ -3,7 +3,7 @@ class Spotlight::TalksController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @talks = Talk.with_essential_card_data
+    @talks = Talk.with_essential_card_data.order(date: :desc)
     @talks = @talks.ft_search(search_query) if search_query.present?
     @talks_count = @talks.size
     @talks = @talks.limit(5)

--- a/app/controllers/spotlight/talks_controller.rb
+++ b/app/controllers/spotlight/talks_controller.rb
@@ -3,8 +3,8 @@ class Spotlight::TalksController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @talks = Talk.with_essential_card_data.order(date: :desc)
-    @talks = @talks.ft_search(search_query) if search_query.present?
+    @talks = Talk.with_essential_card_data
+    @talks = @talks.ft_search(search_query).ranked if search_query.present?
     @talks_count = @talks.size
     @talks = @talks.limit(5)
     respond_to do |format|

--- a/app/models/talk/searchable.rb
+++ b/app/models/talk/searchable.rb
@@ -17,7 +17,7 @@ module Talk::Searchable
     end
 
     scope :ranked, -> do
-      order(Arel.sql("bm25(talks_search_index, 10.0, 1.0, 5.0) ASC"))
+      order(Arel.sql("bm25(talks_search_index, 10.0, 1.0, 5.0) ASC, talks.date DESC"))
     end
 
     after_create_commit :create_in_index

--- a/app/models/talk/searchable.rb
+++ b/app/models/talk/searchable.rb
@@ -1,6 +1,8 @@
 module Talk::Searchable
   extend ActiveSupport::Concern
 
+  DATE_WEIGHT = 0.000000001
+
   included do
     scope :ft_search, ->(query) do
       query = query&.gsub(/[^[:word:]]/, " ") || "" # remove non-word characters
@@ -17,7 +19,10 @@ module Talk::Searchable
     end
 
     scope :ranked, -> do
-      order(Arel.sql("bm25(talks_search_index, 10.0, 1.0, 5.0) ASC, talks.date DESC"))
+      select("talks.*,
+          bm25(talks_search_index, 10.0, 1.0, 5.0) +
+          (strftime('%s', 'now') - strftime('%s', talks.date)) * #{DATE_WEIGHT} AS combined_score")
+        .order(Arel.sql("combined_score ASC"))
     end
 
     after_create_commit :create_in_index


### PR DESCRIPTION
Resolves #219 

Not sure how it was before but after #407 I noticed on the search modal the talks being shown are over a decade old. I think users would prefer to see the newer talks first.

@marcoroth Also mentioned the same issue with the events as well. So I fixed that as well.

### Talks Before

https://github.com/user-attachments/assets/cac36c6b-0138-4615-a5fd-68c53f9b54d5

### Talks After

https://github.com/user-attachments/assets/7337dbbb-0618-4a20-b4a4-b1a57d4f64c3

### Events Before

https://github.com/user-attachments/assets/fe02caba-c769-4d82-ab1d-36f02e3ff9bc

### Events After

https://github.com/user-attachments/assets/c0a7fb90-733d-4315-a768-c64240df51fe

