### PR TITLE
Discard speaker talk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,6 +147,7 @@ gem "country_select"
 gem "avo"
 gem "frozen_record", "~> 0.27.2"
 gem "diffy"
+gem "discard"
 
 # Use OmniAuth to support multi-provider authentication [https://github.com/omniauth/omniauth]
 gem "omniauth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     difftastic (0.0.1-x86_64-darwin)
     difftastic (0.0.1-x86_64-linux)
     diffy (3.4.3)
+    discard (1.4.0)
+      activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
     dockerfile-rails (1.7.3)
       rails (>= 3.0.0)
@@ -639,6 +641,7 @@ DEPENDENCIES
   country_select
   debug
   diffy
+  discard
   dockerfile-rails (>= 1.2)
   dotenv-rails
   dry-initializer-rails

--- a/app/avo/resources/speaker.rb
+++ b/app/avo/resources/speaker.rb
@@ -29,7 +29,7 @@ class Avo::Resources::Speaker < Avo::BaseResource
     field :talks_count, as: :number, sortable: true
     field :canonical, as: :belongs_to, hide_on: :index
     # field :suggestions, as: :has_many
-    field :all_speaker_talks, as: :has_many, resource: Avo::Resources::SpeakerTalk, attach_scope: -> { query.order(title: :asc) }
+    field :speaker_talks, as: :has_many, resource: Avo::Resources::SpeakerTalk, attach_scope: -> { query.order(title: :asc) }
     field :talks, as: :has_many, use_resource: "Avo::Resources::Talk", attach_scope: -> { query.order(title: :asc) }, searchable: true
   end
 

--- a/app/avo/resources/speaker.rb
+++ b/app/avo/resources/speaker.rb
@@ -29,7 +29,7 @@ class Avo::Resources::Speaker < Avo::BaseResource
     field :talks_count, as: :number, sortable: true
     field :canonical, as: :belongs_to, hide_on: :index
     # field :suggestions, as: :has_many
-    # field :speaker_talks, as: :has_many
+    field :all_speaker_talks, as: :has_many, resource: Avo::Resources::SpeakerTalk, attach_scope: -> { query.order(title: :asc) }
     field :talks, as: :has_many, use_resource: "Avo::Resources::Talk", attach_scope: -> { query.order(title: :asc) }, searchable: true
   end
 

--- a/app/avo/resources/speaker_talk.rb
+++ b/app/avo/resources/speaker_talk.rb
@@ -6,9 +6,8 @@ class Avo::Resources::SpeakerTalk < Avo::BaseResource
 
   def fields
     field :id, as: :id
-    field :speaker_id, as: :number
-    field :talk_id, as: :number
-    field :speaker, as: :belongs_to
-    field :talk, as: :belongs_to
+    field :speaker, as: :belongs_to, hide_on: :forms
+    field :talk, as: :belongs_to, hide_on: :forms
+    field :discarded_at, as: :date_time
   end
 end

--- a/app/avo/resources/talk.rb
+++ b/app/avo/resources/talk.rb
@@ -66,8 +66,8 @@ class Avo::Resources::Talk < Avo::BaseResource
     field :thumbnail_md, as: :external_image, hide_on: :index
     field :thumbnail_lg, as: :external_image, hide_on: :index
     field :thumbnail_xl, as: :external_image, hide_on: :index
-    field :all_speaker_talks, as: :has_many, resource: Avo::Resources::SpeakerTalk, attach_scope: -> { query.order(name: :asc) }
-    field :speakers, as: :has_many, resource: Avo::Resources::Talk, attach_scope: -> { query.order(name: :asc) }
+    field :speaker_talks, as: :has_many, attach_scope: -> { query.order(name: :asc) }
+    field :speakers, as: :has_many, attach_scope: -> { query.order(name: :asc) }
     field :raw_transcript, as: :textarea, hide_on: :index, format_using: -> { value&.to_text }, readonly: true
     field :enhanced_transcript, as: :textarea, hide_on: :index, format_using: -> { value&.to_text }, readonly: true
     # field :suggestions, as: :has_many

--- a/app/avo/resources/talk.rb
+++ b/app/avo/resources/talk.rb
@@ -66,11 +66,11 @@ class Avo::Resources::Talk < Avo::BaseResource
     field :thumbnail_md, as: :external_image, hide_on: :index
     field :thumbnail_lg, as: :external_image, hide_on: :index
     field :thumbnail_xl, as: :external_image, hide_on: :index
