### PR TITLE
fix bin/dev server port

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails server -p 3000
+web: bin/rails server
 vite: bin/vite dev
 jobs: bin/jobs


### PR DESCRIPTION
This pull request includes a small change to the `Procfile.dev` file. The change removes the port specification for the Rails server, allowing it to use the default port or the one passed from `bin/dev`

* [`Procfile.dev`](diffhunk://#diff-da156644594f6b621597090ae505c7e3b12ac879e308fd4fc957197149c7969eL1-R1): Removed the `-p 3000` option from the `web` command to use the default port for the Rails server.