### PR TITLE
fix order for talks search to match spotlight search

### DIFF
--- a/app/controllers/spotlight/talks_controller.rb
+++ b/app/controllers/spotlight/talks_controller.rb
@@ -3,7 +3,7 @@ class Spotlight::TalksController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @talks = Talk.includes(:speakers, event: :organisation)
+    @talks = Talk.watchable.includes(:speakers, event: :organisation)
     @talks = @talks.ft_search(search_query).ranked if search_query.present?
     @talks_count = @talks.count(:id)
     @talks = @talks.limit(5)

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -11,13 +11,14 @@ class TalksController < ApplicationController
 
   # GET /talks
   def index
-    @talks = Talk.includes(:speakers, event: :organisation, child_talks: :speakers).order(order_by)
+    @talks = Talk.includes(:speakers, event: :organisation, child_talks: :speakers)
     @talks = @talks.watchable unless params[:all].present?
     @talks = @talks.ft_search(params[:s]).with_snippets.ranked if params[:s].present?
     @talks = @talks.for_topic(params[:topic]) if params[:topic].present?
     @talks = @talks.for_event(params[:event]) if params[:event].present?
     @talks = @talks.for_speaker(params[:speaker]) if params[:speaker].present?
     @talks = @talks.where(kind: talk_kind) if talk_kind.present?
+    @talks = @talks.order(order_by) if order_by
     @pagy, @talks = pagy(@talks, items: 20, page: params[:page]&.to_i || 1)
   end
 
@@ -44,6 +45,9 @@ class TalksController < ApplicationController
   private
 
   def order_by
+    # when searching, don't order by date as the search results are already ordered by relevance
+    # unless the user explicitly asks for it
+    return if params[:s].present? && params[:order_by].blank?
     order_by_options = {
       "date_desc" => "talks.date DESC",
       "date_asc" => "talks.date ASC"


### PR DESCRIPTION
close #560

the talk#index are ordered by default by date This PR ensure that when we search the results are ordered by relevance and not anymore by date to match the search results in the spotlight