### PR TITLE
Optimize contribution page

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -18,6 +18,7 @@ linters:
       - app/views/contributions/_talks_without_slides.html.erb
       - app/views/contributions/_events_without_location.html.erb
       - app/views/contributions/_events_without_dates.html.erb
+      - app/views/contributions/_talks_dates_out_of_bounds.html.erb
   Rubocop:
     enabled: true
     rubocop_config:

--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -12,7 +12,12 @@ linters:
     enabled: true
   PartialInstanceVariable:
     enabled: true
-
+    exclude:
+      - app/views/contributions/_events_without_videos.html.erb
+      - app/views/contributions/_speakers_without_github.html.erb
+      - app/views/contributions/_talks_without_slides.html.erb
+      - app/views/contributions/_events_without_location.html.erb
+      - app/views/contributions/_events_without_dates.html.erb
   Rubocop:
     enabled: true
     rubocop_config:

--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -19,6 +19,7 @@ linters:
       - app/views/contributions/_events_without_location.html.erb
       - app/views/contributions/_events_without_dates.html.erb
       - app/views/contributions/_talks_dates_out_of_bounds.html.erb
+      - app/views/contributions/_missing_videos_cue.html.erb
   Rubocop:
     enabled: true
     rubocop_config:

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -6,8 +6,6 @@ class ContributionsController < ApplicationController
   STEPS = %i[speakers_without_github talks_without_slides events_without_videos events_without_location events_without_dates].freeze
 
   def index
-    @events_without_dates = Static::Playlist.where(start_date: nil).group_by(&:__file_path)
-    @events_without_dates_count = @events_without_dates.flat_map(&:last).count
     # Review Talk Dates
 
     events_with_start_date = Static::Playlist.all.pluck(:title, :start_date, :end_date).select { |_, start_date| start_date.present? }

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -1,24 +1,16 @@
 class ContributionsController < ApplicationController
+  include Turbo::ForceFrameResponse
+  force_frame_response only: %i[show]
   skip_before_action :authenticate_user!, only: %i[index]
 
+  STEPS = %i[speakers_without_github talks_without_slides events_without_videos].freeze
+
   def index
-    speaker_ids_with_pending_github_suggestions = Suggestion.pending.where("json_extract(content, '$.github') IS NOT NULL").where(suggestable_type: "Speaker").pluck(:suggestable_id)
-    @speakers_without_github = Speaker.canonical.without_github.order(talks_count: :desc).where.not(id: speaker_ids_with_pending_github_suggestions)
-    @speakers_without_github_count = @speakers_without_github.count
-
-    speakers_with_speakerdeck = Speaker.where.not(speakerdeck: "")
-    @talks_without_slides = Talk.preload(:speakers).joins(:speakers).where(slides_url: nil).where(speakers: {id: speakers_with_speakerdeck}).order(date: :desc)
-    @talks_without_slides_count = @talks_without_slides.count
-
-    @events_without_videos = Event.includes(:organisation).left_joins(:talks).where(talks_count: 0).group_by(&:organisation)
-    @events_without_videos_count = @events_without_videos.flat_map(&:last).count
-
     @events_without_location = Static::Playlist.where(location: nil).group_by(&:__file_path)
     @events_without_location_count = @events_without_location.flat_map(&:last).count
 
     @events_without_dates = Static::Playlist.where(start_date: nil).group_by(&:__file_path)
     @events_without_dates_count = @events_without_dates.flat_map(&:last).count
-
     # Review Talk Dates
 
     events_with_start_date = Static::Playlist.all.pluck(:title, :start_date, :end_date).select { |_, start_date| start_date.present? }
@@ -52,7 +44,11 @@ class ContributionsController < ApplicationController
     # Missing events
 
     conference_names = Event.all.pluck(:name)
