### PR TITLE
disable YJIT in local to speed up tests

### DIFF
--- a/config/initializers/yjit.rb
+++ b/config/initializers/yjit.rb
@@ -1,0 +1,7 @@
+Rails.application.configure do
+  # YJIT slows down the test suite and doesn't really help in development
+  # It will be disabled by default in Rails 8.1
+  # https://github.com/rails/rails/pull/53746
+
+  config.yjit = !Rails.env.local?
+end


### PR DESCRIPTION
Not significant as the test suite is small but this will be the default in Rails 8.1

I also had a few cases of crashes due to YJIT in development https://github.com/kaspth/active_job-performs/issues/13