### PR TITLE
Kamal remote builder

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -41,6 +41,7 @@ builder:
     image: rubyvideo-build-cache
   secrets:
     - RAILS_MASTER_KEY
+  remote: ssh://root@5.75.232.156
 
 env:
   clear:


### PR DESCRIPTION
inspired by work done by @leonvogt, this PR adds a remote builder for Kamal.

The current Arch for the production VPS is ARM. It is slow and unreliable to build and deploy from the CI that runs on AMD arch. I have an extra VPS on Hetzner on ARM that is setup for KAMAL (has docker installed). This PR setup a remote builder for Kamal using this VPS

From the test I did on a warm cache we should be able to deploy in about 1min30s 