-    @upstream_conferences = RubyConferences::Client.new.conferences_cached.reverse
+    @upstream_conferences = begin
+      RubyConferences::Client.new.conferences_cached.reverse
+    rescue
+      []
+    end
     @pending_conferences = @upstream_conferences.reject { |conference| conference["name"].in?(conference_names) }
 
     @with_video_link, @without_video_link = @pending_conferences.partition { |conference| conference["video_link"].present? }
@@ -69,5 +65,48 @@ class ContributionsController < ApplicationController
     # Conferences with missing schedules
     @conferences_with_missing_schedule = Event.joins(:organisation).where(organisation: {kind: :conference}).reject { |event| event.schedule.exist? }.group_by(&:organisation)
     @conferences_with_missing_schedule_count = @conferences_with_missing_schedule.flat_map(&:last).count
+  end
+
+  def show
+    @step = params[:step].to_sym.presence_in(STEPS)
+
+    if @step
+      send(@step)
+    else
+      raise StandardError, "missing step"
+    end
+  end
+
+  def speakers_without_github
+    speaker_ids_with_pending_github_suggestions = Suggestion.pending.where("json_extract(content, '$.github') IS NOT NULL").where(suggestable_type: "Speaker").pluck(:suggestable_id)
+    @speakers_without_github = Speaker.canonical.without_github.order(talks_count: :desc).where.not(id: speaker_ids_with_pending_github_suggestions)
+    @speakers_without_github_count = @speakers_without_github.count
+  end
+
+  def talks_without_slides
+    speakers_with_speakerdeck = Speaker.where.not(speakerdeck: "")
+    @talks_without_slides = Talk.preload(:speakers).joins(:speakers).where(slides_url: nil).where(speakers: {id: speakers_with_speakerdeck}).order(date: :desc)
+    @talks_without_slides_count = @talks_without_slides.count
+  end
+
+  def events_without_videos
+    @events_without_videos = Event.includes(:organisation).left_joins(:talks).where(talks_count: 0).group_by(&:organisation)
+    @events_without_videos_count = @events_without_videos.flat_map(&:last).count
+
+    @events_without_location = Static::Playlist.where(location: nil).group_by(&:__file_path)
+    @events_without_location_count = @events_without_location.flat_map(&:last).count
+
+    @events_without_dates = Static::Playlist.where(start_date: nil).group_by(&:__file_path)
+    @events_without_dates_count = @events_without_dates.flat_map(&:last).count
+  end
+
+  def events_without_location
+    @events_without_location = Static::Playlist.where(location: nil).group_by(&:__file_path)
+    @events_without_location_count = @events_without_location.flat_map(&:last).count
+  end
+
+  def events_without_dates
+    @events_without_dates = Static::Playlist.where(start_date: nil).group_by(&:__file_path)
+    @events_without_dates_count = @events_without_dates.flat_map(&:last).count
   end
 end

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -3,12 +3,9 @@ class ContributionsController < ApplicationController
   force_frame_response only: %i[show]
   skip_before_action :authenticate_user!, only: %i[index]
 
-  STEPS = %i[speakers_without_github talks_without_slides events_without_videos].freeze
+  STEPS = %i[speakers_without_github talks_without_slides events_without_videos events_without_location events_without_dates].freeze
 
   def index
-    @events_without_location = Static::Playlist.where(location: nil).group_by(&:__file_path)
-    @events_without_location_count = @events_without_location.flat_map(&:last).count
-
     @events_without_dates = Static::Playlist.where(start_date: nil).group_by(&:__file_path)
     @events_without_dates_count = @events_without_dates.flat_map(&:last).count
     # Review Talk Dates

