### PR TITLE
Add SF Bay Area Ruby Meetup November and December 2024 recordings

### DIFF
--- a/data/sf-bay-area-ruby/sf-bay-area-ruby-meetup/videos.yml
+++ b/data/sf-bay-area-ruby/sf-bay-area-ruby-meetup/videos.yml
@@ -391,7 +391,7 @@
       start_cue: "1:01:37"
       end_cue: "1:03:00"
       event_name: SF Bay Area Ruby Meetup - November 2024
-      video_id: todo-open-mic-sf-bay-area-ruby-meetup-november-2024
+      video_id: esparta-palma-open-mic-sf-bay-area-ruby-meetup-november-2024
       video_provider: parent
       description: ""
       speakers:

--- a/data/sf-bay-area-ruby/sf-bay-area-ruby-meetup/videos.yml
+++ b/data/sf-bay-area-ruby/sf-bay-area-ruby-meetup/videos.yml
@@ -565,3 +565,60 @@
         Repo: https://github.com/anycable/anycable
       speakers:
         - Irina Nazarova
+
+- title: SF Bay Area Ruby Meetup - January 2025
+  raw_title: "SF Ruby January Meetup @ Productboard"
+  event_name: SF Bay Area Ruby Meetup - January 2025
+  published_at: "2025-01-16"
+  description: |-
+    ​​Hey, Bay Area builders and tinkerers!
+
+    While Ruby may not dominate the headlines, it's the silent force behind the Bay Area's most successful startups. From GitHub and Stripe to Chime and Stackblitz, Ruby powers teams that go HUGE with less.
+
+    ​Join us as we re-kindle the SF Ruby community's flame! It is a unique place to meet authors of your favorite open-source tools (or members of the Ruby core team), incredibly experienced engineers and new converts, as well as new startup founders building and experimenting with the power of Ruby and Rails. It's a chance to meet every month and make new Ruby friends.
+
+    Our meetups explore practical and explorational stories about Rails at scale, performance and maintainability, deployments, frontend, AI-powered features, and so much more—all through Ruby's uniquely productive lens.
+
+    For the first event of the year, Productboard is our gracious host!
+
+    Our special 🌟 speaker is Jason Swett, coming from Michigan!
+
+    Submit a talk proposal here:
+    ​​https://forms.gle/C9HQzaT5jvwA5xwc7
+
+    Catch you on the flip side! A massive shoutout to Productboard for hosting and sponsoring the event!
+
+    https://lu.ma/goujxu3a
+  video_provider: scheduled
+  video_id: sf-bay-area-ruby-meetup-january-2025
+  speakers:
+    - Jason Swett
+    - TBD
+
+- title: SF Bay Area Ruby Meetup - February 2025
+  raw_title: "SF Ruby February Meetup @ GitHub"
+  event_name: SF Bay Area Ruby Meetup - February 2025
+  published_at: "2025-02-13"
+  description: |-
+    ​​Hey, Bay Area builders and tinkerers!
+
+    While Ruby may not dominate the headlines, it's the silent force behind the Bay Area's most successful startups. From GitHub and Stripe to Chime and Stackblitz, Ruby powers teams that go HUGE with less.
+
+    ​Join us as we re-kindle the SF Ruby community's flame! It is a unique place to meet authors of your favorite open-source tools (or members of the Ruby core team), incredibly experienced engineers and new converts, as well as new startup founders building and experimenting with the power of Ruby and Rails. It's a chance to meet every month and make new Ruby friends.
+
+    Our meetups explore Rails at scale, practical Hotwire implementations, methods for building AI-native apps and so much more—all through Ruby's uniquely productive lens.
+
+    For the first event of the year, GitHub is our gracious host!
+
+    Speakers and agenda are TBD
+
+    Submit a talk proposal here:
+    ​​https://forms.gle/C9HQzaT5jvwA5xwc7
+
+    Catch you on the flip side! A massive shoutout to GitHub for hosting and sponsoring the event!
+
+    https://lu.ma/hoou421h
+  video_provider: scheduled
+  video_id: sf-bay-area-ruby-meetup-february-2025
+  speakers:
+    - TBD

--- a/data/sf-bay-area-ruby/sf-bay-area-ruby-meetup/videos.yml
+++ b/data/sf-bay-area-ruby/sf-bay-area-ruby-meetup/videos.yml
@@ -296,32 +296,33 @@
     Address: 580 California St. Suite 400 San Francisco, CA 94104
 
     https://lu.ma/f4pfsigc
-  video_provider: not_published
-  video_id: sf-bay-area-ruby-meetup-november-2024
+  video_provider: youtube
+  video_id: emg8KhSKXzI
   talks:
-    - title: "Intro"
+    - title: "Intro words"
       start_cue: "00:00"
-      end_cue: "TODO"
+      end_cue: "05:20"
       event_name: SF Bay Area Ruby Meetup - November 2024
       video_id: irina-nazarova-intro-sf-bay-area-ruby-meetup-november-2024
       video_provider: parent
       speakers:
         - Irina Nazarova
 
-    - title: "Designing for Loose Coupling in Ruby"
-      start_cue: "TODO"
-      end_cue: "TODO"
+    - title: "Design for Loose Coupling in Ruby"
+      raw_title: "Designing for Loose Coupling in Ruby"
+      start_cue: "05:20"
+      end_cue: "29:20"
       event_name: SF Bay Area Ruby Meetup - November 2024
       video_id: konstantin-gredeskoul-sf-bay-area-ruby-meetup-november-2024
       video_provider: parent
       description: |-
-        Konstantin Gredeskoul (Academia.edu) "Designing for Loose Coupling in Ruby"
+        Konstantin Gredeskoul (Academia.edu)
       speakers:
         - Konstantin Gredeskoul
 
-    - title: "How to translate your Rails app into over 20 languages"
-      start_cue: "TODO"
-      end_cue: "TODO"
+    - title: "How to translate your Rails app into over 20 languages - and why you should!"
+      start_cue: "29:20"
+      end_cue: "56:06"
       event_name: SF Bay Area Ruby Meetup - November 2024
       video_id: chris-fung-sf-bay-area-ruby-meetup-november-2024
       video_provider: parent
@@ -330,22 +331,92 @@
       speakers:
         - Chris Fung
 
-    - title: "Open Mic"
-      start_cue: "TODO"
-      end_cue: "TODO"
+    - title: "Open Mic: filterameter"
+      start_cue: "56:06"
+      end_cue: "57:47"
       event_name: SF Bay Area Ruby Meetup - November 2024
-      video_id: open-mic-sf-bay-area-ruby-meetup-november-2024
+      video_id: todd-kummer-open-mic-sf-bay-area-ruby-meetup-november-2024
       video_provider: parent
+      description: |-
+        Simplify and speed development of Rails controllers by making filter parameters declarative.
+
+        Repo: https://github.com/RockSolt/filterameter
       speakers:
-        - TODO
+        - Todd Kummer
+
+    - title: "Open Mic: Looking For A PM Role"
+      start_cue: "57:47"
+      end_cue: "58:26"
+      event_name: SF Bay Area Ruby Meetup - November 2024
+      video_id: ken-decanio-open-mic-sf-bay-area-ruby-meetup-november-2024
+      video_provider: parent
+      description: ""
+      speakers:
+        - Ken Decanio
+
+    - title: "Open Mic: rubyvideo.dev"
+      start_cue: "58:26"
+      end_cue: "59:50"
+      event_name: SF Bay Area Ruby Meetup - November 2024
+      video_id: cameron-dutro-open-mic-sf-bay-area-ruby-meetup-november-2024
+      video_provider: parent
+      description: ""
+      speakers:
+        - Cameron Dutro
+
+    - title: "Open Mic: Veteran Ruby Meetups"
+      start_cue: "59:50"
+      end_cue: "1:00:38"
+      event_name: SF Bay Area Ruby Meetup - November 2024
+      video_id: dave-doolin-open-mic-sf-bay-area-ruby-meetup-november-2024
+      video_provider: parent
+      description: ""
+      speakers:
+        - Dave Doolin
+
+    - title: "Open Mic: us_geo"
+      start_cue: "1:00:38"
+      end_cue: "1:03:00"
+      event_name: SF Bay Area Ruby Meetup - November 2024
+      video_id: brian-durand-open-mic-sf-bay-area-ruby-meetup-november-2024
+      video_provider: parent
+      description: |-
+        Collection of geographic data for the United States for use with ActiveRecord
+
+        Repo: https://github.com/bdurand/us_geo
+      speakers:
+        - Brian Durand
+
+    - title: "Open Mic: Esparta Palma"
+      start_cue: "1:01:37"
+      end_cue: "1:03:00"
+      event_name: SF Bay Area Ruby Meetup - November 2024
+      video_id: todo-open-mic-sf-bay-area-ruby-meetup-november-2024
+      video_provider: parent
+      description: ""
+      speakers:
+        - Esparta Palma
+
+    - title: "Open Mic: macchiato.dev"
+      start_cue: "1:03:00"
+      end_cue: "1:06:00"
+      event_name: SF Bay Area Ruby Meetup - November 2024
+      video_id: benjamin-atkin-open-mic-sf-bay-area-ruby-meetup-november-2024
+      video_provider: parent
+      description: |-
+        A notebook container and a collection of notebooks for interacting with data.
+
+        Repo: https://github.com/macchiato-dev
+      speakers:
+        - Benjamin Atkin
 
     - title: "Build ambitious content websites in Rails"
       raw_title: "Manage Content with Sitepress in Rails Apps or Static Websites"