-    field :speakers, as: :has_many, through: :speaker_talks, attach_scope: -> { query.order(name: :asc) }
+    field :all_speaker_talks, as: :has_many, resource: Avo::Resources::SpeakerTalk, attach_scope: -> { query.order(name: :asc) }
+    field :speakers, as: :has_many, resource: Avo::Resources::Talk, attach_scope: -> { query.order(name: :asc) }
     field :raw_transcript, as: :textarea, hide_on: :index, format_using: -> { value&.to_text }, readonly: true
     field :enhanced_transcript, as: :textarea, hide_on: :index, format_using: -> { value&.to_text }, readonly: true
     # field :suggestions, as: :has_many
-    # field :speaker_talks, as: :has_many
   end
 
   def actions

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -22,7 +22,7 @@ class SitemapsController < ApplicationController
 
         add speakers_path, priority: 0.7, changefreq: "weekly"
 
-        Speaker.canonical.pluck(:slug, :updated_at).each do |speaker_slug, updated_at|
+        Speaker.with_talks.canonical.pluck(:slug, :updated_at).each do |speaker_slug, updated_at|
           add speaker_path(speaker_slug), priority: 0.9, lastmod: updated_at
         end
 

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -24,7 +24,7 @@ class SpeakersController < ApplicationController
 
   # GET /speakers/1
   def show
-    @talks = @speaker.talks.includes(:speakers, event: :organisation, child_talks: :speakers).order(date: :desc)
+    @talks = @speaker.kept_talks.includes(:speakers, event: :organisation, child_talks: :speakers).order(date: :desc)
     @topics = @speaker.topics.approved.tally.sort_by(&:last).reverse.map(&:first)
 
     @back_path = speakers_path

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -92,6 +92,12 @@ class Speaker < ApplicationRecord
     "https://#{instance}/@#{handle}"
   }
 
+  def self.reset_talks_counts
+    find_each do |speaker|
+      speaker.update_column(:talks_count, speaker.talks.count)
+    end
+  end
+
   def title
     name
   end
@@ -224,13 +230,12 @@ class Speaker < ApplicationRecord
       save!
 
       speaker_talks.each do |speaker_talk|
-        speaker_talk.update(speaker: canonical_speaker)
+        SpeakerTalk.create(talk: speaker_talk.talk, speaker: canonical_speaker)
       end
 
       # We need to destroy the remaining speaker_talks. They can be remaining given the unicity constraint
       # on the speaker_talks table. The update above swallows the error if the speaker_talk duet exists already
       SpeakerTalk.where(speaker_id: id).destroy_all
-      Speaker.reset_counters(canonical_speaker.id, :talks)
     end
   end
 

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -53,7 +53,7 @@ class Speaker < ApplicationRecord
   # associations
   has_many :speaker_talks, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id
   has_many :talks, through: :speaker_talks, inverse_of: :speakers
-  has_many :kept_talks, -> { joins(:speaker_talks).where(speaker_talks: {discarded_at: nil}) },
+  has_many :kept_talks, -> { joins(:speaker_talks).where(speaker_talks: {discarded_at: nil}).distinct },
     through: :speaker_talks, inverse_of: :speakers, class_name: "Talk", source: :talk
   has_many :events, -> { distinct }, through: :talks, inverse_of: :speakers
   has_many :aliases, class_name: "Speaker", foreign_key: "canonical_id"

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -51,7 +51,9 @@ class Speaker < ApplicationRecord
   }.freeze
 
   # associations
-  has_many :speaker_talks, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id
+  has_many :speaker_talks, -> { kept }, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id
+  has_many :all_speaker_talks, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id,
+    class_name: "SpeakerTalk"
   has_many :talks, through: :speaker_talks, inverse_of: :speakers
   has_many :events, -> { distinct }, through: :talks, inverse_of: :speakers
   has_many :aliases, class_name: "Speaker", foreign_key: "canonical_id"

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -51,10 +51,10 @@ class Speaker < ApplicationRecord
   }.freeze
 
   # associations
-  has_many :speaker_talks, -> { kept }, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id
-  has_many :all_speaker_talks, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id,
-    class_name: "SpeakerTalk"
+  has_many :speaker_talks, dependent: :destroy, inverse_of: :speaker, foreign_key: :speaker_id
   has_many :talks, through: :speaker_talks, inverse_of: :speakers
