### PR TITLE
Refactor Talk indexing into a Talk::Index record.

### DIFF
--- a/app/models/talk/index.rb
+++ b/app/models/talk/index.rb
@@ -1,0 +1,37 @@
+class Talk::Index < ApplicationRecord
+  self.table_name = :talks_search_index
+  self.primary_key = :rowid
+
+  attribute :rowid, :integer
+  alias_attribute :id, :rowid
+
+  belongs_to :talk, foreign_key: :rowid
+
+  # SQLite/Active Record doesn't pick up the virtual table primary key by default.
+  # So on direct queries we need to do `Talk::Index.with_rowid.first`, if we want
+  # to have `rowid`/`id` values populated in the result set.
+  scope :with_rowid, -> { select("#{table_name}.rowid, #{table_name}.*") }
+
+  def self.search(query)
+    query = query&.gsub(/[^[:word:]]/, " ") || "" # remove non-word characters
+    query = query.split.map { |word| "#{word}*" }.join(" ") # wildcard search
+    where("#{table_name} match ?", query)
+  end
+
+  def self.snippets(**)
+    COLUMNS_WITH_OFFSETS.each_key.reduce(all) { |relation, column| relation.snippet(column, **) }
+  end
+
+  def self.snippet(column, tag: "mark", omission: "…", limit: 32)
+    select("snippet(#{table_name}, #{COLUMNS_WITH_OFFSETS.fetch(column)}, '<#{tag}>', '</#{tag}>', '#{omission}', #{limit}) AS #{column}_snippet")
+  end
+
+  def reindex
+    update! ALL_COLUMNS.index_with { talk.public_send _1 }
+  end
+
+  private
+
+  ALL_COLUMNS = %i[id title summary speaker_names]
+  COLUMNS_WITH_OFFSETS = ALL_COLUMNS.without(:id).each.with_index.to_h
+end

--- a/app/models/talk/searchable.rb
+++ b/app/models/talk/searchable.rb
@@ -4,40 +4,29 @@ module Talk::Searchable
   DATE_WEIGHT = 0.000000001
 
   included do
-    scope :ft_search, ->(query) do
-      query = query&.gsub(/[^[:word:]]/, " ") || "" # remove non-word characters
-      query = query.split.map { |word| "#{word}*" }.join(" ") # wildcard search
-      joins("join talks_search_index idx on talks.id = idx.rowid")
-        .where("talks_search_index match ?", query)
-    end
+    has_one :index, -> { with_rowid }, foreign_key: :rowid, dependent: :destroy
+
+    scope :ft_search, ->(query) { joins(:index).merge(Talk::Index.search(query)) }
 
     scope :with_snippets, ->(**options) do
-      select("talks.*")
-        .select_snippet("title", 0, **options)
-        .select_snippet("summary", 1, **options)
-        .select_snippet("speaker_names", 2, **options)
+      select("talks.*").merge(Talk::Index.snippets(**options))
     end
 
     scope :ranked, -> do
       select("talks.*,
           bm25(talks_search_index, 10.0, 1.0, 5.0) +
           (strftime('%s', 'now') - strftime('%s', talks.date)) * #{DATE_WEIGHT} AS combined_score")
-        .order(Arel.sql("combined_score ASC"))
+        .order(combined_score: :asc)
     end
 
     after_create_commit :create_in_index
     after_update_commit :update_in_index
-    after_destroy_commit :remove_from_index
   end
 
   class_methods do
-    def rebuild_search_index
-      connection.execute("DELETE FROM talks_search_index")
+    def reindex_all
+      Index.delete_all
       Talk.find_each(&:create_in_index)
-    end
-
-    def select_snippet(column, offset, tag: "mark", omission: "…", limit: 32)
-      select("snippet(talks_search_index, #{offset}, '<#{tag}>', '</#{tag}>', '#{omission}', #{limit}) AS #{column}_snippet")
     end
   end
 
@@ -46,20 +35,10 @@ module Talk::Searchable
   end
 
   def create_in_index
-    execute_sql_with_binds "insert into talks_search_index(rowid, title, summary, speaker_names) values (?, ?, ?, ?)", id, title, summary, speaker_names
+    build_index.reindex
   end
 
   def update_in_index
-    execute_sql_with_binds "update talks_search_index set title = ?, summary = ?, speaker_names = ? where rowid = ?", title, summary, speaker_names, id
-  end
-
-  def remove_from_index
-    execute_sql_with_binds "delete from talks_search_index where rowid = ?", id
-  end
-
-  private
-
-  def execute_sql_with_binds(*statement)
-    self.class.connection.execute self.class.sanitize_sql(statement)
+    index.reindex
   end
 end


### PR DESCRIPTION
This does take some extra work since Active Record can't detect `rowid` is the primary key.

But with some awareness around that, it's pretty smooth sailing and we can entirely remove a lot of the custom SQL with standard Active Record.