--- a/app/views/contributions/_events_without_dates.html.erb
+++ b/app/views/contributions/_events_without_dates.html.erb
@@ -1,0 +1,21 @@
+<%= turbo_frame_tag "events_without_dates" do %>
+  <h2 class="mb-4">Events without conference dates (<%= @events_without_dates_count %>)</h2>
+
+  <article class="prose mb-6">This section lists events that are missing conference dates. Adding conference dates allows us to show when this event took place, so we could show them in a calendar or similar.</article>
+
+  <div id="events-without-dates" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
+    <% @events_without_dates.each do |file_path, events| %>
+      <%= link_to "https://github.com/adrienpoly/rubyvideo/edit/main/#{file_path}", id: "event-#{file_path}", class: "hover:bg-gray-100 p-4 rounded-lg border bg-white", target: :_blank do %>
+        <div class="flex flex-col">
+          <h3 class="line-clamp-1"><pre>Data File: <%= file_path %></pre></h3>
+
+          <b class="mt-4 mb-2">Events missing dates:</b>
+
+          <% events.each do |event| %>
+            <span><%= event.title %></span>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/contributions/_events_without_location.html.erb
+++ b/app/views/contributions/_events_without_location.html.erb
@@ -1,0 +1,21 @@
+<%= turbo_frame_tag "events_without_location" do %>
+  <h2 class="mb-4">Events without locations (<%= @events_without_location_count %>)</h2>
+
+  <article class="prose mb-6">This section lists events that are missing location information. By adding a location, we can show in which city/country this event took place.</article>
+
+  <div id="events-without-locations" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
+    <% @events_without_location.each do |file_path, events| %>
+      <%= link_to "https://github.com/adrienpoly/rubyvideo/edit/main/#{file_path}", id: "event-#{file_path}", class: "hover:bg-gray-100 p-4 rounded-lg border bg-white", target: :_blank do %>
+        <div class="flex flex-col">
+          <h3 class="line-clamp-1"><pre>Data File: <%= file_path %></pre></h3>
+
+          <b class="mt-4 mb-2">Events missing locations:</b>
+
+          <% events.each do |event| %>
+            <span><%= event.title %></span>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/contributions/_events_without_videos.html.erb
+++ b/app/views/contributions/_events_without_videos.html.erb
@@ -1,0 +1,21 @@
+<%= turbo_frame_tag "events_without_videos" do %>
+  <h2 class="mb-4">Events without videos (<%= @events_without_videos_count %>)</h2>
+
+  <article class="prose mb-6">This section highlights events that do not have associated videos available. Explore these events to see if the talks weren't recorded or just not yet added the site.</article>
+
+  <div id="events-without-locations" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
+    <% @events_without_videos.each do |organisation, events| %>
+      <%= content_tag :div, id: dom_id(organisation, "without-videos"), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
+        <div class="flex flex-col">
+          <h3 class="line-clamp-1"><p>Organisation: <%= link_to organisation.name, organisation, class: "hover:underline" %></p></h3>
+
+          <b class="mt-4 mb-2">Events without videos:</b>
+
+          <% events.each do |event| %>
+            <span><%= link_to event.name, event, class: "hover:underline" %></span>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/contributions/_introduction.html.erb
+++ b/app/views/contributions/_introduction.html.erb
@@ -1,0 +1,19 @@
+<article class="prose">
+  <h2>Welcome to RubyVideo.dev! 🌟</h2>
+
+  <p>We are thrilled to have you here and appreciate your interest in making this resource the best it can be for the community. If you would like to lend a hand, there are various ways you can contribute.</p>
+
+  <p>This page serves as a friendly starting point for anyone looking to get involved but unsure where to begin. Here are some ways you can help:</p>
+
+  <ul>
+    <li>Assist in adding missing GitHub handles to speakers</li>
+    <li>Help identify speakers based on conference screenshots</li>
+    <li>Contribute by adding last names to speakers</li>
+    <li>Attach Slides to talks</li>
+    <li>Review the date when the talk was given</li>
+    <li>Add location information to conferences</li>
+    <li>Add event dates to conferences</li>
+    <li>Add data for new conferences</li>
+  </ul>
+</article>
+</div>

