### PR TITLE
Extract a `retries` helper for performs to clarify intent

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,4 +4,9 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  # Apply a catch-all fallback that retries on most exceptions.
+  def self.retries(attempts, wait: :polynomially_longer)
+    retry_on StandardError, attempts:, wait:
+  end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -45,7 +45,6 @@
 #
 # rubocop:enable Layout/LineLength
 class Talk < ApplicationRecord
-  extend ActiveJob::Performs
   include Talk::TranscriptCommands
   include Talk::SummaryCommands
   include Sluggable

--- a/app/models/talk/summary_commands.rb
+++ b/app/models/talk/summary_commands.rb
@@ -3,8 +3,7 @@ module Talk::SummaryCommands
 
   included do
     # jobs
-    performs :create_summary!, queue_as: :low do
-      retry_on StandardError, attempts: 3, wait: :polynomially_longer
+    performs :create_summary!, queue_as: :low, retries: 3 do
       limits_concurrency to: 1, key: "openai_api", duration: 1.hour # this is to comply to the rate limit of openai 60 000 tokens per minute
     end
   end

--- a/app/models/talk/transcript_commands.rb
+++ b/app/models/talk/transcript_commands.rb
@@ -6,14 +6,11 @@ module Talk::TranscriptCommands
     serialize :raw_transcript, coder: TranscriptSerializer
 
     # jobs
-    performs :enhance_transcript!, queue_as: :low do
-      retry_on StandardError, attempts: 3, wait: :polynomially_longer
+    performs :enhance_transcript!, queue_as: :low, retries: 3 do
       limits_concurrency to: 1, key: "openai_api", duration: 1.hour # this is to comply to the rate limit of openai 60 000 tokens per minute
     end
 
-    performs :fetch_and_update_raw_transcript!, queue_as: :low do
-      retry_on StandardError, attempts: 3, wait: :polynomially_longer
-    end
+    performs :fetch_and_update_raw_transcript!, queue_as: :low, retries: 3
   end
 
   def fetch_and_update_raw_transcript!


### PR DESCRIPTION
The key detail here is the `retry_on StandardError` and that it really means retry on most exceptions.

It seems like callers shouldn't be privy to that implementation detail.

Having a `retries` method that we can pass an attempts argument into, let's our jobs be a bit simpler.

Spotted from #466.