### PR TITLE
Ranking test

### DIFF
--- a/app/controllers/spotlight/events_controller.rb
+++ b/app/controllers/spotlight/events_controller.rb
@@ -6,7 +6,7 @@ class Spotlight::EventsController < ApplicationController
     @events = Event.includes(:organisation).canonical
     @events = @events.ft_search(search_query) if search_query.present?
     @events_count = @events.count
-    @events = @events.limit(5)
+    @events = @events.limit(8)
     respond_to do |format|
       format.turbo_stream
     end

--- a/app/controllers/spotlight/speakers_controller.rb
+++ b/app/controllers/spotlight/speakers_controller.rb
@@ -6,7 +6,7 @@ class Spotlight::SpeakersController < ApplicationController
     @speakers = Speaker.canonical
     @speakers = @speakers.ft_search(search_query) if search_query.present?
     @speakers_count = @speakers.count
-    @speakers = @speakers.limit(5)
+    @speakers = @speakers.limit(8)
     respond_to do |format|
       format.turbo_stream
     end

--- a/app/controllers/spotlight/talks_controller.rb
+++ b/app/controllers/spotlight/talks_controller.rb
@@ -5,6 +5,7 @@ class Spotlight::TalksController < ApplicationController
   def index
     @talks = Talk.with_essential_card_data
     @talks = @talks.ft_search(search_query) if search_query.present?
+    @talks = @talks.ranked_with_bm25_and_date if search_query.present?
     @talks_count = @talks.size
     @talks = @talks.limit(5)
     respond_to do |format|

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -8,10 +8,10 @@ class TalksController < ApplicationController
   # GET /talks
   def index
     @talks = Talk.with_essential_card_data
-    if params[:s].present?
-      @talks = @talks.ft_search(params[:s]).with_snippets.ranked_with_bm25_and_date
+    @talks = if params[:s].present?
+      @talks.ft_search(params[:s]).with_snippets.ranked_with_bm25_and_date
     else
-      @talks = @talks.order(order_by)
+      @talks.order(order_by)
     end
     @talks = @talks.for_topic(params[:topic]) if params[:topic].present?
     @talks = @talks.for_event(params[:event]) if params[:event].present?

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -7,8 +7,12 @@ class TalksController < ApplicationController
 
   # GET /talks
   def index
-    @talks = Talk.with_essential_card_data.order(order_by)
-    @talks = @talks.ft_search(params[:s]).with_snippets.ranked if params[:s].present?
+    @talks = Talk.with_essential_card_data
+    if params[:s].present?
+      @talks = @talks.ft_search(params[:s]).with_snippets.ranked_with_bm25_and_date
+    else
+      @talks = @talks.order(order_by)
+    end
     @talks = @talks.for_topic(params[:topic]) if params[:topic].present?
     @talks = @talks.for_event(params[:event]) if params[:event].present?
     @talks = @talks.for_speaker(params[:speaker]) if params[:speaker].present?

--- a/app/views/spotlight/talks/_talk.html.erb
+++ b/app/views/spotlight/talks/_talk.html.erb
@@ -5,6 +5,7 @@
 
   <div class="flex flex-col gap-1 text-sm">
     <%= content_tag :div, class: "" do %>
+      <%= content_tag :div, "#{talk.combined_score.round(2)} - #{l(talk.date, format: :long)}", class: "text-xs text-gray-500" %>
       <%= content_tag :div, talk.title, class: "font-regular line-clamp-2" %>
     <% end %>
 

--- a/app/views/spotlight/talks/_talk.html.erb
+++ b/app/views/spotlight/talks/_talk.html.erb
@@ -5,7 +5,9 @@
 
   <div class="flex flex-col gap-1 text-sm">
     <%= content_tag :div, class: "" do %>
