### PR TITLE
downcase github handle

### DIFF
--- a/app/models/connected_account.rb
+++ b/app/models/connected_account.rb
@@ -28,4 +28,6 @@ class ConnectedAccount < ApplicationRecord
   belongs_to :user
 
   encrypts :access_token
+
+  normalizes :username, with: ->(value) { value.strip.downcase }
 end

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -76,7 +76,9 @@ class Speaker < ApplicationRecord
   scope :not_canonical, -> { where.not(canonical_id: nil) }
 
   # normalizes
-  normalizes :github, with: ->(value) { value.gsub(/^(?:https?:\/\/)?(?:www\.)?github\.com\//, "").gsub(/^@/, "") }
+  normalizes :github, with: ->(value) {
+    value.gsub(/^(?:https?:\/\/)?(?:www\.)?github\.com\//, "").gsub(/^@/, "").downcase
+  }
   normalizes :twitter, with: ->(value) { value.gsub(%r{https?://(?:www\.)?(?:x\.com|twitter\.com)/}, "").gsub(/@/, "") }
   normalizes :bsky, with: ->(value) {
                             value.gsub(%r{https?://(?:www\.)?(?:x\.com|bsky\.app/profile)/}, "").gsub(/@/, "")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,7 +53,7 @@ class User < ApplicationRecord
     value
       .gsub(GITHUB_URL_PATTERN, "")
       .delete("@")
-      .strip
+      .strip.downcase
   end
 
   after_update if: :password_digest_previously_changed? do

--- a/db/migrate/20250218073648_normalize_github_handle.rb
+++ b/db/migrate/20250218073648_normalize_github_handle.rb
@@ -1,0 +1,18 @@
+class NormalizeGitHubHandle < ActiveRecord::Migration[8.0]
+  def change
+    User.all.each do |u|
+      next if u.github_handle.blank?
+      u.update_column(:github_handle, u.github_handle.strip.downcase)
+    end
+
+    ConnectedAccount.all.each do |ca|
+      next if ca.username.blank?
+
+      ca.update_column(:username, ca.username.strip.downcase)
+    end
+
+    Speaker.where.not(github: [nil, ""]).each do |s|
+      s.update_column(:github, s.github.strip.downcase)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_28_085252) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_18_073648) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"


### PR DESCRIPTION
I realized that some user could not claimed their profil as their GitHub handle had a mix of capitalized and downcased version

We now ensure that all GitHub handles are downcased in every model 

A migration updates all the existing content 