### PR TITLE
remove infinite back_to chain

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,13 @@ module ApplicationHelper
     @back_path || root_path
   end
 
+  def back_to_from_request
+    # remove the back_to params from the query string to avoid creating recusive redirects
+    uri = URI.parse(request.fullpath)
+    uri.query = uri.query&.split("&")&.reject { |param| param.start_with?("back_to=") }&.join("&")
+    uri.to_s
+  end
+
   def active_link_to(text = nil, path = nil, active_class: "", **options, &)
     path ||= text
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -12,7 +12,7 @@
                 locals: {
                   favoritable: true,
                   user_favorite_talks_ids: @user_favorite_talks_ids,
-                  back_to: request.fullpath,
+                  back_to: back_to_from_request,
                   back_to_title: @event.name
                 },
                 as: :talk %>

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -6,7 +6,7 @@
 
   <% if @topics.any? %>
     <div class="mt-9 mb-3">
-      <%= render partial: "topics/badge_list", locals: {topics: @topics, back_to_url: request.fullpath, back_to_title: @speaker.name} %>
+      <%= render partial: "topics/badge_list", locals: {topics: @topics, back_to_url: back_to_from_request, back_to_title: @speaker.name} %>
     </div>
   <% end %>
 
@@ -25,7 +25,7 @@
                   favoritable: true,
                   user_favorite_talks_ids: @user_favorite_talks_ids,
                   watched_talks_ids: user_watched_talks_ids,
-                  back_to: request.fullpath,
+                  back_to: back_to_from_request,
                   back_to_title: @speaker.name
                 } %>
         </div>

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -259,7 +259,7 @@
     <% end %>
 
     <% if talk.approved_topics.any? %>
-      <%= render partial: "topics/badge_list", locals: {topics: talk.approved_topics, back_to_url: request.fullpath, back_to_title: talk.title} %>
+      <%= render partial: "topics/badge_list", locals: {topics: talk.approved_topics, back_to_url: back_to_from_request, back_to_title: talk.title} %>
     <% end %>
 
     <div role="tablist" class="tabs tabs-bordered mt-6">

--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -17,7 +17,7 @@
             locals: {
               favoritable: true,
               user_favorite_talks_ids: @user_favorite_talks_ids,
-              back_to: request.fullpath
+              back_to: back_to_from_request
             } %>
     </div>
     <div class="flex mt-4 w-full">

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -18,7 +18,7 @@
             favoritable: true,
             user_favorite_talks_ids: @user_favorite_talks_ids,
             watched_talks_ids: user_watched_talks_ids,
-            back_to: request.fullpath,
+            back_to: back_to_from_request,
             back_to_title: @topic.name
           } %>
   </div>


### PR DESCRIPTION
this is an example of links the bots are crawling

![CleanShot 2025-01-07 at 23 04 02@2x](https://github.com/user-attachments/assets/2f5b047d-25dc-446a-acf0-89221fe54afc)


back_to are somehow recursive and they could be infinite. I noticed that some we crawler will keep  navigating the site for all those variations of url.

Some bots are not becoming very aggressive and taking up a lot of ressources 

Hopefully removing those recursive link should help