### PR TITLE
Add published_at and announced_at to talk show page

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -365,6 +365,18 @@ class Talk < ApplicationRecord
     Talk.includes(event: :organisation).where(id: ids)
   end
 
+  def announced_at
+    Date.parse(static_metadata[:announced_at])
+  rescue => e
+    nil
+  end
+
+  def published_at
+    Date.parse(static_metadata[:published_at])
+  rescue => e
+    nil
+  end
+
   def formatted_date
     date.strftime("%B %d, %Y")
   rescue => _e

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -254,7 +254,19 @@
         <article class="prose">
           <p>
             <b><%= talk.title %></b><br>
-            <%= talk.speakers.map(&:name).to_sentence %> • <%= talk.formatted_date %> <% if talk.event.location %> • <%= talk.event.location %><% end %> <% if language && language != "English" %> • <%= language %> <% end %> • <%= talk.formatted_kind %>
+            <%= talk.speakers.map(&:name).to_sentence %>
+            <% if talk.event.location %> • <%= talk.event.location %><% end %>
+            <% if language && language != "English" %> • <%= language %> <% end %> •
+            <%= talk.formatted_kind %>
+          </p>
+
+          <p>
+            Date: <% if talk.date %> <%= talk.formatted_date %> <% else %> unknown<% end %><br/>
+
+            <span class="text-gray-400">
+              Published: <% if talk.published_at %><%= talk.published_at.strftime("%B %d, %Y") %><% else %> not published<% end %><br/>
+              Announced: <% if talk.announced_at %><%= talk.announced_at.strftime("%B %d, %Y") %><% else %> unknown<% end %>
+            </span>
           </p>
 
           <%= simple_format auto_link(talk.description, html: {target: "_blank", class: "link"}) %>


### PR DESCRIPTION
We have been using the `published_at` date as the "Talk Date" in the past and there still some cases where it's ambiguous now. To help with that and to start resolving #134 and #470 we can show the dates more explicitly on the talk show page:

![CleanShot 2025-01-29 at 17 42 36@2x](https://github.com/user-attachments/assets/fbe6df7d-994f-4b91-9987-98889f9966b8)
