### PR TITLE
lazy load speakerdeck oembed

### DIFF
--- a/app/controllers/talks/slides_controller.rb
+++ b/app/controllers/talks/slides_controller.rb
@@ -1,0 +1,10 @@
+class Talks::SlidesController < ApplicationController
+  include Turbo::ForceFrameResponse
+  force_frame_response
+
+  skip_before_action :authenticate_user!
+
+  def show
+    @talk = Talk.find_by(slug: params[:talk_slug])
+  end
+end

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -306,24 +306,11 @@
       <% end %>
 
       <% if talk.slides_url.present? %>
-        <% uri = URI(talk.slides_url) %>
-
         <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="Slides">
         <div role="tabpanel" class="tab-content !rounded-s-xl rounded-xl bg-base-200/50 p-6 mt-6 overflow-hidden">
-          <% cache [talk.slides_url] do %>
-            <% if ["speakerdeck.com", "www.speakerdeck.com"].include?(uri.host) %>
-              <% oembed_url = URI("https://speakerdeck.com/oembed.json?url=#{talk.slides_url}") %>
-              <% oembed_json = begin
-                   JSON.parse(Net::HTTP.get(oembed_url))
-                 rescue
-                   {}
-                 end %>
-
-              <%= sanitize oembed_json.dig("html"), tags: ["iframe"], attributes: ["id", "class", "src", "width", "height", "style", "frameborder", "allowtransparency", "allowfullscreen"] %>
-            <% end %>
+          <%= turbo_frame_tag dom_id(talk, :slides), src: talk_slides_path(talk), loading: :lazy do %>
+            <div class="skeleton h-32 w-full rounded"></div>
           <% end %>
-
-          <a class="btn btn-primary mt-6" href="<%= talk.slides_url %>" target="_blank">See Slides on <%= uri.host %></a>
         </div>
       <% end %>
 

--- a/app/views/talks/slides/show.html.erb
+++ b/app/views/talks/slides/show.html.erb
@@ -1,0 +1,19 @@
+<%= turbo_frame_tag dom_id(@talk, :slides) do %>
+  <% if @talk.slides_url.present? %>
+    <% uri = URI(@talk.slides_url) %>
+    <% cache [@talk.slides_url] do %>
+      <% if ["speakerdeck.com", "www.speakerdeck.com"].include?(uri.host) %>
+        <% oembed_url = URI("https://speakerdeck.com/oembed.json?url=#{@talk.slides_url}") %>
+        <% oembed_json = begin
+              JSON.parse(Net::HTTP.get(oembed_url))
+            rescue
+              {}
+            end %>
+
+        <%= sanitize oembed_json.dig("html"), tags: ["iframe"], attributes: ["id", "class", "src", "width", "height", "style", "frameborder", "allowtransparency", "allowfullscreen"] %>
+      <% end %>
+    <% end %>
+
+    <a class="btn btn-primary mt-6" href="<%= @talk.slides_url %>" target="_blank">See Slides on <%= uri.host %></a>
+  <% end %>
+<% end %>

--- a/app/views/talks/slides/show.html.erb
+++ b/app/views/talks/slides/show.html.erb
@@ -5,10 +5,10 @@
       <% if ["speakerdeck.com", "www.speakerdeck.com"].include?(uri.host) %>
         <% oembed_url = URI("https://speakerdeck.com/oembed.json?url=#{@talk.slides_url}") %>
         <% oembed_json = begin
-              JSON.parse(Net::HTTP.get(oembed_url))
-            rescue
-              {}
-            end %>
+             JSON.parse(Net::HTTP.get(oembed_url))
+           rescue
+             {}
+           end %>
 
         <%= sanitize oembed_json.dig("html"), tags: ["iframe"], attributes: ["id", "class", "src", "width", "height", "style", "frameborder", "allowtransparency", "allowfullscreen"] %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,12 +46,15 @@ Rails.application.routes.draw do
       get :top_searches
     end
   end
+
   resources :talks, param: :slug, only: [:index, :show, :update, :edit] do
     scope module: :talks do
       resources :recommendations, only: [:index]
       resource :watched_talk, only: [:create, :destroy]
+      resource :slides, only: :show
     end
   end
+
   resources :speakers, param: :slug, only: [:index, :show, :update, :edit]
   resources :events, param: :slug, only: [:index, :show, :update, :edit] do
     scope module: :events do

--- a/test/controllers/talks/slides_controller_test.rb
+++ b/test/controllers/talks/slides_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Talks::SlidesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @talk = talks(:one)
+  end
+
+  test "should get show" do
+    get talk_slides_path(@talk), headers: {"Turbo-Frame" => "true"}
+    assert_response :ok
+    assert_template "talks/slides/show"
+  end
+end


### PR DESCRIPTION
the generation of the oembed tyopicaly takes about 300ms. This is slowing down the entire page for the first visit. Once it is cache it is faster. Yet since this is content within a tab I think it would be best to lazy load it in a Turbo Frame