### PR TITLE
speed up with cache the icon inline tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,6 @@ gem "solid_cache"
 gem "solid_queue"
 gem "mission_control-jobs"
 
-gem "inline_svg", "~> 1.9"
 gem "meilisearch-rails"
 gem "ahoy_matey"
 gem "vite_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -632,7 +632,6 @@ DEPENDENCIES
   frozen_record (~> 0.27.2)
   google-protobuf
   groupdate
-  inline_svg (~> 1.9)
   iso-639
   jbuilder
   json-repair (~> 0.2.0)


### PR DESCRIPTION
This PR removes the inline_svg gem and replace it by a simple built in inliner. the main advantage is that we cache the svgs to speed up the rendering. I noticed that using the inline_svg gem could lead to a rather larger performance impact for rendering simple icons. as an example the partial `_search_bar` with a single icon was taking 5ms to render vs 20us with the current implementation