### PR TITLE
Rename `Talk::ThumbnailExtractor` to `Talk::Thumbnails`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,10 +13,10 @@ task verify_thumbnails: :environment do |t, args|
   Talk.where(meta_talk: true).flat_map(&:child_talks).each do |child_talk|
     if child_talk.static_metadata
       if child_talk.static_metadata.start_cue.present? && child_talk.static_metadata.start_cue != "TODO"
-        if child_talk.thumbnails.thumbnail_path.exist?
+        if child_talk.thumbnails.exist?
           thumbnails_count += 1
         else
-          puts "missing thumbnail for child_talk: #{child_talk.video_id} at: #{child_talk.thumbnails.thumbnail_path}"
+          puts "missing thumbnail for child_talk: #{child_talk.video_id} at: #{child_talk.thumbnails.path}"
           child_talks_with_missing_thumbnails << child_talk
         end
       end

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task verify_thumbnails: :environment do |t, args|
   Talk.where(meta_talk: true).flat_map(&:child_talks).each do |child_talk|
     if child_talk.static_metadata
       if child_talk.static_metadata.start_cue.present? && child_talk.static_metadata.start_cue != "TODO"
-        if child_talk.thumbnails.exist?
+        if child_talk.thumbnails.path.exist?
           thumbnails_count += 1
         else
           puts "missing thumbnail for child_talk: #{child_talk.video_id} at: #{child_talk.thumbnails.path}"

--- a/Rakefile
+++ b/Rakefile
@@ -13,10 +13,10 @@ task verify_thumbnails: :environment do |t, args|
   Talk.where(meta_talk: true).flat_map(&:child_talks).each do |child_talk|
     if child_talk.static_metadata
       if child_talk.static_metadata.start_cue.present? && child_talk.static_metadata.start_cue != "TODO"
-        if child_talk.thumbnail_extractor.thumbnail_path.exist?
+        if child_talk.thumbnails.thumbnail_path.exist?
           thumbnails_count += 1
         else
-          puts "missing thumbnail for child_talk: #{child_talk.video_id} at: #{child_talk.thumbnail_extractor.thumbnail_path}"
+          puts "missing thumbnail for child_talk: #{child_talk.video_id} at: #{child_talk.thumbnails.thumbnail_path}"
           child_talks_with_missing_thumbnails << child_talk
         end
       end
@@ -43,8 +43,8 @@ end
 desc "Download mp4 files for all meta talks with missing thumbnails"
 task download_missing_meta_talks: :environment do |t, args|
   meta_talks = Talk.where(meta_talk: true)
-  extractable_meta_talks = meta_talks.select { |talk| talk.thumbnail_extractor.extractable? }
-  missing_talks = extractable_meta_talks.reject { |talk| talk.thumbnail_extractor.extracted? }
+  extractable_meta_talks = meta_talks.select { |talk| talk.thumbnails.extractable? }
+  missing_talks = extractable_meta_talks.reject { |talk| talk.thumbnails.extracted? }
   missing_talks_without_downloads = missing_talks.reject { |talk| talk.downloader.downloaded? }
 
   puts "Found #{missing_talks_without_downloads.size} missing talks without downloaded videos."
@@ -57,7 +57,7 @@ end
 desc "Fetch thumbnails for meta talks for all cues"
 task extract_thumbnails: :environment do |t, args|
   Talk.where(meta_talk: true).each do |meta_video|
-    meta_video.thumbnail_extractor.extract!
+    meta_video.thumbnails.extract!
   end
 end
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -63,7 +63,7 @@ class Talk < ApplicationRecord
   # extend Pagy::Meilisearch
 
   has_object :downloader
-  has_object :thumbnail_extractor
+  has_object :thumbnails
 
   # associations
   belongs_to :event, optional: true, counter_cache: :talks_count, touch: true

--- a/app/models/talk/thumbnails.rb
+++ b/app/models/talk/thumbnails.rb
@@ -2,7 +2,6 @@ class Talk::Thumbnails < ActiveRecord::AssociatedObject
   def path
     directory / "#{talk.video_id}.webp"
   end
-  delegate :exist?, to: :path
 
   def extractable?
     talk.meta_talk? && talk.static_metadata&.talks&.any? && !start_cues.include?("TODO")