--- a/app/views/contributions/_missing_videos_cue.html.erb
+++ b/app/views/contributions/_missing_videos_cue.html.erb
@@ -1,0 +1,25 @@
+<%= turbo_frame_tag "missing_videos_cue" do %>
+  <h2 class="mb-4">Missing Video Cues (<%= @missing_videos_cue_count %>)</h2>
+
+  <article class="prose mb-6">
+    This section highlights talks that have child talks but are missing video cues. You can help by adding video cues to these talks so we can let users play the the talk from the exact time it starts.
+  </article>
+
+  <div id="talks-dates-out-of-bounds" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
+    <% @missing_videos_cue.each do |event, talks| %>
+      <%= content_tag :div, id: dom_id(event), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
+        <article class="prose">
+          <h3 class="line-clamp-1">Event: <%= event.name %></h3>
+
+          <b class="mt-4 mb-2">Recording doesn't have cues for it's child talks:</b>
+
+          <ul>
+            <% talks.each do |talk| %>
+              <li><%= link_to talk.title, talk %> (<%= link_to pluralize(talk.child_talks.size, "talk"), talk %>) [<%= link_to "Data File", "https://github.com/adrienpoly/rubyvideo/edit/main/#{talk.static_metadata.__file_path}", target: :_blank %>]</li>
+            <% end %>
+          </ul>
+        </article>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/contributions/_speakers_without_github.html.erb
+++ b/app/views/contributions/_speakers_without_github.html.erb
@@ -1,0 +1,26 @@
+<%= turbo_frame_tag "speakers_without_github" do %>
+  <h2 class="mb-4">Speakers without GitHub handles (<%= @speakers_without_github_count %>)</h2>
+
+  <article class="prose mb-6">These speakers are currently missing a GitHub handle. By adding a GitHub handle to their profile, we can enhance their speaker profiles with an avatar and automatically retrieve additional information.</article>
+
+  <div id="speakers" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 min-w-full mb-6">
+    <% @speakers_without_github.each do |speaker| %>
+      <%= content_tag :div, id: dom_id(speaker), class: "flex justify-between p-4 rounded-lg border bg-white" do %>
+        <span><%= link_to speaker.name, edit_speaker_path(speaker), class: "underline link", data: {turbo_frame: "modal"} %></span>
+        <span>
+          <%= link_to "https://github.com/search?q=#{speaker.name}&type=users", target: "_blank", class: "underline link" do %>
+            <%= heroicon "magnifying-glass", variant: :outline, class: "size-5" %>
+          <% end %>
+        </span>
+      <% end %>
+    <% end %>
+
+    <% remaining_speakers_count = (@speakers_without_github_count - @speakers_without_github.count) %>
+
+    <% if remaining_speakers_count.positive? %>
+      <div class="flex items-center hover:bg-gray-100 p-4 rounded-lg border bg-white">
+        <span>and <%= remaining_speakers_count %> more</span>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/contributions/_talks_dates_out_of_bounds.html.erb
+++ b/app/views/contributions/_talks_dates_out_of_bounds.html.erb
@@ -1,0 +1,25 @@
+<%= turbo_frame_tag "talks_dates_out_of_bounds" do %>
+  <h2 class="mb-4">Review Talk Dates (<%= @out_of_bound_talks_count %>)</h2>
+
+  <article class="prose mb-6">This section shows talks with dates that don't quite match the event dates. Sometimes we only have the year for certain events, so we use that as a reference.</article>
+
+  <div id="talks-dates-out-of-bounds" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
+    <% @out_of_bound_talks.select { |_event, talks| talks.any? }.each do |event, talks| %>
+      <%= content_tag :div, id: dom_id(event), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
+        <article class="prose">
+          <h3 class="line-clamp-1">Event: <%= event.name %></h3>
+
+          <b class="mt-4 mb-2">Talk date is outside event dates:</b>
+
+          <p class="mb-2">Event Dates: <%= @dates_by_event_name[event.name].inspect %></p>
+
+          <ul>
+            <% talks.each do |talk| %>
+              <li><%= link_to talk.title, talk %> (<%= link_to talk.date.to_fs(:long), talk %>)</li>
+            <% end %>
+          </ul>
+        </article>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/contributions/_talks_without_slides.html.erb
+++ b/app/views/contributions/_talks_without_slides.html.erb
@@ -1,0 +1,24 @@
+<%= turbo_frame_tag "talks_without_slides" do %>
+  <h2 class="mb-4">Talks without slides (<%= @talks_without_slides_count %>)</h2>
+
+  <article class="prose mb-6">These talks currently do not have slides attached. However, we know that the speaker has an account on Speakerdeck where they usually upload their slides. Feel free to explore if these talks have associated slidedecks on Speakerdeck.com.</article>
+
+  <div id="speakers" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
+    <% @talks_without_slides.each do |talk| %>
+      <%= link_to edit_talk_path(talk), id: dom_id(talk), class: "hover:bg-gray-100 p-4 rounded-lg border bg-white" do %>
+        <div class="flex flex-col">
+          <span class="font-bold"><%= talk.title %></span>
+          <span><%= talk.speakers.first.name %></span>
+        </div>
+      <% end %>
+    <% end %>
+
+    <% remaining_talks_count = (@talks_without_slides_count - @talks_without_slides.count) %>
+
+    <% if remaining_talks_count.positive? %>
+      <div class="flex items-center hover:bg-gray-100 p-4 rounded-lg border bg-white">
+        <span>and <%= remaining_talks_count %> more</span>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/contributions/index.html.erb
+++ b/app/views/contributions/index.html.erb
@@ -34,33 +34,9 @@
       <%= turbo_frame_tag "events_without_dates", src: contribution_path(:events_without_dates), loading: :lazy %>
     </div>
 
