### PR TITLE
Add Vienna.rb March 2025 Videos

### DIFF
--- a/data/vienna-rb/playlists.yml
+++ b/data/vienna-rb/playlists.yml
@@ -1,16 +1,15 @@
-- id: PLJVqPQvGhwyzrZ0fsm00wsLz7JoQHOpHV
-  title: 'Vienna.rb #63 - The Ruby Spring Meetup'
+- id: vienna-rb-meetup
+  title: Vienna.rb Meetup
   location: "Vienna, Austria"
-  description: Talks from the Ruby Meetup on the 6th of March 2025 at Platogo.
+  description: "Vienna.rb: The Vienna Ruby Meetup"
   kind: meetup
-  published_at: '2025-03-10'
-  start_date: '2025-03-06'
-  end_date: '2025-03-06'
-  channel_id: UCk_uV6AV6vBy7tz7nr0V-wQ
-  year: 2025
-  videos_count: 4
+  published_at: "2025-02-03"
+  channel_id: ""
+  year: "2025"
+  videos_count: 0
   metadata_parser: Youtube::VideoMetadata
-  slug: vienna-rb-63-the-ruby-spring-meetup
-  banner_background: "#DC153C"
-  featured_background: "#000000"
-  featured_color: "#FFFFFF"
+  slug: vienna-rb-meetup
+  banner_background: "#FFFFFF"
+  featured_background: "#FFFFFF"
+  featured_color: "#FF0000"
+  website: https://ruby.wien

--- a/data/vienna-rb/playlists.yml
+++ b/data/vienna-rb/playlists.yml
@@ -1,15 +1,16 @@
-- id: vienna-rb-meetup
-  title: Vienna.rb Meetup
+- id: PLJVqPQvGhwyzrZ0fsm00wsLz7JoQHOpHV
+  title: 'Vienna.rb #63 - The Ruby Spring Meetup'
   location: "Vienna, Austria"
-  description: "Vienna.rb: The Vienna Ruby Meetup"
+  description: Talks from the Ruby Meetup on the 6th of March 2025 at Platogo.
   kind: meetup
-  published_at: "2025-02-03"
-  channel_id: ""
-  year: "2025"
-  videos_count: 0
+  published_at: '2025-03-10'
+  start_date: '2025-03-06'
+  end_date: '2025-03-06'
+  channel_id: UCk_uV6AV6vBy7tz7nr0V-wQ
+  year: 2025
+  videos_count: 4
   metadata_parser: Youtube::VideoMetadata
-  slug: vienna-rb-meetup
-  banner_background: "#FFFFFF"
-  featured_background: "#FFFFFF"
-  featured_color: "#FF0000"
-  website: https://ruby.wien
+  slug: vienna-rb-63-the-ruby-spring-meetup
+  banner_background: "#DC153C"
+  featured_background: "#000000"
+  featured_color: "#FFFFFF"

--- a/data/vienna-rb/vienna-rb-meetup/videos.yml
+++ b/data/vienna-rb/vienna-rb-meetup/videos.yml
@@ -91,7 +91,7 @@
   event_name: "Vienna.rb March 2025"
   date: "2025-03-06"
   announced_at: "2025-02-03"
-  published_at: "2025-03-06"
+  published_at: "2025-03-10"
   video_provider: "children"
   video_id: "vienna-rb-march-2025"
   thumbnail_xs: https://secure.meetupstatic.com/photos/event/1/8/8/5/600_526206277.webp?w=750
@@ -160,19 +160,20 @@
       published_at: "2025-03-10"
       speakers:
         - Jan Grodowski
+      id: "jan-grodowski-vienna-rb-march-2025"
       video_id: "G7kuYXr5oKA"
       video_provider: "youtube"
       description: |-
-        We're joined by Jan Grodowski ( https://x.com/mrgrodo ), a Staff Engineer at Shopify. Jan dives deep into Ruby testing and shares what he has learned as a Solopreneur maintaining UndercoverCI ( https://undercover-ci.com ). 
+        We're joined by Jan Grodowski (https://x.com/mrgrodo), a Staff Engineer at Shopify. Jan dives deep into Ruby testing and shares what he has learned as a Solopreneur maintaining UndercoverCI ( https://undercover-ci.com ).
 
         Thank you to Platogo for hosting!
 
         Follow Vienna.rb on:
-        - https://www.meetup.com/vienna-rb 
+        - https://www.meetup.com/vienna-rb
         - https://x.com/vienna-rb
         - https://bsky.app/profile/ruby.wien
 
-        Timestamps: 
+        Timestamps:
         00:00 Start
         23:25 Live Demo
         49:40 Q&A
@@ -183,15 +184,16 @@
       published_at: "2025-03-10"
       speakers:
         - Seth Horsley
+      id: "seth-horsley-vienna-rb-march-2025"
       video_id: "rQOHlmwPHoo"
       video_provider: "youtube"
       description: |-
