### PR TITLE
add created_at filter and orders to talks api

### DIFF
--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -77,6 +77,15 @@ two:
   slug: talk-title-2
   kind: "talk"
   date: "2025-01-31"
+  video_provider: youtube
+
+three:
+  title: talk title 3
+  description: talk descritpion 3
+  slug: talk-title-3
+  kind: "talk"
+  date: "2025-01-31"
+  video_provider: youtube
 
 brightonruby_2024_one:
   title: Getting to Two Million Users as a One Woman Dev Team

--- a/test/jobs/recurring/youtube_video_statistics_job_test.rb
+++ b/test/jobs/recurring/youtube_video_statistics_job_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Recurring::YoutubeVideoStatisticsJobTest < ActiveJob::TestCase
   test "should update view_count and like_count for youtube talks" do
     VCR.use_cassette("recurring_youtube_statistics_job", match_requests_on: [:method]) do
-      talk = Talk.youtube.first
+      talk = talks(:one)
       assert_not talk.view_count.positive?
       assert_not talk.like_count.positive?
       Recurring::YoutubeVideoStatisticsJob.new.perform


### PR DESCRIPTION
This will be usefull to get recently created talks form the API 