### PR TITLE
Add my 2016 talk about Fix testing framework

### DIFF
--- a/data/paris-rb/paris-rb-meetup/videos.yml
+++ b/data/paris-rb/paris-rb-meetup/videos.yml
@@ -90,3 +90,30 @@
     Retrouvez Gauthier:
     https://www.squadracer.com
     https://www.linkedin.com/company/squadracer/
+
+- title: "Fix - Simple, stupid testing framework for Ruby"
+  raw_title: "Fix - Simple, stupid testing framework for Ruby by Cyril Kato"
+  speakers:
+    - Cyril Kato
+  event_name: Paris.rb Meetup March 2016
+  language: french
+  date: "2016-03-16"
+  video_provider: youtube
+  video_id: XV6tVZtKMfA
+  description: |-
+    Talk in French.
+
+    By Cyril Kato
+    Paris.rb @ Le Wagon, March 2016
+
+    A presentation of the Fix testing framework, as an alternative to RSpec.
+
+    Links:
+    Meetup: https://www.meetup.com/parisrb/events/220872045/
+    Slides: https://speakerdeck.com/cyril/fix-simple-stupid-testing-framework-for-ruby
+    Code in slides: https://github.com/cyril/parisrb
+    Fix project: https://fixrb.dev/
+    RSpec clone project: https://r-spec.dev/
+
+    Find Cyril Kato at:
+    https://github.com/cyril


### PR DESCRIPTION
I'd like to add my "[Fix - Simple, stupid testing framework for Ruby](https://youtu.be/XV6tVZtKMfA)" presentation from the March 2016 Paris.rb meetup at Le Wagon to the video collection.

This was a brief introduction to the Fix testing framework as a lightweight alternative to RSpec. Though the talk is in French, I've included an English description with relevant links to the project.

Let me know if any adjustments are needed before merging.