-        We're joined by Seth Horsley ( https://github.com/SethHorsley ) from StateCert. Seth shares the future of Rails UIs with us. Creating amazing interfaces with plain Ruby using Ruby UI ( https://github.com/ruby-ui/ruby_ui ). 
+        We're joined by Seth Horsley (https://github.com/SethHorsley) from StateCert. Seth shares the future of Rails UIs with us. Creating amazing interfaces with plain Ruby using Ruby UI ( https://github.com/ruby-ui/ruby_ui ).
 
         Thank you to Platogo for hosting!
 
         Follow Vienna.rb on:
-        - https://www.meetup.com/vienna-rb 
+        - https://www.meetup.com/vienna-rb
         - https://x.com/vienna-rb
         - https://bsky.app/profile/ruby.wien
 
@@ -206,15 +208,16 @@
       published_at: "2025-03-10"
       speakers:
         - Anton Bangratz
+      id: "anton-bangratz-vienna-rb-march-2025"
       video_id: "6TMVcYxRjZ0"
       video_provider: "youtube"
       description: |-
-        We're joined by Anton "Tony" Bangratz ( https://github.com/abangratz ). Anton is a veteran Ruby developer from Vienna who works at Platogo. In this talk, he shares his experience using Jujutsu ( https://jj-vcs.github.io/jj/latest/ ) and explains why you should probably use it too!
+        We're joined by Anton "Tony" Bangratz (https://github.com/abangratz). Anton is a veteran Ruby developer from Vienna who works at Platogo. In this talk, he shares his experience using Jujutsu ( https://jj-vcs.github.io/jj/latest/ ) and explains why you should probably use it too!
 
         Thank you to Platogo for hosting!
 
         Follow Vienna.rb on:
-        - https://www.meetup.com/vienna-rb 
+        - https://www.meetup.com/vienna-rb
         - https://x.com/vienna-rb
         - https://bsky.app/profile/ruby.wien
 
@@ -229,15 +232,16 @@
       published_at: "2025-03-10"
       speakers:
         - Johannes Daxböck
+      id: "johannes-daxboeck-vienna-rb-march-2025"
       video_id: "_rdIWfyfuK4"
       video_provider: "youtube"
       description: |-
-        We're joined by Johannes Daxböck ( https://www.linkedin.com/in/johdax ). Johannes shares his exploration of logic programming in Ruby with us. If you have worked with Prolog at some point, this one might interest you. If you haven't, then too!
+        We're joined by Johannes Daxböck (https://www.linkedin.com/in/johdax). Johannes shares his exploration of logic programming in Ruby with us. If you have worked with Prolog at some point, this one might interest you. If you haven't, then too!
 
         Thank you to Platogo for hosting!
 
         Follow Vienna.rb on:
-        - https://www.meetup.com/vienna-rb 
+        - https://www.meetup.com/vienna-rb
         - https://x.com/vienna-rb
         - https://bsky.app/profile/ruby.wien
 

--- a/data/vienna-rb/vienna-rb-meetup/videos.yml
+++ b/data/vienna-rb/vienna-rb-meetup/videos.yml
@@ -91,7 +91,7 @@
   event_name: "Vienna.rb March 2025"
   date: "2025-03-06"
   announced_at: "2025-02-03"
-  published_at: "TODO"
+  published_at: "2025-03-06"
   video_provider: "children"
   video_id: "vienna-rb-march-2025"
   thumbnail_xs: https://secure.meetupstatic.com/photos/event/1/8/8/5/600_526206277.webp?w=750
@@ -123,7 +123,7 @@
 
     ⚡ Johannes Daxböck
     ▶️ Logical, Mr Matz: A Foray into Logic Programming in Ruby
-    🗒️ TBD
+    🗒️ Ruby supports multiple programming paradigms, including object-oriented, functional, and imperative/procedural styles. However, it is rarely associated with logic programming. In this talk, I'll explore the concepts and applications of logic programming through its most prominent language, Prolog, and compare them to Ruby. We'll also dive into some Ruby archaeology, uncovering existing Ruby-based logic programming libraries.
 
     Location
     ~~~~~~~~
@@ -157,52 +157,91 @@
     - title: "Balancing Quality and Speed of Testing with the Undercover Gem"
       event_name: "Vienna.rb March 2025"
       date: "2025-03-06"
-      published_at: "TODO"
+      published_at: "2025-03-10"
       speakers:
         - Jan Grodowski
-      video_id: "jan-grodowski-vienna-rb-march-2025"
-      video_provider: "scheduled"
+      video_id: "G7kuYXr5oKA"
+      video_provider: "youtube"
       description: |-
-        We'll take a look at Ruby test coverage strategies and the variables that come into play when preventing faults in our software products. We'll discuss what makes tests good, what to test versus not to and when is the right time to do it. I'll introduce the undercover Ruby gem and additionally share a few stories about turning this idea and gem into a side hustle.
+        We're joined by Jan Grodowski ( https://x.com/mrgrodo ), a Staff Engineer at Shopify. Jan dives deep into Ruby testing and shares what he has learned as a Solopreneur maintaining UndercoverCI ( https://undercover-ci.com ). 
+
+        Thank you to Platogo for hosting!
+
+        Follow Vienna.rb on:
+        - https://www.meetup.com/vienna-rb 
+        - https://x.com/vienna-rb
+        - https://bsky.app/profile/ruby.wien
+
+        Timestamps: 
+        00:00 Start
+        23:25 Live Demo
+        49:40 Q&A
 
     - title: "Building Beautiful UIs with Ruby: A Rails-Native Approach"
       event_name: "Vienna.rb March 2025"
       date: "2025-03-06"