-      start_cue: "TODO"
-      end_cue: "TODO"
+      start_cue: "1:06:00"
+      end_cue: "1:26:16"
       event_name: SF Bay Area Ruby Meetup - November 2024
-      video_id: K2N8fp2P7Ms
-      video_provider: youtube
+      video_id: brad-gessler-sf-bay-area-ruby-meetup-november-2024
+      video_provider: parent
       description: |-
         Brad Gessler (Rocketship, Fly) "Content management in Rails with Sitepress.cc"
 
@@ -354,14 +425,15 @@
         During the talk, we explore how the developer documentation at https://terminalwire.com use Sitepress’s advanced features, such as using markdown for pages, frontmatter for metadata, and traversing content with powerful tools like globbing and page models. A live demo showcased how these features come together to create polished documentation sites for developers.
 
         Links:
-        https://sitepress.cc - Website with Sitepress documentation and examples.
-        https://terminalwire.com - Example used in presentation that uses Sitepress.
+        Longer extended version of the talk: https://youtube.com/watch?v=K2N8fp2P7Ms
+        Website with Sitepress documentation and examples: https://sitepress.cc
+        Example used in presentation that uses Sitepress: https://terminalwire.com
       speakers:
         - Brad Gessler
 
-    - title: "The first 10 years of Roda"
-      start_cue: "TODO"
-      end_cue: "TODO"
+    - title: "The First 10 Years of Roda"
+      start_cue: "1:26:16"
+      end_cue: "2:13:56"
       event_name: SF Bay Area Ruby Meetup - November 2024
       video_id: jeremy-evans-sf-bay-area-ruby-meetup-november-2024
       video_provider: parent
@@ -375,7 +447,7 @@
   event_name: SF Bay Area Ruby Meetup - December 2024
   published_at: "2024-12-03"
   description: |-
-    ​Registration closes at noon on Dec 2.
+    Registration closes at noon on Dec 2.
     Address: 45 Fremont St, we'll be meeting you in the lobby. If you are running late, please send a message.
 
     Before the event, you will receive a message from Sentry (no-reply@envoy.com). Please fill out your details and sign a visitor's agreement. They ask for a photo too =) After that, you'll receive a QR code to enter.
@@ -384,22 +456,22 @@
 
     From GitHub and Stripe to Chime and Stackblitz, Ruby powers teams that go HUGE with less.
 
-    ​Join us as we re-kindle the SF Ruby community's flame! It is a place to meet authors of your favorite open-source and Ruby/Rails core, experienced Rubyists and new converts, entrepreneurs, and, well, people who hire. We meet every month and gradually make new Ruby friends.
+    Join us as we re-kindle the SF Ruby community's flame! It is a place to meet authors of your favorite open-source and Ruby/Rails core, experienced Rubyists and new converts, entrepreneurs, and, well, people who hire. We meet every month and gradually make new Ruby friends.
 
     For our December edition, Sentry is our gracious host! This time, we dedicate the event to all aspects of building AI-native apps and leveraging the power of AI in our Ruby applications.
 
     It is also our special HOLIDAY edition, so let's do something about it! Choose your fighter:
-    – bake and bring your cookies 🍪 (two people are doing it already, join us!)
-    – wear something 🎅-esque
-    – steal the Xmas 😈
+    - bake and bring your cookies 🍪 (two people are doing it already, join us!)
+    - wear something 🎅-esque
+    - steal the Xmas 😈
 
     https://lu.ma/q7fwrtj2
-  video_provider: scheduled
-  video_id: sf-bay-area-ruby-meetup-december-2024
+  video_provider: youtube
+  video_id: NU7ld8ERUFY
   talks:
-    - title: "Intro"
+    - title: "Welcome Words"
       start_cue: "00:00"
-      end_cue: "TODO"
+      end_cue: "07:30"
       event_name: SF Bay Area Ruby Meetup - December 2024
       video_id: irina-nazarova-intro-sf-bay-area-ruby-meetup-december-2024
       video_provider: parent
@@ -407,8 +479,8 @@
         - Irina Nazarova
 
     - title: "AI Grouping for Ruby SDK at Sentry"
-      start_cue: "TODO"
-      end_cue: "TODO"
+      start_cue: "07:30"
+      end_cue: "35:32"
       event_name: SF Bay Area Ruby Meetup - December 2024
       video_id: tillman-elser-sf-bay-area-ruby-meetup-december-2024
       video_provider: parent
