### PR TITLE
Discard talk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,3 +157,5 @@ gem "omniauth-rails_csrf_protection"
 
 # silence Ruby 3.4 warnings
 gem "ostruct"
+
+gem "discard", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
       reline (>= 0.3.8)
     device_detector (1.1.3)
     diffy (3.4.3)
+    discard (1.4.0)
+      activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
     dockerfile-rails (1.6.25)
       rails (>= 3.0.0)
@@ -612,6 +614,7 @@ DEPENDENCIES
   country_select
   debug
   diffy
+  discard (~> 1.4)
   dockerfile-rails (>= 1.2)
   dotenv-rails
   dry-initializer-rails

--- a/app/avo/resources/talk.rb
+++ b/app/avo/resources/talk.rb
@@ -38,6 +38,10 @@ class Avo::Resources::Talk < Avo::BaseResource
       record.summary.present?
     end
     field :description, as: :textarea, hide_on: :index
+    field :discarded_at, as: :date, hide_on: :index
+    field :discarded, as: :boolean, only_on: :index do
+      record.discarded?
+    end
     field :language, hide_on: :index
     field :slug, as: :text, hide_on: :index
     field :year, as: :number, hide_on: :index

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -16,7 +16,7 @@ class SitemapsController < ApplicationController
       SitemapGenerator::Sitemap.create(adapter: adapter) do
         add talks_path, priority: 0.9, changefreq: "weekly"
 
-        Talk.pluck(:slug, :updated_at).each do |talk_slug, updated_at|
+        Talk.kept.pluck(:slug, :updated_at).each do |talk_slug, updated_at|
           add talk_path(talk_slug), priority: 0.9, lastmod: updated_at
         end
 

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -24,7 +24,7 @@ class SpeakersController < ApplicationController
 
   # GET /speakers/1
   def show
-    @talks = @speaker.talks.with_essential_card_data.order(date: :desc)
+    @talks = @speaker.talks.kept.with_essential_card_data.order(date: :desc)
     @topics = @speaker.topics.approved.tally.sort_by(&:last).reverse.map(&:first)
 
     @back_path = speakers_path

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -22,6 +22,7 @@ class TalksController < ApplicationController
 
   # GET /talks/1
   def show
+    redirect_to talks_path, status: :moved_permanently if @talk.discarded?
     set_meta_tags(@talk)
   end
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -6,6 +6,7 @@
 #  id                  :integer          not null, primary key
 #  date                :date             indexed
 #  description         :text             default(""), not null
+#  discarded_at        :datetime         indexed
 #  end_seconds         :integer
 #  enhanced_transcript :text             default(#<Transcript:0x000000012f650498 @cues=[]>), not null
 #  external_player     :boolean          default(FALSE), not null
@@ -37,6 +38,7 @@
 # Indexes
 #
 #  index_talks_on_date            (date)
+#  index_talks_on_discarded_at    (discarded_at)
 #  index_talks_on_event_id        (event_id)
 #  index_talks_on_kind            (kind)
 #  index_talks_on_parent_talk_id  (parent_talk_id)
@@ -55,6 +57,7 @@ class Talk < ApplicationRecord
   include Suggestable
   include Searchable
   include Watchable
+  include Discard::Model
   slug_from :title
 
   # include MeiliSearch::Rails

--- a/db/migrate/20241215081736_add_discarded_at_to_talks.rb
+++ b/db/migrate/20241215081736_add_discarded_at_to_talks.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToTalks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :talks, :discarded_at, :datetime
+    add_index :talks, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_03_001515) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_15_081736) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -211,7 +211,9 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_03_001515) do
     t.boolean "meta_talk", default: false, null: false
     t.integer "start_seconds"
     t.integer "end_seconds"
+    t.datetime "discarded_at"
     t.index ["date"], name: "index_talks_on_date"
+    t.index ["discarded_at"], name: "index_talks_on_discarded_at"
     t.index ["event_id"], name: "index_talks_on_event_id"
     t.index ["kind"], name: "index_talks_on_kind"
     t.index ["parent_talk_id"], name: "index_talks_on_parent_talk_id"

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -28,6 +28,13 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should show speaker without discarded talk" do
+    get speaker_url(@speaker)
+    assert_response :success
+    assert @speaker.talks.include?(talks(:discarded))
+    refute assigns(:talks).include?(talks(:discarded))
+  end
+
   test "should redirect to canonical speaker" do
     talk = @speaker_with_talk.talks.first
     @speaker_with_talk.assign_canonical_speaker!(canonical_speaker: @speaker)

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -45,6 +45,13 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should show talk without discarded talk" do
+    @discarded_talk = talks(:discarded)
+    get talk_url(@discarded_talk)
+    assert_response :moved_permanently
+    assert_redirected_to talks_path
+  end
+
   test "should redirect to talks for wrong slugs" do
     get talk_url("wrong-slug")
     assert_response :moved_permanently

--- a/test/fixtures/speaker_talks.yml
+++ b/test/fixtures/speaker_talks.yml
@@ -18,5 +18,13 @@
 # rubocop:enable Layout/LineLength
 
 one:
-  speaker: yaroslav
+  speaker: one
   talk: one
+
+two:
+  speaker: one
+  talk: two
+
+discarded:
+  speaker: one
+  talk: discarded

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -77,6 +77,13 @@ two:
   slug: talk-title-2
   kind: "talk"
 
+discarded:
+  title: discarded talk
+  description: talk descritpion 3
+  slug: discarded-talk
+  kind: "talk"
+  discarded_at: 2024-12-15 08:17:36
+
 brightonruby_2024_one:
   title: Getting to Two Million Users as a One Woman Dev Team
   description: talk descritpion 2

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -6,6 +6,7 @@
 #  id                  :integer          not null, primary key
 #  date                :date             indexed
 #  description         :text             default(""), not null
+#  discarded_at        :datetime         indexed
 #  end_seconds         :integer
 #  enhanced_transcript :text             default(#<Transcript:0x000000012f650498 @cues=[]>), not null
 #  external_player     :boolean          default(FALSE), not null
@@ -37,6 +38,7 @@
 # Indexes
 #
 #  index_talks_on_date            (date)
+#  index_talks_on_discarded_at    (discarded_at)
 #  index_talks_on_event_id        (event_id)
 #  index_talks_on_kind            (kind)
 #  index_talks_on_parent_talk_id  (parent_talk_id)


### PR DESCRIPTION

this is a first stab at #372

while implementing the feature and in particular trying the discard the talks from Zzak I realised that since a talk can have multiple speaker (https://www.rubyvideo.dev/talks/building-cli-apps-for-everyone) if a talk is discarded then it will be hidden for all speakers of that talk. 

I wonder if we should keep it like that or discard the SpeakerTalk relationship?

close #372