-      published_at: "TODO"
+      published_at: "2025-03-10"
       speakers:
         - Seth Horsley
-      video_id: "seth-horsley-vienna-rb-march-2025"
-      video_provider: "scheduled"
+      video_id: "rQOHlmwPHoo"
+      video_provider: "youtube"
       description: |-
-        Tired of slow ERB templates and messy view logic? Discover how Phlex and RubyUI bring blazing-fast (12x!) and beautiful components to Rails while maintaining the Ruby way we all love. Let's see how we can build modern, accessible UIs without leaving the Rails ecosystem!
+        We're joined by Seth Horsley ( https://github.com/SethHorsley ) from StateCert. Seth shares the future of Rails UIs with us. Creating amazing interfaces with plain Ruby using Ruby UI ( https://github.com/ruby-ui/ruby_ui ). 
+
+        Thank you to Platogo for hosting!
+
+        Follow Vienna.rb on:
+        - https://www.meetup.com/vienna-rb 
+        - https://x.com/vienna-rb
+        - https://bsky.app/profile/ruby.wien
+
+        Timestamps:
+        00:00 Start
+        4:08 Demo
+        7:13 Q&A
 
     - title: "Jujutsu: Will it replace Git?"
       event_name: "Vienna.rb March 2025"
       date: "2025-03-06"
-      published_at: "TODO"
+      published_at: "2025-03-10"
       speakers:
         - Anton Bangratz
-      video_id: "anton-bangratz-vienna-rb-march-2025"
-      video_provider: "scheduled"
+      video_id: "6TMVcYxRjZ0"
+      video_provider: "youtube"
       description: |-
-        Jujutsu is a DVCS, or "distributed version control system". You are probably familiar with the biggest of those systems: Git. Jujutsiy is said to be easier and simpler than Git while being even more powerful. In this talk we'll find out if that's true!
+        We're joined by Anton "Tony" Bangratz ( https://github.com/abangratz ). Anton is a veteran Ruby developer from Vienna who works at Platogo. In this talk, he shares his experience using Jujutsu ( https://jj-vcs.github.io/jj/latest/ ) and explains why you should probably use it too!
+
+        Thank you to Platogo for hosting!
+
+        Follow Vienna.rb on:
+        - https://www.meetup.com/vienna-rb 
+        - https://x.com/vienna-rb
+        - https://bsky.app/profile/ruby.wien
+
+        Timestamps:
+        00:00 Start
+        0:52 What is Jujutsu
+        8:46 Q&A
 
     - title: "Logical, Mr Matz: A Foray into Logic Programming in Ruby"
       event_name: "Vienna.rb March 2025"
       date: "2025-03-06"
-      published_at: "TODO"
+      published_at: "2025-03-10"
       speakers:
         - Johannes Daxböck
-      video_id: "johannes-daxboeck-vienna-rb-march-2025"
-      video_provider: "scheduled"
-      description: ""
+      video_id: "_rdIWfyfuK4"
+      video_provider: "youtube"
+      description: |-
+        We're joined by Johannes Daxböck ( https://www.linkedin.com/in/johdax ). Johannes shares his exploration of logic programming in Ruby with us. If you have worked with Prolog at some point, this one might interest you. If you haven't, then too!
 
-    - title: "Lightning Talks"
-      event_name: "Vienna.rb March 2025"
-      date: "2025-03-06"
-      published_at: "TODO"
-      speakers:
-        - TBA
-      video_id: "lightning-talks-vienna-rb-march-2025"
-      video_provider: "scheduled"
-      description: "Lightning talks are limited to 10 minutes and are an excellent opportunity for first-time speakers to try their hand at public speaking."
+        Thank you to Platogo for hosting!
+
+        Follow Vienna.rb on:
+        - https://www.meetup.com/vienna-rb 
+        - https://x.com/vienna-rb
+        - https://bsky.app/profile/ruby.wien
+
+        Timestamps:
+        00:00 Start
+        00:51 Intro to logic programming
+        14:48 Q&A


### PR DESCRIPTION
Videos of the talks from Vienna.rb on 6th of March have been published, adding them here. 

I tried to follow the guidelines [here](https://github.com/adrienpoly/rubyvideo/blob/main/docs/contributing.md), but that completely overwrote the existing data from last Decembers meetup. I ended up manually filling in a bunch of data. It wasn't too bad, I just hope I didn't break something somewhere. 

I also created a playlists for some old talks (see [here](https://www.youtube.com/playlist?list=PLJVqPQvGhwyyfrneIB4MaAjNoxDNaVkZw) ), not sure what the best way to backfill that kind of data is. Any guidance is much appreciated :bow: 