### PR TITLE
Add missing talks/workshops/schedule for Community Conference 2025

### DIFF
--- a/data/ruby-community-conference/ruby-community-conference-winter-edition-2025/schedule.yml
+++ b/data/ruby-community-conference/ruby-community-conference-winter-edition-2025/schedule.yml
@@ -1,0 +1,46 @@
+# Schedule: https://www.rubycommunityconference.com/#agenda
+
+days:
+  - name: "Day Before The Conference"
+    date: "2025-02-27"
+    grid:
+      - start_time: "Evening"
+        end_time: "Evening"
+        slots: 1
+        items:
+          - title: Join Us For KRUG (Kraków Ruby User Group)
+            description: With Some Fantastic Talks, Followed By A Fun Pre-Party To Kick Things Off!
+
+  - name: "Conference Day"
+    date: "2025-02-28"
+    grid:
+      - start_time: "Morning"
+        end_time: "Morning"
+        slots: 1
+        items:
+          - title: Workshops
+            description: The Main Event Starts With Morning Workshops
+
+      - start_time: "Afternoon"
+        end_time: "Afternoon"
+        slots: 1
+        items:
+          - title: Talks
+            description: Afternoon Talks
+
+      - start_time: "Evening"
+        end_time: "Evening"
+        slots: 1
+        items:
+          - title: After-Party
+            description: Wraps Up With The After-Party!
+
+  - name: "Day After The Conference"
+    date: "2025-03-01"
+    grid:
+      - start_time: "All-Day"
+        end_time: "All-Day"
+        slots: 1
+        items:
+          - title: City Tour
+            description: Stick Around To Explore The Beautiful City Of Kraków With The Ruby Friends.

--- a/data/ruby-community-conference/ruby-community-conference-winter-edition-2025/videos.yml
+++ b/data/ruby-community-conference/ruby-community-conference-winter-edition-2025/videos.yml
@@ -21,6 +21,17 @@
   video_provider: scheduled
   video_id: aaron-patterson-ruby-community–conference-winter–edition-2025
 
+- title: "The Joy of Creativity in the Age of AI"
+  raw_title: "The Joy of Creativity in the Age of AI"
+  speakers:
+    - Paweł Strzałkowski
+  event_name: Ruby Community Conference Winter Edition 2025
+  date: "2025-02-28"
+  description: |-
+    We'll explore how Ruby can unlock new avenues of creativity in the age of AI and cross-technology innovation. By leveraging Ruby's simplicity and adaptability, we can seamlessly integrate cutting-edge solutions like speech recognition and generation, or image analysis and creation. We can also incorporate advanced techniques like vector search into our projects with minimal effort. Let's rediscover the joy of building beyond traditional boundaries and position the Ruby community at the forefront of technological invention and creativity.
+  video_provider: scheduled
+  video_id: the-joy-of-creativity-in-the-age-of-ai-ruby-community–conference-winter–edition-2025
+
 - title: "Workshop: Building a Live Kanban Board Application With Hotwire and Rails"
   raw_title: "Building a Live Kanban Board Application With Hotwire and Rails"
   speakers:
@@ -54,3 +65,33 @@
     You’ll leave with a deeper understanding of Kamal and the ability to handle deployment challenges effectively! 💪
   video_provider: scheduled
   video_id: workshop-deploy-with-kamal-2-ruby-community–conference-winter–edition-2025
+
+- title: "Workshop: Taming The Beast: TDD, Service Objects, and dry.rb for Complex Business Logic"
+  raw_title: "Taming The Beast: TDD, Service Objects, and dry.rb for Complex Business Logic"
+  speakers:
+    - Oskar Lakner
+  event_name: Ruby Community Conference Winter Edition 2025
+  date: "2025-02-28"
+  description: ""
+  video_provider: scheduled
+  video_id: workshop-taming-the-beast-ruby-community–conference-winter–edition-2025
+
+- title: "Workshop: Fix Bugs 20x Faster: From Zero To Incident Superhero"
+  raw_title: "Fix Bugs 20x Faster: From Zero To Incident Superhero"
+  speakers:
+    - John Gallagher
+  event_name: Ruby Community Conference Winter Edition 2025
+  date: "2025-02-28"
+  description: ""
+  video_provider: scheduled
+  video_id: workshop-fix-bugs-20x-faster-ruby-community–conference-winter–edition-2025
+
+- title: "Workshop: Image Vector Search"
+  raw_title: "Image Vector Search"
+  speakers:
+    - Chris Hasiński
+  event_name: Ruby Community Conference Winter Edition 2025
+  date: "2025-02-28"
+  description: ""
+  video_provider: scheduled
+  video_id: workshop-image-vector-search-ruby-community–conference-winter–edition-2025


### PR DESCRIPTION

![CleanShot 2025-01-19 at 21 10 49@2x](https://github.com/user-attachments/assets/89474d51-3508-473a-aeab-bdf6a3fb49e3)