-    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Review Talk Dates (<%= @out_of_bound_talks_count %>)" style="width: 200px">
+    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Review Talk Dates" style="width: 200px">
     <div role="tabpanel" class="tab-content py-6">
-      <div class="">
-        <h2 class="mb-4">Review Talk Dates (<%= @out_of_bound_talks_count %>)</h2>
-
-        <article class="prose mb-6">This section shows talks with dates that don't quite match the event dates. Sometimes we only have the year for certain events, so we use that as a reference.</article>
-
-        <div id="talks-dates-out-of-bounds" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
-          <% @out_of_bound_talks.select { |_event, talks| talks.any? }.each do |event, talks| %>
-            <%= content_tag :div, id: dom_id(event), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
-              <article class="prose">
-                <h3 class="line-clamp-1">Event: <%= event.name %></h3>
-
-                <b class="mt-4 mb-2">Talk date is outside event dates:</b>
-
-                <p class="mb-2">Event Dates: <%= @dates_by_event_name[event.name].inspect %></p>
-
-                <ul>
-                  <% talks.each do |talk| %>
-                    <li><%= link_to talk.title, talk %> (<%= link_to talk.date.to_fs(:long), talk %>)</li>
-                  <% end %>
-                </ul>
-              </article>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
+      <%= turbo_frame_tag "talks_dates_out_of_bounds", src: contribution_path(:talks_dates_out_of_bounds), loading: :lazy %>
     </div>
 
     <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Missing Video Cues (<%= @missing_videos_cue_count %>)" style="width: 200px">

--- a/app/views/contributions/index.html.erb
+++ b/app/views/contributions/index.html.erb
@@ -39,33 +39,9 @@
       <%= turbo_frame_tag "talks_dates_out_of_bounds", src: contribution_path(:talks_dates_out_of_bounds), loading: :lazy %>
     </div>
 
