### PR TITLE
migrate staging server to an AMD64 arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,5 +83,4 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start server via Thruster by default, this can be overwritten at runtime
 EXPOSE 80
-# CMD ["./bin/rails", "server"]
 CMD ["./bin/thrust", "./bin/rails", "server"]

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -8,7 +8,7 @@ image: adrienpoly/rubyvideo_staging
 servers:
   web:
     hosts:
-      - 5.75.232.156
+      - 159.69.222.18
     options:
       cpus: 1
       memory: 0.5g
@@ -16,16 +16,17 @@ servers:
 
   job:
     hosts:
-      - 5.75.232.156
+      - 159.69.222.18
     options:
       cpus: 0.2
       memory: 0.5g
       memory-swap: 2g
     cmd: bin/jobs
 
-# Enable SSL auto certification via Let's Encrypt (and allow for multiple apps on one server).
-# If using something like Cloudflare, it is recommended to set encryption mode
-# in Cloudflare's SSL/TLS setting to "Full" to enable end-to-end encryption.
+# Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
+# Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
+#
+# Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
   ssl: true
   hosts:
@@ -39,17 +40,6 @@ registry:
   password:
     - KAMAL_REGISTRY_PASSWORD
 
-# Configure builder setup.
-builder:
-  arch:
-    - arm64
-  cache:
-    type: gha
-    options: mode=max
-    image: rubyvideo-staging-build-cache
-  secrets:
-    - RAILS_MASTER_KEY
-
 env:
   clear:
     WEB_CONCURRENCY: 1
@@ -59,15 +49,54 @@ env:
     - RAILS_MASTER_KEY
     - MEILI_MASTER_KEY
 
-# Use a persistent storage volume.
-#
-volumes:
-  - "storage:/rails/storage"
+# Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
+# "bin/kamal logs -r job" will tail logs from the first server in the job section.
+aliases:
+  console: app exec --interactive --reuse "bin/rails console"
+  shell: app exec --interactive --reuse "bash"
+  logs: app logs -f
+  dbc: app exec --interactive --reuse "bin/rails dbconsole"
 
+# Use a persistent storage volume for sqlite database files and local Active Storage files.
+# Recommended to change this to a mounted volume path that is backed up off server.
+volumes:
+  - "ruby_video_storage:/rails/storage"
+
+# Bridge fingerprinted assets, like JS and CSS, between versions to avoid
+# hitting 404 on in-flight requests. Combines all files from new and old
+# version inside the asset_path.
+asset_path: /rails/public/assets
+
+# Configure the image builder.
+builder:
+  arch:
+    - amd64
+  cache:
+    type: gha
+    options: mode=max
+    image: rubyvideo-staging-build-cache
+  secrets:
+    - RAILS_MASTER_KEY
+
+  # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
+  # remote: ssh://docker@docker-builder-server
+  #
+  # # Pass arguments and secrets to the Docker build process
+  # args:
+  #   RUBY_VERSION: ruby-3.3.4
+  # secrets:
+  #   - GITHUB_TOKEN
+  #   - RAILS_MASTER_KEY
+# Use a different ssh user than root
+# ssh:
+#   user: app
+
+# Use accessory services (secrets come from .kamal/secrets).
+# accessories:
 accessories:
   search:
     image: getmeili/meilisearch:v1.10
-    host: 5.75.232.156
+    host: 159.69.222.18
     port: 7700
     env:
       clear:
@@ -82,3 +111,25 @@ accessories:
         - MEILI_MASTER_KEY
     volumes:
       - "storage:/rails/storage"
+
+  #   db:
+#     image: mysql:8.0
+#     host: 192.168.0.2
+#     # Change to 3306 to expose port to the world instead of just local network.
+#     port: "127.0.0.1:3306:3306"
+#     env:
+#       clear:
+#         MYSQL_ROOT_HOST: '%'
+#       secret:
+#         - MYSQL_ROOT_PASSWORD
+#     files:
+#       - config/mysql/production.cnf:/etc/mysql/my.cnf
+#       - db/production.sql:/docker-entrypoint-initdb.d/setup.sql
+#     directories:
+#       - data:/var/lib/mysql
+#   redis:
+#     image: redis:7.0
+#     host: 192.168.0.2
+#     port: 6379
+#     directories:
+#       - data:/data


### PR DESCRIPTION
Migrating ton an AMD 64 arch server should speed up the deploy phase as the target arch will be the same as the runner

once everything is ok on staging I intend to do the same for the production server