+  has_many :kept_talks, -> { joins(:speaker_talks).where(speaker_talks: {discarded_at: nil}) },
+    through: :speaker_talks, inverse_of: :speakers, class_name: "Talk", source: :talk
   has_many :events, -> { distinct }, through: :talks, inverse_of: :speakers
   has_many :aliases, class_name: "Speaker", foreign_key: "canonical_id"
   has_many :topics, through: :talks

--- a/app/models/speaker_talk.rb
+++ b/app/models/speaker_talk.rb
@@ -35,6 +35,6 @@ class SpeakerTalk < ApplicationRecord
   private
 
   def update_speaker_talks_count
-    speaker.update_column(:talks_count, speaker.talks.count)
+    speaker.update_column(:talks_count, speaker.kept_talks.count)
   end
 end

--- a/app/models/speaker_talk.rb
+++ b/app/models/speaker_talk.rb
@@ -3,11 +3,12 @@
 #
 # Table name: speaker_talks
 #
-#  id         :integer          not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  speaker_id :integer          not null, indexed, indexed => [talk_id]
-#  talk_id    :integer          not null, indexed => [speaker_id], indexed
+#  id           :integer          not null, primary key
+#  discarded_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  speaker_id   :integer          not null, indexed, indexed => [talk_id]
+#  talk_id      :integer          not null, indexed => [speaker_id], indexed
 #
 # Indexes
 #
@@ -18,6 +19,9 @@
 # rubocop:enable Layout/LineLength
 class SpeakerTalk < ApplicationRecord
   self.table_name = "speaker_talks"
+
+  # mixins
+  include Discard::Model
 
   # associations
   belongs_to :speaker, counter_cache: :talks_count

--- a/app/models/speaker_talk.rb
+++ b/app/models/speaker_talk.rb
@@ -30,7 +30,11 @@ class SpeakerTalk < ApplicationRecord
   validates :speaker_id, uniqueness: {scope: :talk_id}
 
   # callbacks
-  after_commit do
+  after_commit :update_speaker_talks_count
+
+  private
+
+  def update_speaker_talks_count
     speaker.update_column(:talks_count, speaker.talks.count)
   end
 end

--- a/app/models/speaker_talk.rb
+++ b/app/models/speaker_talk.rb
@@ -28,4 +28,9 @@ class SpeakerTalk < ApplicationRecord
   belongs_to :talk, touch: true
 
   validates :speaker_id, uniqueness: {scope: :talk_id}
+
+  # callbacks
+  after_commit do
+    speaker.update_column(:talks_count, speaker.talks.count)
+  end
 end

--- a/app/models/speaker_talk.rb
+++ b/app/models/speaker_talk.rb
@@ -24,7 +24,7 @@ class SpeakerTalk < ApplicationRecord
   include Discard::Model
 
   # associations
-  belongs_to :speaker, counter_cache: :talks_count
+  belongs_to :speaker
   belongs_to :talk, touch: true
 
   validates :speaker_id, uniqueness: {scope: :talk_id}

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -66,10 +66,11 @@ class Talk < ApplicationRecord
   belongs_to :parent_talk, optional: true, class_name: "Talk", foreign_key: :parent_talk_id
 
   has_many :child_talks, class_name: "Talk", foreign_key: :parent_talk_id, dependent: :destroy
-  has_many :speaker_talks, -> { kept }, dependent: :destroy, inverse_of: :talk, foreign_key: :talk_id
-  has_many :all_speaker_talks, dependent: :destroy, inverse_of: :talk, foreign_key: :talk_id, class_name: "SpeakerTalk"
+  has_many :speaker_talks, dependent: :destroy, inverse_of: :talk, foreign_key: :talk_id
+  has_many :kept_speaker_talks, -> { kept }, dependent: :destroy, inverse_of: :talk, foreign_key: :talk_id,
+    class_name: "SpeakerTalk"
   has_many :speakers, through: :speaker_talks, inverse_of: :talks
-  has_many :all_speakers, through: :all_speaker_talks, inverse_of: :talks, class_name: "Speaker", source: :speaker
+  has_many :kept_speakers, through: :kept_speaker_talks, inverse_of: :talks, class_name: "Speaker", source: :speaker
 
   has_many :talk_topics, dependent: :destroy
   has_many :topics, through: :talk_topics

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -66,8 +66,10 @@ class Talk < ApplicationRecord
   belongs_to :parent_talk, optional: true, class_name: "Talk", foreign_key: :parent_talk_id
 
   has_many :child_talks, class_name: "Talk", foreign_key: :parent_talk_id, dependent: :destroy