-    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Missing Video Cues (<%= @missing_videos_cue_count %>)" style="width: 200px">
-    <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-box p-6">
-      <div class="">
-        <h2 class="mb-4">Missing Video Cues (<%= @missing_videos_cue_count %>)</h2>
-
-        <article class="prose mb-6">
-          This section highlights talks that have child talks but are missing video cues. You can help by adding video cues to these talks so we can let users play the the talk from the exact time it starts.
-        </article>
-
-        <div id="talks-dates-out-of-bounds" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
-          <% @missing_videos_cue.each do |event, talks| %>
-            <%= content_tag :div, id: dom_id(event), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
-              <article class="prose">
-                <h3 class="line-clamp-1">Event: <%= event.name %></h3>
-
-                <b class="mt-4 mb-2">Recording doesn't have cues for it's child talks:</b>
-
-                <ul>
-                  <% talks.each do |talk| %>
-                    <li><%= link_to talk.title, talk %> (<%= link_to pluralize(talk.child_talks.size, "talk"), talk %>) [<%= link_to "Data File", "https://github.com/adrienpoly/rubyvideo/edit/main/#{talk.static_metadata.__file_path}", target: :_blank %>]</li>
-                  <% end %>
-                </ul>
-              </article>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
+    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Missing Video Cues" style="width: 200px">
+    <div role="tabpanel" class="tab-content py-6">
+      <%= turbo_frame_tag "missing_videos_cue", src: contribution_path(:missing_videos_cue), loading: :lazy %>
     </div>
 
     <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Overdue scheduled talks (<%= @overdue_scheduled_talks_count %>)" style="width: 250px">

--- a/app/views/contributions/index.html.erb
+++ b/app/views/contributions/index.html.erb
@@ -24,29 +24,9 @@
       <%= turbo_frame_tag "events_without_videos", src: contribution_path(:events_without_videos), loading: :lazy %>
     </div>
 
-    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Events without locations (<%= @events_without_location_count %>)" style="width: 225px">
+    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Events without locations" style="width: 225px">
     <div role="tabpanel" class="tab-content py-6">
-      <div class="">
-        <h2 class="mb-4">Events without locations (<%= @events_without_location_count %>)</h2>
-
-        <article class="prose mb-6">This section lists events that are missing location information. By adding a location, we can show in which city/country this event took place.</article>
-
-        <div id="events-without-locations" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
-          <% @events_without_location.each do |file_path, events| %>
-            <%= link_to "https://github.com/adrienpoly/rubyvideo/edit/main/#{file_path}", id: "event-#{file_path}", class: "hover:bg-gray-100 p-4 rounded-lg border bg-white", target: :_blank do %>
-              <div class="flex flex-col">
-                <h3 class="line-clamp-1"><pre>Data File: <%= file_path %></pre></h3>
-
-                <b class="mt-4 mb-2">Events missing locations:</b>
-
-                <% events.each do |event| %>
-                  <span><%= event.title %></span>
-                <% end %>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
+      <%= turbo_frame_tag "events_without_location", src: contribution_path(:events_without_location), loading: :lazy %>
     </div>
 
     <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Events without conference dates (<%= @events_without_dates_count %>)" style="width: 300px">

--- a/app/views/contributions/index.html.erb
+++ b/app/views/contributions/index.html.erb
@@ -7,108 +7,21 @@
   <div role="tablist" class="tabs tabs-bordered mt-6">
     <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Introduction" checked="checked" style="width: 125px">
     <div role="tabpanel" class="tab-content py-6">
-      <article class="prose">
-        <h2>Welcome to RubyVideo.dev! 🌟</h2>
+      <%= render "contributions/introduction" %>
 
