### PR TITLE
ensure the player is ready when we pause

### DIFF
--- a/app/javascript/controllers/video_player_controller.js
+++ b/app/javascript/controllers/video_player_controller.js
@@ -57,6 +57,7 @@ export default class extends Controller {
   }
 
   handlePlayerReady (player) {
+    this.ready = true
     // for seekTo to work we need to store again the player instance
     this.player = player
 
@@ -92,6 +93,8 @@ export default class extends Controller {
   }
 
   seekTo (event) {
+    if (!this.ready) return
+
     const { time } = event.params
 
     if (time) {
@@ -100,6 +103,8 @@ export default class extends Controller {
   }
 
   pause () {
+    if (!this.ready) return
+
     this.player.pause()
   }
 


### PR DESCRIPTION
close https://github.com/adrienpoly/rubyvideo/issues/591

loading a page and immediately click on play in youtube can cause a JS error this.player.pause is not a function. This happen when the player doesn't have yet fully loaded

I added a ready variable that get set in the onPlayerReady callback 