### PR TITLE
remove AssociatedObject annotation warnings

### DIFF
--- a/app/models/event/schedule.rb
+++ b/app/models/event/schedule.rb
@@ -1,3 +1,4 @@
+# -*- SkipSchemaAnnotations
 class Event::Schedule < ActiveRecord::AssociatedObject
   def file_path
     event.data_folder.join("schedule.yml")

--- a/app/models/speaker/profiles.rb
+++ b/app/models/speaker/profiles.rb
@@ -1,3 +1,4 @@
+# -*- SkipSchemaAnnotations
 class Speaker::Profiles < ActiveRecord::AssociatedObject
   performs(retries: 3) { limits_concurrency key: -> { _1.id } }
 

--- a/app/models/talk/agents.rb
+++ b/app/models/talk/agents.rb
@@ -1,3 +1,4 @@
+# -*- SkipSchemaAnnotations
 class Talk::Agents < ActiveRecord::AssociatedObject
   performs retries: 3 do
     # this is to comply to the rate limit of openai 60 000 tokens per minute

--- a/app/models/talk/downloader.rb
+++ b/app/models/talk/downloader.rb
@@ -1,3 +1,5 @@
+# -*- SkipSchemaAnnotations
+
 class Talk::Downloader < ActiveRecord::AssociatedObject
   def download_path
     Rails.root / "tmp" / "videos" / talk.video_provider / "#{talk.video_id}.mp4"

--- a/app/models/talk/thumbnails.rb
+++ b/app/models/talk/thumbnails.rb
@@ -1,3 +1,5 @@
+# -*- SkipSchemaAnnotations
+
 class Talk::Thumbnails < ActiveRecord::AssociatedObject
   def path
     directory / "#{talk.video_id}.webp"


### PR DESCRIPTION
when running migrations we have those warnings for associated objects

![CleanShot 2025-01-02 at 18 59 27@2x](https://github.com/user-attachments/assets/4304d198-acfa-41b8-8b1f-672e54e52d0c)


I have opened [this issue](https://github.com/drwl/annotaterb/issues/172) on the annotate repo in case their could be a simpler solution 