-        <p>We are thrilled to have you here and appreciate your interest in making this resource the best it can be for the community. If you would like to lend a hand, there are various ways you can contribute.</p>
-
-        <p>This page serves as a friendly starting point for anyone looking to get involved but unsure where to begin. Here are some ways you can help:</p>
-
-        <ul>
-          <li>Assist in adding missing GitHub handles to speakers</li>
-          <li>Help identify speakers based on conference screenshots</li>
-          <li>Contribute by adding last names to speakers</li>
-          <li>Attach Slides to talks</li>
-          <li>Review the date when the talk was given</li>
-          <li>Add location information to conferences</li>
-          <li>Add event dates to conferences</li>
-          <li>Add data for new conferences</li>
-        </ul>
-      </article>
+    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Speakers without GitHub handles" style="width: 300px">
+    <div role="tabpanel" class="tab-content py-6">
+      <%= turbo_frame_tag "speakers_without_github", src: contribution_path(:speakers_without_github), loading: :lazy %>
     </div>
 
-    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Speakers without GitHub handles (<%= @speakers_without_github_count %>)" style="width: 300px">
+    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Talks without slides" style="width: 225px">
     <div role="tabpanel" class="tab-content py-6">
-      <div class="">
-        <h2 class="mb-4">Speakers without GitHub handles (<%= @speakers_without_github_count %>)</h2>
-
-        <article class="prose mb-6">These speakers are currently missing a GitHub handle. By adding a GitHub handle to their profile, we can enhance their speaker profiles with an avatar and automatically retrieve additional information.</article>
-
-        <div id="speakers" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 min-w-full mb-6">
-          <% @speakers_without_github.each do |speaker| %>
-            <%= content_tag :div, id: dom_id(speaker), class: "flex justify-between p-4 rounded-lg border bg-white" do %>
-              <span><%= link_to speaker.name, edit_speaker_path(speaker), class: "underline link", data: {turbo_frame: "modal"} %></span>
-              <span>
-                <%= link_to "https://github.com/search?q=#{speaker.name}&type=users", target: "_blank", class: "underline link" do %>
-                  <%= heroicon "magnifying-glass", variant: :outline, class: "size-5" %>
-                <% end %>
-              </span>
-            <% end %>
-          <% end %>
-
-          <% remaining_speakers_count = (@speakers_without_github_count - @speakers_without_github.count) %>
-
-          <% if remaining_speakers_count.positive? %>
-            <div class="flex items-center hover:bg-gray-100 p-4 rounded-lg border bg-white">
-              <span>and <%= remaining_speakers_count %> more</span>
-            </div>
-          <% end %>
-        </div>
-      </div>
+      <%= turbo_frame_tag "talks_without_slides", src: contribution_path(:talks_without_slides), loading: :lazy %>
     </div>
 
-    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Talks without slides (<%= @talks_without_slides_count %>)" style="width: 225px">
+    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Events without videos" style="width: 225px">
     <div role="tabpanel" class="tab-content py-6">
-      <div class="">
-        <h2 class="mb-4">Talks without slides (<%= @talks_without_slides_count %>)</h2>
-
-        <article class="prose mb-6">These talks currently do not have slides attached. However, we know that the speaker has an account on Speakerdeck where they usually upload their slides. Feel free to explore if these talks have associated slidedecks on Speakerdeck.com.</article>
-
-        <div id="speakers" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
-          <% @talks_without_slides.each do |talk| %>
-            <%= link_to edit_talk_path(talk), id: dom_id(talk), class: "hover:bg-gray-100 p-4 rounded-lg border bg-white" do %>
-              <div class="flex flex-col">
-                <span class="font-bold"><%= talk.title %></span>
-                <span><%= talk.speakers.first.name %></span>
-              </div>
-            <% end %>
-          <% end %>
-
-          <% remaining_talks_count = (@talks_without_slides_count - @talks_without_slides.count) %>
-
-          <% if remaining_talks_count.positive? %>
-            <div class="flex items-center hover:bg-gray-100 p-4 rounded-lg border bg-white">
-              <span>and <%= remaining_talks_count %> more</span>
-            </div>
-          <% end %>
-        </div>
-      </div>
-
-    </div>
-
-    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Events without videos (<%= @events_without_videos_count %>)" style="width: 225px">
-    <div role="tabpanel" class="tab-content py-6">
-      <div class="">
-        <h2 class="mb-4">Events without videos (<%= @events_without_videos_count %>)</h2>
-
-        <article class="prose mb-6">This section highlights events that do not have associated videos available. Explore these events to see if the talks weren't recorded or just not yet added the site.</article>
-
-        <div id="events-without-locations" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
-          <% @events_without_videos.each do |organisation, events| %>
-            <%= content_tag :div, id: dom_id(organisation, "without-videos"), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
-              <div class="flex flex-col">
-                <h3 class="line-clamp-1"><p>Organisation: <%= link_to organisation.name, organisation, class: "hover:underline" %></p></h3>
-
-                <b class="mt-4 mb-2">Events without videos:</b>
-
-                <% events.each do |event| %>
-                  <span><%= link_to event.name, event, class: "hover:underline" %></span>
-                <% end %>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
+      <%= turbo_frame_tag "events_without_videos", src: contribution_path(:events_without_videos), loading: :lazy %>
     </div>
 
     <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Events without locations (<%= @events_without_location_count %>)" style="width: 225px">