@@ -416,46 +488,80 @@
         - Tillman Elser
 
     - title: "ActiveAgents"
-      start_cue: "TODO"
-      end_cue: "TODO"
+      start_cue: "35:32"
+      end_cue: "59:38"
       event_name: SF Bay Area Ruby Meetup - December 2024
       video_id: justin-bowen-sf-bay-area-ruby-meetup-december-2024
       video_provider: parent
+      description: |-
+        Website: https://www.activeagents.ai
+        Repo: https://github.com/activeagents/activeagent
       speakers:
         - Justin Bowen
 
-    - title: "Voice AI apps and AnyCable"
-      start_cue: "TODO"
-      end_cue: "TODO"
-      event_name: SF Bay Area Ruby Meetup - December 2024
-      video_id: irina-nazarova-sf-bay-area-ruby-meetup-december-2024
-      video_provider: parent
-      speakers:
-        - Irina Nazarova
-
-    - title: "Open Mic"
-      start_cue: "TODO"
-      end_cue: "TODO"
-      event_name: SF Bay Area Ruby Meetup - December 2024
-      video_id: open-mic-sf-bay-area-ruby-meetup-december-2024
-      video_provider: parent
-      speakers:
-        - TODO
-
-    - title: "Ruby&AI at Stepful"
-      start_cue: "TODO"
-      end_cue: "TODO"
+    - title: "Ruby & GenAI @ Stepful"
+      start_cue: "59:38"
+      end_cue: "1:16:45"
       event_name: SF Bay Area Ruby Meetup - December 2024
       video_id: edoardo-serra-sf-bay-area-ruby-meetup-december-2024
       video_provider: parent
+      description: |-
+        Website: https://stepful.com
       speakers:
         - Edoardo Serra
 
-    - title: "Lammy"
-      start_cue: "TODO"
-      end_cue: "TODO"
+    - title: "Open Mic: Learning Rails"
+      start_cue: "1:16:45"
+      end_cue: "1:18:32"
+      event_name: SF Bay Area Ruby Meetup - December 2024
+      video_id: ken-decanio-open-mic-sf-bay-area-ruby-meetup-december-2024
+      video_provider: parent
+      speakers:
+        - Ken Decanio
+
+    - title: "Open Mic: epicstrips.tv"
+      start_cue: "1:18:32"
+      end_cue: "1:20:05"
+      event_name: SF Bay Area Ruby Meetup - December 2024
+      video_id: chris-hobbs-open-mic-sf-bay-area-ruby-meetup-december-2024
+      video_provider: parent
+      description: |-
+        Website: https://epicstrips.tv
+      speakers:
+        - Chris Hobbs
+
+    - title: "Open Mic: Ruby Central"
+      start_cue: "1:20:05"
+      end_cue: "1:22:57"
+      event_name: SF Bay Area Ruby Meetup - December 2024
+      video_id: rhiannon-payne-open-mic-sf-bay-area-ruby-meetup-december-2024
+      video_provider: parent
+      description: |-
+        Website: https://rubycentral.org
+        Marketing Agency: https://seafoam.media
+      speakers:
+        - Rhiannon Payne
+
+    - title: "Introducing Lammy"
+      start_cue: "1:22:57"
+      end_cue: "1:38:35"
       event_name: SF Bay Area Ruby Meetup - December 2024
       video_id: kamil-nicieja-sf-bay-area-ruby-meetup-december-2024
       video_provider: parent
+      description: |-
+        Lammy is a simple LLM library for Ruby. It doesn't treat prompts as just strings. They represent the entire code that generates the strings sent to a LLM. The abstraction also makes it easy to attach these methods directly to models, avoiding the need for boilerplate service code.
+
+        Repo: https://github.com/nicieja/lammy
       speakers:
         - Kamil Nicieja
+
+    - title: "Building Voice AI Apps with Ruby"
+      start_cue: "1:38:35"
+      end_cue: "2:01:21"
+      event_name: SF Bay Area Ruby Meetup - December 2024
+      video_id: irina-nazarova-sf-bay-area-ruby-meetup-december-2024
+      video_provider: parent
+      description: |-
+        Repo: https://github.com/anycable/anycable
+      speakers:
+        - Irina Nazarova


### PR DESCRIPTION
Also adds the upcoming January + February events as scheduled.

| November 2024 | December 2024 |
| --- | --- |
| ![CleanShot 2024-12-06 at 03 31 59](https://github.com/user-attachments/assets/3b86632e-8471-444a-ac41-89afaf906c7f) | ![CleanShot 2024-12-06 at 03 31 45](https://github.com/user-attachments/assets/48a09e34-51be-4a6b-945d-cc2c1552fc21) |
