### PR TITLE
disable page view transition default fade effect

### DIFF
--- a/app/assets/stylesheets/components/transition.css
+++ b/app/assets/stylesheets/components/transition.css
@@ -1,4 +1,9 @@
 @layer components {
+  ::view-transition-group(root) {
+    animation: none;
+    mix-blend-mode: normal;
+  }
+
   .navbar {
     view-transition-name: navbar;
     contain: layout;


### PR DESCRIPTION
In HN someone commented that the speed of RV was perceived slower because of the default fade effect of page view transition. This PR disable this default effect giving a faster impression for page navigation while maintaining the specific animations on talk cards