-      <%= content_tag :div, "#{talk.combined_score.round(2)} - #{l(talk.date, format: :long)}", class: "text-xs text-gray-500" %>
+      <% if talk.try(:combined_score).present? %>
+        <%= content_tag :div, "#{talk.combined_score.round(2)} - #{l(talk.date, format: :long)}", class: "text-xs text-gray-500" %>
+      <% end %>
       <%= content_tag :div, talk.title, class: "font-regular line-clamp-2" %>
     <% end %>
 

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -91,7 +91,9 @@
       <div class="flex items-start justify-between gap-2 w-full">
         <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), data: {action: "mouseover->preserve-scroll#updateLinkBackToWithScrollPosition", turbo_frame: "_top"} do %>
           <%= content_tag :h2, class: "text-sm font-sans font-medium" do %>
-            <%= content_tag :div, "#{talk.combined_score.round(2)} - #{l(talk.date, format: :long)}", class: "text-xs text-gray-500" %>
+            <% if talk.try(:combined_score).present? %>
+              <%= content_tag :div, "#{talk.combined_score.round(2)} - #{l(talk.date, format: :long)}", class: "text-xs text-gray-500" %>
+            <% end %>
             <%= sanitize(talk.title_with_snippet, tags: ["mark"]) %>
           <% end %>
         <% end %>

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -91,6 +91,7 @@
       <div class="flex items-start justify-between gap-2 w-full">
         <%= link_to talk_path(talk, back_to: back_to, back_to_title: back_to_title), data: {action: "mouseover->preserve-scroll#updateLinkBackToWithScrollPosition", turbo_frame: "_top"} do %>
           <%= content_tag :h2, class: "text-sm font-sans font-medium" do %>
+            <%= content_tag :div, "#{talk.combined_score.round(2)} - #{l(talk.date, format: :long)}", class: "text-xs text-gray-500" %>
             <%= sanitize(talk.title_with_snippet, tags: ["mark"]) %>
           <% end %>
         <% end %>

--- a/test/controllers/spotlight/events_controller_test.rb
+++ b/test/controllers/spotlight/events_controller_test.rb
@@ -24,7 +24,7 @@ class Spotlight::EventsControllerTest < ActionDispatch::IntegrationTest
 
     get spotlight_events_url(format: :turbo_stream)
     assert_response :success
-    assert_equal 5, assigns(:events).size
+    assert_equal 8, assigns(:events).size
     assert_equal Event.all.count, assigns(:events_count)
   end
 

--- a/test/controllers/spotlight/speakers_controller_test.rb
+++ b/test/controllers/spotlight/speakers_controller_test.rb
@@ -23,7 +23,7 @@ class Spotlight::SpeakersControllerTest < ActionDispatch::IntegrationTest
 
     get spotlight_speakers_url(format: :turbo_stream)
     assert_response :success
-    assert_equal 5, assigns(:speakers).size
+    assert_equal 8, assigns(:speakers).size
     assert_equal Speaker.all.count, assigns(:speakers_count)
   end
 


### PR DESCRIPTION
NOT to merge 

This is an exploration PR to follow #486

It displays the bm25 ranking in the card so that we can understand the effect of the weight for the date

adjusting the date weight to DATE_WEIGHT = 0.000000001 seemed to gave good results 

as an example searching for hotwire http://localhost:3000/talks?s=hotwire
give this results

![CleanShot 2024-12-06 at 23 58 25@2x](https://github.com/user-attachments/assets/3dc51ba6-3fd4-4020-a81c-6d02cd634405)

we have all the talk sorted by date with hotwire in the title

then page two after older talks with hotwire in the title we start to see talks without Hotwire in the title (probably found from the description) but from earlier date. So we keep a good relevancy on the title math with some weight for the date 

![CleanShot 2024-12-06 at 23 59 45@2x](https://github.com/user-attachments/assets/24faa7f9-2120-4340-bf31-a5eef5f427fe)


This PR is not really intended to be merged but more as food for thought for finishing #486


poke @aamfahim 