-  has_many :speaker_talks, dependent: :destroy, inverse_of: :talk, foreign_key: :talk_id
+  has_many :speaker_talks, -> { kept }, dependent: :destroy, inverse_of: :talk, foreign_key: :talk_id
+  has_many :all_speaker_talks, dependent: :destroy, inverse_of: :talk, foreign_key: :talk_id, class_name: "SpeakerTalk"
   has_many :speakers, through: :speaker_talks, inverse_of: :talks
+  has_many :all_speakers, through: :all_speaker_talks, inverse_of: :talks, class_name: "Speaker", source: :speaker
 
   has_many :talk_topics, dependent: :destroy
   has_many :topics, through: :talk_topics

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -4,7 +4,7 @@
 <div class="container py-8">
   <%= render partial: "speakers/header", locals: {speaker: @speaker} %>
 
-  <% if @topics.any? %>
+  <% if @topics.any? && @talks.length.positive? %>
     <div class="mt-9 mb-3">
       <%= render partial: "topics/badge_list", locals: {topics: @topics, back_to_url: back_to_from_request, back_to_title: @speaker.name} %>
     </div>
@@ -13,7 +13,7 @@
   <hr class="my-6">
 
   <div role="tablist" class="tabs tabs-bordered mt-6">
-    <% if @speaker.talks.any? %>
+    <% if @talks.length.positive? %>
       <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="All Talks" style="width: 100px" checked>
 
       <div role="tabpanel" class="tab-content mt-6">

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -272,7 +272,7 @@
         </div>
       <% end %>
 
-      <% if talk.speakers.any? %>
+      <% if talk.speakers.length.positive? %>
         <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="<%= "Speaker".pluralize(talk.speakers.size) %>">
         <div role="tabpanel" class="tab-content !rounded-s-xl rounded-xl bg-base-200/50 p-6 mt-6 overflow-hidden">
           <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -272,17 +272,18 @@
         </div>
       <% end %>
 
-      <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="<%= "Speaker".pluralize(talk.speakers.size) %>">
-      <div role="tabpanel" class="tab-content !rounded-s-xl rounded-xl bg-base-200/50 p-6 mt-6 overflow-hidden">
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <% talk.speakers.each do |speaker| %>
-            <div class="border bg-gray-100 rounded-lg hover:bg-gray-200/50 transition-bg duration-300 ease-in-out">
-              <%= render partial: "talks/speaker", locals: {speaker: speaker} %>
-            </div>
-          <% end %>
+      <% if talk.speakers.any? %>
+        <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="<%= "Speaker".pluralize(talk.speakers.size) %>">
+        <div role="tabpanel" class="tab-content !rounded-s-xl rounded-xl bg-base-200/50 p-6 mt-6 overflow-hidden">
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <% talk.speakers.each do |speaker| %>
+              <div class="border bg-gray-100 rounded-lg hover:bg-gray-200/50 transition-bg duration-300 ease-in-out">
+                <%= render partial: "talks/speaker", locals: {speaker: speaker} %>
+              </div>
+            <% end %>
+          </div>
         </div>
-      </div>
-
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/db/migrate/20250124210823_add_discarded_at_speaker_talk.rb
+++ b/db/migrate/20250124210823_add_discarded_at_speaker_talk.rb
@@ -1,0 +1,5 @@
+class AddDiscardedAtSpeakerTalk < ActiveRecord::Migration[8.0]
+  def change
+    add_column :speaker_talks, :discarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_15_215944) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_24_210823) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_15_215944) do
     t.integer "talk_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
     t.index ["speaker_id", "talk_id"], name: "index_speaker_talks_on_speaker_id_and_talk_id", unique: true
     t.index ["speaker_id"], name: "index_speaker_talks_on_speaker_id"
     t.index ["talk_id"], name: "index_speaker_talks_on_talk_id"

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -28,6 +28,12 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should show speaker with talks" do
+    get speaker_url(@speaker_with_talk)
+    assert_response :success
+    assert_equal @speaker_with_talk.talks_count, assigns(:talks).length
+  end
+
   test "should redirect to canonical speaker" do
     talk = @speaker_with_talk.talks.first
     @speaker_with_talk.assign_canonical_speaker!(canonical_speaker: @speaker)

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -157,4 +157,15 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_includes speaker_names, @speaker_with_talk.name
     assert_includes canonical_slugs, last.slug
   end
