### PR TITLE
update video statistics with a recurring job

### DIFF
--- a/app/clients/youtube/video.rb
+++ b/app/clients/youtube/video.rb
@@ -13,8 +13,8 @@ module Youtube
 
       response.each_with_object({}) do |item, hash|
         hash[item["id"]] = {
-         view_count: item["statistics"]["viewCount"],
-         like_count: item["statistics"]["likeCount"]
+          view_count: item["statistics"]["viewCount"],
+          like_count: item["statistics"]["likeCount"]
         }
       end
     end

--- a/app/clients/youtube/video.rb
+++ b/app/clients/youtube/video.rb
@@ -11,10 +11,15 @@ module Youtube
 
       return unless response.present?
 
-      {
-        view_count: response.first["statistics"]["viewCount"],
-        like_count: response.first["statistics"]["likeCount"]
-      }
+      hash = {}
+      response.map do |item|
+        hash[item["id"]] = {
+          view_count: item["statistics"]["viewCount"],
+          like_count: item["statistics"]["likeCount"]
+        }
+      end
+
+      hash
     end
   end
 end

--- a/app/clients/youtube/video.rb
+++ b/app/clients/youtube/video.rb
@@ -11,15 +11,12 @@ module Youtube
 
       return unless response.present?
 
-      hash = {}
-      response.map do |item|
+      response.each_with_object({}) do |item, hash|
         hash[item["id"]] = {
-          view_count: item["statistics"]["viewCount"],
-          like_count: item["statistics"]["likeCount"]
+         view_count: item["statistics"]["viewCount"],
+         like_count: item["statistics"]["likeCount"]
         }
       end
-
-      hash
     end
   end
 end

--- a/app/jobs/recurring/youtube_video_statistics_job.rb
+++ b/app/jobs/recurring/youtube_video_statistics_job.rb
@@ -1,0 +1,14 @@
+class Recurring::YoutubeVideoStatisticsJob < ApplicationJob
+  queue_as :low
+
+  def perform
+    Talk.youtube.in_batches(of: 50) do |talks|
+      stats = Youtube::Video.new.get_statistics(talks.pluck(:video_id))
+      talks.each do |talk|
+        if stats[talk.video_id]
+          talk.update!(view_count: stats[talk.video_id][:view_count], like_count: stats[talk.video_id][:like_count])
+        end
+      end
+    end
+  end
+end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -12,7 +12,7 @@
 #  external_player_url :string           default(""), not null
 #  kind                :string           default("talk"), not null, indexed
 #  language            :string           default("en"), not null
-#  like_count          :integer
+#  like_count          :integer          default(0)
 #  meta_talk           :boolean          default(FALSE), not null
 #  raw_transcript      :text             default(#<Transcript:0x000000012f650588 @cues=[]>), not null
 #  slides_url          :string
@@ -27,7 +27,7 @@
 #  thumbnail_xs        :string           default(""), not null
 #  title               :string           default(""), not null, indexed
 #  video_provider      :string           default("youtube"), not null
-#  view_count          :integer
+#  view_count          :integer          default(0)
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null, indexed
 #  event_id            :integer          indexed

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,3 @@
+youtube_video_statistics_job:
+  class: Recurring::YoutubeVideoStatisticsJob
+  schedule: every day at 1am

--- a/db/migrate/20250108221813_set_view_count_default_on_talk.rb
+++ b/db/migrate/20250108221813_set_view_count_default_on_talk.rb
@@ -1,0 +1,6 @@
+class SetViewCountDefaultOnTalk < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :talks, :view_count, 0
+    change_column_default :talks, :like_count, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_02_175230) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_08_221813) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -196,8 +196,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_02_175230) do
     t.string "thumbnail_xs", default: "", null: false
     t.string "thumbnail_xl", default: "", null: false
     t.date "date"
-    t.integer "like_count"
-    t.integer "view_count"
+    t.integer "like_count", default: 0
+    t.integer "view_count", default: 0
     t.text "raw_transcript", default: "", null: false
     t.text "enhanced_transcript", default: "", null: false
     t.text "summary", default: "", null: false

--- a/test/clients/youtube/video_test.rb
+++ b/test/clients/youtube/video_test.rb
@@ -12,8 +12,8 @@ module Youtube
       VCR.use_cassette("youtube_statistics", match_requests_on: [:method]) do
         stats = @client.get_statistics(video_id)
         assert_not_nil stats
-        assert stats.has_key?(:view_count)
-        assert stats.has_key?(:like_count)
+        assert stats[video_id].has_key?(:view_count)
+        assert stats[video_id].has_key?(:like_count)
       end
     end
 

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -12,7 +12,7 @@
 #  external_player_url :string           default(""), not null
 #  kind                :string           default("talk"), not null, indexed
 #  language            :string           default("en"), not null
-#  like_count          :integer
+#  like_count          :integer          default(0)
 #  meta_talk           :boolean          default(FALSE), not null
 #  raw_transcript      :text             default(#<Transcript:0x000000012f650588 @cues=[]>), not null
 #  slides_url          :string
@@ -27,7 +27,7 @@
 #  thumbnail_xs        :string           default(""), not null
 #  title               :string           default(""), not null, indexed
 #  video_provider      :string           default("youtube"), not null
-#  view_count          :integer
+#  view_count          :integer          default(0)
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null, indexed
 #  event_id            :integer          indexed

--- a/test/jobs/recurring/youtube_video_statistics_job_test.rb
+++ b/test/jobs/recurring/youtube_video_statistics_job_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Recurring::YoutubeVideoStatisticsJobTest < ActiveJob::TestCase
+  test "should update view_count and like_count for youtube talks" do
+    VCR.use_cassette("recurring_youtube_statistics_job", match_requests_on: [:method]) do
+      talk = Talk.youtube.first
+      assert_not talk.view_count.positive?
+      assert_not talk.like_count.positive?
+      Recurring::YoutubeVideoStatisticsJob.new.perform
+      assert talk.reload.view_count.positive?
+      assert talk.like_count.positive?
+    end
+  end
+end

--- a/test/vcr_cassettes/recurring_youtube_statistics_job.yml
+++ b/test/vcr_cassettes/recurring_youtube_statistics_job.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://youtube.googleapis.com/youtube/v3/videos?id=F75k4Oc6g9Q&key=AIzaSyCe3yTMydyYrEKSS0N0oh9w5y9Rct3g3QU&maxResults=50&part=statistics
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 08 Jan 2025 22:23:33 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "kind": "youtube#videoListResponse",
+          "etag": "V60dqYQfDUoSn3bi_kr_AEZP2KU",
+          "items": [
+            {
+              "kind": "youtube#video",
+              "etag": "pVbmMiy3eNUSosIwPZ4Fgc5MK2o",
+              "id": "F75k4Oc6g9Q",
+              "statistics": {
+                "viewCount": "13105",
+                "likeCount": "371",
+                "favoriteCount": "0",
+                "commentCount": "31"
+              }
+            }
+          ],
+          "pageInfo": {
+            "totalResults": 1,
+            "resultsPerPage": 1
+          }
+        }
+  recorded_at: Wed, 08 Jan 2025 22:23:33 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
This PR : 
- updates our youtube video client to collect statistics from a collection of talks (1 call can retreive 50 talks stats)
- adds a job to iterate Youtube Talk in batches of 50 and get their stats from YT
- setup a reccuring task to update this data every day at 1am


poke @nicogaldamez 