--- a/app/models/talk/thumbnails.rb
+++ b/app/models/talk/thumbnails.rb
@@ -1,10 +1,6 @@
 class Talk::Thumbnails < ActiveRecord::AssociatedObject
   def thumbnails_directory
-    directory = Rails.root / "app" / "assets" / "images" / "thumbnails"
-
-    directory.mkdir unless directory.exist?
-
-    directory
+    Rails.root.join("app/assets/images/thumbnails").tap(&:mkpath)
   end
 
   def thumbnail_path

--- a/app/models/talk/thumbnails.rb
+++ b/app/models/talk/thumbnails.rb
@@ -1,4 +1,4 @@
-class Talk::ThumbnailExtractor < ActiveRecord::AssociatedObject
+class Talk::Thumbnails < ActiveRecord::AssociatedObject
   def thumbnails_directory
     directory = Rails.root / "app" / "assets" / "images" / "thumbnails"
 
@@ -20,7 +20,7 @@ class Talk::ThumbnailExtractor < ActiveRecord::AssociatedObject
   end
 
   def extracted?
-    talk.child_talks.map { |child_talk| child_talk.thumbnail_extractor.thumbnail_path.exist? }.reduce(:&)
+    talk.child_talks.map { |child_talk| child_talk.thumbnails.thumbnail_path.exist? }.reduce(:&)
   end
 
   def extract!(force: false, download: false)
@@ -59,7 +59,7 @@ class Talk::ThumbnailExtractor < ActiveRecord::AssociatedObject
         next
       end
 
-      extract_thumbnail(child_talk.static_metadata.thumbnail_cue, talk.downloader.download_path, child_talk.thumbnail_extractor.thumbnail_path)
+      extract_thumbnail(child_talk.static_metadata.thumbnail_cue, talk.downloader.download_path, child_talk.thumbnails.thumbnail_path)
     end
   end
 

--- a/app/models/talk/thumbnails.rb
+++ b/app/models/talk/thumbnails.rb
@@ -1,7 +1,8 @@
 class Talk::Thumbnails < ActiveRecord::AssociatedObject
-  def thumbnail_path
+  def path
     directory / "#{talk.video_id}.webp"
   end
+  delegate :exist?, to: :path
 
   def extractable?
     talk.meta_talk? && talk.static_metadata&.talks&.any? && !start_cues.include?("TODO")
@@ -12,7 +13,7 @@ class Talk::Thumbnails < ActiveRecord::AssociatedObject
   end
 
   def extracted?
-    talk.child_talks.map { |child_talk| child_talk.thumbnails.thumbnail_path.exist? }.reduce(:&)
+    talk.child_talks.map { |child_talk| child_talk.thumbnails.exist? }.reduce(:&)
   end
 
   def extract!(force: false, download: false)
@@ -51,7 +52,7 @@ class Talk::Thumbnails < ActiveRecord::AssociatedObject
         next
       end
 
-      extract_thumbnail(child_talk.static_metadata.thumbnail_cue, talk.downloader.download_path, child_talk.thumbnails.thumbnail_path)
+      extract_thumbnail(child_talk.static_metadata.thumbnail_cue, talk.downloader.download_path, child_talk.thumbnails.path)
     end
   end
 

--- a/app/models/talk/thumbnails.rb
+++ b/app/models/talk/thumbnails.rb
@@ -1,10 +1,6 @@
 class Talk::Thumbnails < ActiveRecord::AssociatedObject
-  def thumbnails_directory
-    Rails.root.join("app/assets/images/thumbnails").tap(&:mkpath)
-  end
-
   def thumbnail_path
-    thumbnails_directory / "#{talk.video_id}.webp"
+    directory / "#{talk.video_id}.webp"
   end
 
   def extractable?
@@ -61,5 +57,11 @@ class Talk::Thumbnails < ActiveRecord::AssociatedObject
 
   def extract_thumbnail(timestamp, input_file, output_file)
     Command.run(%(ffmpeg -y -ss #{timestamp} -i "#{input_file}" -map 0:v:0 -frames:v 1 -q:v 50 -vf scale=1080:-1 "#{output_file}"))
+  end
+
+  private
+
+  def directory
+    Rails.root.join("app/assets/images/thumbnails").tap(&:mkpath)
   end
 end


### PR DESCRIPTION
I'm trying to port over the naming scheme from `Speaker#profiles` and seeing what other changes we may want from the ramifications of that.

It seems like we can get away with removing the `thumbnail_` prefixes then.