--- a/app/views/contributions/index.html.erb
+++ b/app/views/contributions/index.html.erb
@@ -29,29 +29,9 @@
       <%= turbo_frame_tag "events_without_location", src: contribution_path(:events_without_location), loading: :lazy %>
     </div>
 
-    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Events without conference dates (<%= @events_without_dates_count %>)" style="width: 300px">
+    <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Events without conference dates" style="width: 300px">
     <div role="tabpanel" class="tab-content py-6">
-      <div class="">
-        <h2 class="mb-4">Events without conference dates (<%= @events_without_dates_count %>)</h2>
-
-        <article class="prose mb-6">This section lists events that are missing conference dates. Adding conference dates allows us to show when this event took place, so we could show them in a calendar or similar.</article>
-
-        <div id="events-without-dates" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
-          <% @events_without_dates.each do |file_path, events| %>
-            <%= link_to "https://github.com/adrienpoly/rubyvideo/edit/main/#{file_path}", id: "event-#{file_path}", class: "hover:bg-gray-100 p-4 rounded-lg border bg-white", target: :_blank do %>
-              <div class="flex flex-col">
-                <h3 class="line-clamp-1"><pre>Data File: <%= file_path %></pre></h3>
-
-                <b class="mt-4 mb-2">Events missing dates:</b>
-
-                <% events.each do |event| %>
-                  <span><%= event.title %></span>
-                <% end %>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
+      <%= turbo_frame_tag "events_without_dates", src: contribution_path(:events_without_dates), loading: :lazy %>
     </div>
 
     <input type="radio" name="contribution-tabs" role="tab" class="tab" aria-label="Review Talk Dates (<%= @out_of_bound_talks_count %>)" style="width: 200px">

--- a/app/views/contributions/show.html.erb
+++ b/app/views/contributions/show.html.erb
@@ -1,0 +1,1 @@
+<%= render "contributions/#{@step}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     resource :password_reset, only: [:new, :edit, :create, :update]
   end
 
-  resources :contributions, only: [:index]
+  resources :contributions, only: [:index, :show], param: :step
 
   # resources
   namespace :analytics do


### PR DESCRIPTION
This PR extract the contribution content to lazy loaded partials

While the traffic on this route is not huge the response time is really too much with about 2.5s
![CleanShot 2024-12-19 at 08 21 02@2x](https://github.com/user-attachments/assets/a1a34335-f7f7-4fee-b925-07fbbad2ea72)

With this PR the initial page load should be instant and when navigating tabs load only the required content 
We can even cache this content if needed (mostly when they are large collections of cards to render

## Todo :

- [ ] Overdue scheduled talks
- [ ] Talks without speakers
- [ ] Not published talks
- [ ] Add missing events
- [ ] Events without schedule
