### PR TITLE
adds a watchable scope

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -12,6 +12,7 @@ class TalksController < ApplicationController
   # GET /talks
   def index
     @talks = Talk.with_essential_card_data.order(order_by)
+    @talks = @talks.watchable unless params[:all].present?
     @talks = @talks.ft_search(params[:s]).with_snippets.ranked if params[:s].present?
     @talks = @talks.for_topic(params[:topic]) if params[:topic].present?
     @talks = @talks.for_event(params[:event]) if params[:event].present?

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -182,7 +182,7 @@ class Talk < ApplicationRecord
   scope :for_topic, ->(topic_slug) { joins(:topics).where(topics: {slug: topic_slug}) }
   scope :for_speaker, ->(speaker_slug) { joins(:speakers).where(speakers: {slug: speaker_slug}) }
   scope :for_event, ->(event_slug) { joins(:event).where(events: {slug: event_slug}) }
-  scope :watchable, -> { where(video_provider: [:youtube, :mp4, :vimeo, :parent]) }
+  scope :watchable, -> { where(video_provider: [:youtube, :mp4, :vimeo]) }
 
   scope :with_essential_card_data, -> do
     select(

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -182,6 +182,7 @@ class Talk < ApplicationRecord
   scope :for_topic, ->(topic_slug) { joins(:topics).where(topics: {slug: topic_slug}) }
   scope :for_speaker, ->(speaker_slug) { joins(:speakers).where(speakers: {slug: speaker_slug}) }
   scope :for_event, ->(event_slug) { joins(:event).where(events: {slug: event_slug}) }
+  scope :watchable, -> { where(video_provider: [:youtube, :mp4, :vimeo, :parent]) }
 
   scope :with_essential_card_data, -> do
     select(


### PR DESCRIPTION
relates to #507

This PR adds a Talk scope `watchable` for the video_provider that have watchable content.
This PR defaults the `/talks` view to this scope.
This scope can be bypassed if we pass the params all=true. We would need to see how we convert this into human readable filters and sorting UI