### PR TITLE
Upgrade ActiveRecord::AssociatedObject to 0.8.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     active_link_to (1.0.5)
       actionpack
       addressable
-    active_record-associated_object (0.8.2)
+    active_record-associated_object (0.8.3)
       activerecord (>= 6.1)
     activejob (8.0.0.1)
       activesupport (= 8.0.0.1)

--- a/app/models/speaker/profiles.rb
+++ b/app/models/speaker/profiles.rb
@@ -1,5 +1,4 @@
 class Speaker::Profiles < ActiveRecord::AssociatedObject
-  extend ActiveJob::Performs # TODO: Fix AssociatedObject's Railtie so we don't need to do this
   performs(retries: 3) { limits_concurrency key: -> { _1.id } }
 
   def enhance_all_later

--- a/app/models/talk/agents.rb
+++ b/app/models/talk/agents.rb
@@ -1,6 +1,4 @@
 class Talk::Agents < ActiveRecord::AssociatedObject
-  extend ActiveJob::Performs # TODO: Fix AssociatedObject's Railtie so we don't need to do this
-
   performs retries: 3 do
     # this is to comply to the rate limit of openai 60 000 tokens per minute
     limits_concurrency to: 1, key: "openai_api", duration: 1.hour


### PR DESCRIPTION
So we can cut the `extend ActiveJob::Performs` calls and have the gem do it for us.