+
+  test "discarded speaker_talks" do
+    speaker = speakers(:yaroslav)
+    assert speaker.talks_count.positive?
+
+    speaker.speaker_talks.each(&:discard)
+
+    get speaker_url(speaker)
+    assert_response :success
+    assert_equal 0, assigns(:talks).count
+  end
 end

--- a/test/fixtures/speaker_talks.yml
+++ b/test/fixtures/speaker_talks.yml
@@ -3,11 +3,12 @@
 #
 # Table name: speaker_talks
 #
-#  id         :integer          not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  speaker_id :integer          not null, indexed, indexed => [talk_id]
-#  talk_id    :integer          not null, indexed => [speaker_id], indexed
+#  id           :integer          not null, primary key
+#  discarded_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  speaker_id   :integer          not null, indexed, indexed => [talk_id]
+#  talk_id      :integer          not null, indexed => [speaker_id], indexed
 #
 # Indexes
 #

--- a/test/models/speaker_test.rb
+++ b/test/models/speaker_test.rb
@@ -89,4 +89,17 @@ class SpeakerTest < ActiveSupport::TestCase
   test "normalizes linkedin with slug" do
     assert_equal "username", Speaker.new(linkedin: "username").linkedin
   end
+
+  test "assign_canonical_speaker! resets talks_count" do
+    speaker = speakers(:yaroslav)
+    assert speaker.talks_count.positive?
+
+    speaker_2 = speakers(:one)
+    assert_changes -> { speaker_2.reload.talks_count }, from: 0, to: speaker.talks_count do
+      speaker.assign_canonical_speaker!(canonical_speaker: speaker_2)
+    end
+
+    assert_equal 0, speaker.reload.talks.count
+    assert_equal 0, speaker.reload.talks_count
+  end
 end

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -299,8 +299,8 @@ class TalkTest < ActiveSupport::TestCase
     speaker_talk = talk.speaker_talks.first
     assert_equal 1, speaker_talk.speaker.talks_count
     speaker_talk.discard
-    assert_equal 0, talk.speaker_talks.count
-    assert_equal 1, talk.all_speaker_talks.count
+    assert_equal 1, talk.speaker_talks.count
+    assert_equal 0, talk.kept_speaker_talks.count
     assert_equal 0, speaker_talk.speaker.talks_count
   end
 end

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -293,4 +293,13 @@ class TalkTest < ActiveSupport::TestCase
     talk = talks(:one)
     assert_includes Talk.for_topic("activerecord"), talk
   end
+
+  test "discarded speaker_talks" do
+    talk = talks(:one)
+    speaker_talk = talk.speaker_talks.first
+    speaker_talk.discard
+    assert_equal 0, talk.speaker_talks.count
+    assert_equal 1, talk.all_speaker_talks.count
+    assert_equal 0, speaker_talk.speaker.talks_count
+  end
 end

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -297,6 +297,7 @@ class TalkTest < ActiveSupport::TestCase
   test "discarded speaker_talks" do
     talk = talks(:one)
     speaker_talk = talk.speaker_talks.first
+    assert_equal 1, speaker_talk.speaker.talks_count
     speaker_talk.discard
     assert_equal 0, talk.speaker_talks.count
     assert_equal 1, talk.all_speaker_talks.count

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,6 +24,7 @@ class ActiveSupport::TestCase
 
     Talk.rebuild_search_index
     Speaker.rebuild_search_index
+    Speaker.reset_talks_counts
   end
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)


### PR DESCRIPTION
close #372
alternative to #525 

We can now discard a speaker_talk link

by doing so : 
- we can empty a speaker show page for specific talks
- the talk remains listed in the event page
- the talk show page remains accessible but the speaker is not listed anymore

### here speaker are not visible

![CleanShot 2025-01-24 at 22 58 06@2x](https://github.com/user-attachments/assets/4b031b90-8bd6-4c6d-9a84-4be0912e6aec)

### profile is empty

![CleanShot 2025-01-24 at 22 58 53@2x](https://github.com/user-attachments/assets/4e9dfebd-0d39-416e-914b-ee7b85b04b6e)

### talk is visible in the event page
![CleanShot 2025-01-24 at 22 59 40@2x](https://github.com/user-attachments/assets/76f353bf-4900-4fa8-97c3-d79590fc8bf8)

### Speakers without talks are not listed here

![CleanShot 2025-01-24 at 23 00 46@2x](https://github.com/user-attachments/assets/8f69f799-3a9d-4447-827c-e3fe898c63bb)
